### PR TITLE
Add `ipympl` to default environment

### DIFF
--- a/env_installer/construct.yaml
+++ b/env_installer/construct.yaml
@@ -22,6 +22,7 @@ specs:
   - conda
   - ipywidgets 7.6.5
   - jupyterlab 3.2.4
+  - ipympl >= 0.8.2
   - matplotlib-base
   - numpy
   - pandas


### PR DESCRIPTION
This allows for interactive matplotlib plots to work out of the box which is key for feature parity with classic notebook (where matplotlib itself provides the widget)

This came up in https://github.com/matplotlib/ipympl/issues/388 where someone expected `ipympl` to be installed but found that it was not.

Closes #354