### PR TITLE
Improve error reporting and use pre-defined token

### DIFF
--- a/src/browser/app.tsx
+++ b/src/browser/app.tsx
@@ -293,7 +293,7 @@ class Application extends React.Component<Application.IProps, Application.IState
         return (
             <div className='jpe-content'>
                 <TitleBar uiState={this.props.options.uiState} />
-                <ServerError launchFromPath={this._launchFromPath} changeEnvironment={this._changeEnvironment} error={error} />
+                <ServerError changeEnvironment={this._changeEnvironment} error={error} />
             </div>
         );
     }

--- a/src/browser/components/error/servererror.tsx
+++ b/src/browser/components/error/servererror.tsx
@@ -10,6 +10,8 @@ namespace ServerError {
     export
     interface Props {
         launchFromPath: () => void;
+        changeEnvironment: () => void;
+        error: Error
     }
 }
 
@@ -18,14 +20,24 @@ function ServerError(props: ServerError.Props) {
     return (
         <div className='jpe-ServerError-body'>
             <div className='jpe-ServerError-content'>
-                <div className='jpe-ServerError-icon'></div>
-                <h1 className='jpe-ServerError-header'>Jupyter Server Not Found</h1>
-                <p className='jpe-ServerError-subhead'>We were unable to launch a Jupyter server, which is a prerequisite for JupyterLab Desktop. If Jupyter is installed as a python module, but the python executable is not in your PATH, specify the executable location below. Otherwise, try installing or updating Jupyter. The Jupyter notebook version must be 6.0.0 or greater.</p>
+                <div className='jpe-ServerError-icon'/>
+                <h1 className='jpe-ServerError-header'>Jupyter Server Initialization Failed</h1>
+                <span className='jpe-ServerError-description'>
+                    <p>
+                    Jupyter Server, which is a prerequisite for JupyterLab Desktop, did not initialize properly.<br/>
+                    This might be because of an issue with the selected environment. You can change environment or try setting path to the server using buttons below.<br/>
+                    </p>
+                    <p>
+                    If this does not seem right, please report this issue in the JupyterLab Desktop repository, providing the error details presented below:
+                    </p>
+                </span>
+                <pre className='jpe-ServerError-error'>{props.error.name}: {props.error.message}</pre>
                 <div className='jpe-ServerError-btn-container'>
                     <button className='jpe-ServerError-btn' onClick={props.launchFromPath}>CHOOSE PATH</button>
+                    <button className='jpe-ServerError-btn' onClick={props.changeEnvironment}>CHANGE ENVIRONMENT</button>
                     <button className='jpe-ServerError-btn' onClick={() => {
-                        shell.openExternal('https://www.jupyter.org/install.html');
-                    }}>INSTALL JUPYTER</button>
+                        shell.openExternal('https://github.com/jupyterlab/jupyterlab-desktop/issues').catch(console.error);
+                    }}>REPORT ISSUE</button>
                 </div>
             </div>
         </div>

--- a/src/browser/components/error/servererror.tsx
+++ b/src/browser/components/error/servererror.tsx
@@ -9,7 +9,6 @@ export
 namespace ServerError {
     export
     interface Props {
-        launchFromPath: () => void;
         changeEnvironment: () => void;
         error: Error
     }
@@ -25,7 +24,7 @@ function ServerError(props: ServerError.Props) {
                 <span className='jpe-ServerError-description'>
                     <p>
                     Jupyter Server, which is a prerequisite for JupyterLab Desktop, did not initialize properly.<br/>
-                    This might be because of an issue with the selected environment. You can change environment or try setting path to the server using buttons below.<br/>
+                    This might be because of an issue with the selected environment. You can change environment to try a different server using buttons below.<br/>
                     </p>
                     <p>
                     If this does not seem right, please report this issue in the JupyterLab Desktop repository, providing the error details presented below:
@@ -33,7 +32,6 @@ function ServerError(props: ServerError.Props) {
                 </span>
                 <pre className='jpe-ServerError-error'>{props.error.name}: {props.error.message}</pre>
                 <div className='jpe-ServerError-btn-container'>
-                    <button className='jpe-ServerError-btn' onClick={props.launchFromPath}>CHOOSE PATH</button>
                     <button className='jpe-ServerError-btn' onClick={props.changeEnvironment}>CHANGE ENVIRONMENT</button>
                     <button className='jpe-ServerError-btn' onClick={() => {
                         shell.openExternal('https://github.com/jupyterlab/jupyterlab-desktop/issues').catch(console.error);

--- a/src/browser/components/error/style/index.css
+++ b/src/browser/components/error/style/index.css
@@ -14,12 +14,16 @@
 
 .jpe-ServerError-content {
     margin: auto;
-    width: 600px;
+    width: 650px;
     height: 300px;
     text-align: center;
     display: flex;
     flex-direction: column;
     justify-content: center;
+}
+
+.jpe-ServerError-error {
+    margin: 10px 0;
 }
 
 .jpe-ServerError-icon {
@@ -40,10 +44,15 @@
     cursor: default;
 }
 
-.jpe-ServerError-subhead {
+.jpe-ServerError-description {
     margin-bottom: 16px;
     line-height: 1.36;
     cursor: default;
+    text-align: left;
+}
+
+.jpe-ServerError-description p {
+    margin-bottom: 8px;
 }
 
 .jpe-ServerError-btn-container {

--- a/src/browser/extensions/electron-extension/index.ts
+++ b/src/browser/extensions/electron-extension/index.ts
@@ -22,7 +22,7 @@ import {
 } from '../../../main/sessions';
 
 import {
-  ServiceManager, ServerConnection
+  ServerConnection
 } from '@jupyterlab/services';
 
 import {
@@ -155,10 +155,6 @@ class ElectronJupyterLab extends JupyterLab {
     };
   }
 
-  /**
-   * The service manager used by the application.
-   */
-  readonly serviceManager: ServiceManager;
 
   private _electronInfo: ElectronJupyterLab.IInfo;
 }

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -74,9 +74,10 @@ class JupyterServer {
             this._nbServer = execFile(this._info.environment.path, [
                 '-m', 'jupyterlab',
                 '--no-browser',
+                // do not use any config file
                 '--JupyterApp.config_file_name', '',
+                // use our token rather than any pre-configured password
                 '--ServerApp.password', '',
-                '--ServerApp.disable_check_xsrf', 'True',
                 '--ServerApp.allow_origin', '*'
             ], {
                 cwd: home,

--- a/src/main/tokens.ts
+++ b/src/main/tokens.ts
@@ -39,7 +39,7 @@ export const EnvironmentTypeName = {
 };
 
 /**
- * The respresentation of the python environment
+ * The representation of the python environment
  */
  export interface IPythonEnvironment {
   /**
@@ -47,7 +47,7 @@ export const EnvironmentTypeName = {
    */
   path: string;
   /**
-   * Arbitrary name used for display, not garuanteed to be unique
+   * Arbitrary name used for display, not guaranteed to be unique
    */
   name: string;
   /**


### PR DESCRIPTION
https://github.com/jupyterlab/jupyterlab-desktop/issues/238 demonstrates that for an unknown reasons the Jupyter Server does not get setup correctly for some users. It is very difficult to debug currently, so I tried to address this in multiple ways:
- removing one of the modes of failures which was in retrieving the token (which if not found could lead to promise rejection and error screen state)
- displaying the actual error that led to the error screen (and encouraging reporting of these errors)
- allowing users to change environment with the selector introduced in https://github.com/jupyterlab/jupyterlab-desktop/pull/317
- rewriting the error message which was incorrectly suggesting that it was due to server not being in path, where in reality there are several code paths which could lead to the promise rejection and that screen; instead it is now more accurately titled "Jupyter Server Initialization Failed"
- I also removed the "Install Jupyter" link, because the JupyterLab Desktop now ships with a builtin conda environment so it is redundant and it was directing users to rather not very useful generic Jupyter website (so they could end up installing Notebook and getting frustrated that it did not help).
- I added code for parsing the actual version of Jupyter Server that got started, but end up not using it for now. We should consider if we want to add a check on the version at this level too - it could help against some inconsistent environments - but it can wait for another PR.
- The server standard error output is now logged into the console. We may want to change this in the future (or make it optional, only for debugging) but it seems important for this stage of development.

I also restored the XSRF checks as I do not see any reason for having those disabled when the token is properly set up.

Tested by manually adding a `reject(new Error('test'))`:

![Screenshot from 2021-11-18 21-00-50](https://user-images.githubusercontent.com/5832902/142498651-69367141-dad7-4193-bccc-057abbb83c68.png)

And selecting a non-Python path fusing the first button:

![Screenshot from 2021-11-18 21-00-56](https://user-images.githubusercontent.com/5832902/142498877-ee0db6f0-3439-4569-b46f-e3fd2e989d77.png)

The environment selector works well too:

![Screenshot from 2021-11-18 21-01-22](https://user-images.githubusercontent.com/5832902/142498945-7d4bb164-c4a3-468e-ab33-4949d1eb08a3.png)
