### PR TITLE
Add (temporary?) fallback context menu

### DIFF
--- a/src/main/sessions.ts
+++ b/src/main/sessions.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-    BrowserWindow, ipcMain, app
+    BrowserWindow, ipcMain, app, Menu, MenuItemConstructorOptions, clipboard
 } from 'electron';
 
 import {
@@ -404,6 +404,7 @@ class JupyterLabSession {
         });
 
         this._window.setMenuBarVisibility(false);
+        this._addFallbackContextMenu();
 
         if (this._info.x && this._info.y) {
             this._window.setBounds({x: this._info.x, y: this._info.y, height: this._info.height, width: this._info.width });
@@ -468,6 +469,55 @@ class JupyterLabSession {
             state: info.serverState,
             remoteServerId: info.remoteServerId
         };
+    }
+
+    /**
+     * Simple fallback context menu shown on Shift + Right Click.
+     * May be removed in future versions once (/if) JupyterLab builtin menu
+     * supports cut/copy/paste, including "Copy link URL" and "Copy image".
+     * @private
+     */
+    private _addFallbackContextMenu(): void {
+        const selectionTemplate: MenuItemConstructorOptions[] = [
+            {role: 'copy'},
+        ];
+
+        const inputMenu = Menu.buildFromTemplate([
+            {role: 'cut'},
+            {role: 'copy'},
+            {role: 'paste'},
+            {role: 'selectAll'}
+        ]);
+
+        this._window.webContents.on('context-menu', (event, params) => {
+            if (params.isEditable) {
+                inputMenu.popup({window: this._window});
+            } else {
+                const template: MenuItemConstructorOptions[] = []
+                if (params.selectionText) {
+                    template.push(...selectionTemplate);
+                }
+                if (params.linkURL) {
+                    template.push({
+                        'label': 'Copy link URL',
+                        'click': () => {
+                            clipboard.writeText(params.linkURL);
+                        }
+                    })
+                }
+                if (params.hasImageContents) {
+                    template.push({
+                        'label': 'Copy image',
+                        'click': () => {
+                            this._window.webContents.copyImageAt(params.x, params.y);
+                        }
+                    });
+                }
+                if (template.length) {
+                    Menu.buildFromTemplate(template).popup({window: this._window});
+                }
+            }
+        });
     }
 
     private _addRenderAPI(): void {


### PR DESCRIPTION
Fixes #297 and implements the "Approach D" described in https://github.com/jupyterlab/jupyterlab-desktop/issues/206#issuecomment-974670327 (until a better solution, "approach C" is implemented in core JupyterLab).

Please see https://github.com/jupyterlab/jupyterlab-desktop/issues/206#issuecomment-974670327 for technical discussion.

Notebook for testing: https://gist.github.com/krassowski/9cecfcc0efd1177c124a066f7d0ece8b

### User-facing changes

The fallback context menu is available when holding `Shift`:

![demo](https://user-images.githubusercontent.com/5832902/142731537-131362c1-1b3f-4260-8da1-56f3dc7cf2fb.gif)
