### PR TITLE
Upgrade Electron to 13.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "@yarnpkg/lockfile": "~1.1.0",
     "@types/ejs": "^3.1.0",
     "css-loader": "~5.1.1",
-    "electron": "^12.0.0",
+    "electron": "^13.0.0",
     "electron-builder": "^22.11.11",
     "file-loader": "~6.2.0",
     "fs-extra": "~9.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3117,9 +3117,10 @@ electron-to-chromium@^1.3.896:
   version "1.3.896"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.896.tgz#4a94efe4870b1687eafd5c378198a49da06e8a1b"
 
-electron@^12.0.0:
-  version "12.2.2"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-12.2.2.tgz#9627594d6b5bb589f00355989d316b6542539e54"
+electron@^13.0.0:
+  version "13.6.2"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-13.6.2.tgz#878e01d78cd442a8ec28340b271608ba5b7c7ebd"
+  integrity sha512-ZXx9t68yXftvNZVnQ7v2XHcnH+MPUF6LNStoz4MMXuWpkF9gq3qwjcYSqnbM4wiVkvWVHIyYvt1yemmStza9dQ==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^14.6.2"


### PR DESCRIPTION
New version of electron (16.0) was just released and 12.x is no longer supported. This PR updates to 13.x which is still supported to give us some more time to upgrade to modern versions.