### PR TITLE
Do not hide top panel (menu bar) on MacOS when entering fullscreen

### DIFF
--- a/src/browser/extensions/electron-extension/index.ts
+++ b/src/browser/extensions/electron-extension/index.ts
@@ -18,7 +18,7 @@ import {
 } from '../../utils';
 
 import {
-  JupyterLabSession, ISessions
+  JupyterLabSession
 } from '../../../main/sessions';
 
 import {
@@ -118,14 +118,6 @@ class ElectronJupyterLab extends JupyterLab {
       asyncRemoteRenderer.onRemoteEvent(IShortcutManager.zoomEvent, () => {
         topPanel.node.style.minHeight = topPanel.node.style.height = String(Browser.getTopPanelSize()) + 'px';
         this.shell.fit();
-      });
-
-      asyncRemoteRenderer.onRemoteEvent(ISessions.enterFullScreenEvent, () => {
-        topPanel.hide();
-      });
-
-      asyncRemoteRenderer.onRemoteEvent(ISessions.leaveFullScreenEvent, () => {
-        topPanel.show();
       });
     }
   }


### PR DESCRIPTION
This may be one way to fix #284. Opening this PR so that the CI will create installers allowing users to test if this change set gives desirable result.