### PR TITLE
Expose DevTools, add customised bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,62 @@
+---
+name: "\U0001F41B Bug report"
+about: Create a report to help us repair something that is currently broken
+labels: bug
+---
+
+<!-- Welcome! Thank you for contributing. These HTML comments will not render in the issue.
+
+Before creating a new issue:
+* Search for relevant issues in both:
+   - this repository
+   - the main JupyterLab repository: https://github.com/jupyterlab/jupyterlab
+* Follow the issue reporting guidelines:
+https://jupyterlab.readthedocs.io/en/latest/getting_started/issue.html
+-->
+
+## Description
+
+<!--Describe the bug clearly and concisely. Include screenshots if possible-->
+
+## Reproduce
+
+<!--Describe step-by-step instructions to reproduce the behavior-->
+
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error '...'
+
+<!--Describe how you diagnosed the issue. See the guidelines at
+ https://jupyterlab.readthedocs.io/en/latest/getting_started/issue.html -->
+
+## Expected behavior
+
+<!--Describe what you expected to happen-->
+
+## Context
+
+<!--Complete the following for context, and add any other relevant context-->
+
+- Operating System and version: <!-- e.g. Linux Ubuntu 21.04 -->
+- JupyterLab-Desktop version: <!-- e.g. 3.1.7-2 -->
+- Installer: <!-- .exe, .deb, .pkg, .rpm, .snap, .flatpak -->
+
+<!--The more content you provide, the more we can help!-->
+
+<details><summary>Troubleshoot Output</summary>
+<pre>
+Paste the output from running `jupyter troubleshoot` from the terminal inside of JupyterLab-Desktop here.
+You may want to sanitize the paths in the output.
+</pre>
+</details>
+
+<details><summary>Browser Output</summary>
+<!--Go to `Help` menu -> `Open Developer Console` to access the JavaScript console-->
+<!--If you do not see such a menu entry, please try Ctrl + Shift + I, after focusing on JupyterLab file browser-->
+<pre>
+Paste the output from the DevTools JavaScript console here, if applicable.
+
+</pre>
+</details>
+

--- a/src/browser/extensions/desktop-extension/index.ts
+++ b/src/browser/extensions/desktop-extension/index.ts
@@ -35,8 +35,18 @@ const desktopExtension: JupyterFrontEndPlugin<void> = {
                 asyncRemoteRenderer.runRemoteMethod(IAppRemoteInterface.checkForUpdates, void(0));
             }
         });
-    
-        menu.helpMenu.addGroup([{ command: 'check-for-updates' }], 20);
+
+        app.commands.addCommand('open-dev-tools', {
+            label: 'Open Developer Tools',
+            execute: () => {
+                asyncRemoteRenderer.runRemoteMethod(IAppRemoteInterface.openDevTools, void(0));
+            }
+        });
+
+        menu.helpMenu.addGroup([
+            { command: 'open-dev-tools' },
+            { command: 'check-for-updates' }
+        ], 20);
     },
     autoStart: true
 };

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -93,6 +93,10 @@ namespace IAppRemoteInterface {
     let checkForUpdates: AsyncRemote.IMethod<void, void> = {
         id: 'JupyterLabDesktop-check-for-updates'
     };
+    export
+    let openDevTools: AsyncRemote.IMethod<void, void> = {
+        id: 'JupyterLabDesktop-open-dev-tools'
+    };
 }
 
 export
@@ -250,6 +254,10 @@ class JupyterApplication implements IApplication, IStatefulService {
                 });
         });
 
+        app.on('browser-window-focus', (_event: Event, window: BrowserWindow) => {
+            this._window = window;
+        });
+
         ipcMain.on('set-check-for-updates-automatically', (_event, autoUpdate) => {
             this._applicationState.checkForUpdatesAutomatically = autoUpdate;
         });
@@ -261,6 +269,12 @@ class JupyterApplication implements IApplication, IStatefulService {
         asyncRemoteMain.registerRemoteMethod(IAppRemoteInterface.checkForUpdates,
             (): Promise<void> => {
                 this._checkForUpdates('always');
+                return Promise.resolve();
+            });
+
+        asyncRemoteMain.registerRemoteMethod(IAppRemoteInterface.openDevTools,
+            (): Promise<void> => {
+                this._window.webContents.openDevTools();
                 return Promise.resolve();
             });
     }
@@ -357,6 +371,11 @@ class JupyterApplication implements IApplication, IStatefulService {
     private _services: IStatefulService[] = [];
 
     private _closing: IClosingService[] = [];
+
+    /**
+     * The most recently focused window
+     */
+    private _window: Electron.BrowserWindow;
 }
 
 export


### PR DESCRIPTION
Addresses https://github.com/jupyterlab/jupyterlab-desktop/issues/252#issuecomment-927340295.

I'm still a fan of going the `jupyterlab-js-logs` route, but having the ability to get into the dev tools easily is useful anyways. I guess that we will want to make it configurable (allow to disable dev tools) in the future, but whether those are visible in the menu or not does not change the fact that those are currently available anyways.