### PR TITLE
Enhance navigation guard to fix hash navigation

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -3,7 +3,6 @@ import {
 } from 'electron';
 
 const Bottle = require('bottlejs');
-const URL = require('url').URL;
 import log from 'electron-log';
 import * as yargs from 'yargs';
 import * as path from 'path';
@@ -151,15 +150,10 @@ app.on('ready', () => {
 });
 
 app.on("web-contents-created", (_event: any, webContents: WebContents) => {
-    // Prevent navigation to external websites (which is basically all websites)
+    // Prevent navigation
     webContents.on('will-navigate', (event: Event, navigationUrl) => {
-        const parsedUrl = new URL(navigationUrl);
-        let currentURL = new URL(webContents.getURL());
-
-        if (parsedUrl.origin !== currentURL.origin) {
-            console.warn(`Navigation to ${parsedUrl.href} is not allowed`);
-            event.preventDefault();
-        }
+        console.warn(`Navigation is not allowed; attempted navigation to: ${navigationUrl}`);
+        event.preventDefault();
     });
 
     // handle page's beforeunload prompt natively

--- a/src/main/sessions.ts
+++ b/src/main/sessions.ts
@@ -450,13 +450,8 @@ class JupyterLabSession {
         // Prevent reloading app from the server when jumping to an anchor
         this._window.webContents.on('will-navigate', (event: Event, navigationUrl) => {
             const parsedUrl = new URL(navigationUrl);
-            let currentURL = new URL(this._window.webContents.getURL());
 
-            // TODO: also check origin once we do have server URL here,
-            //  but it requires cleaning up the remote jupyter servers code first
-            if (parsedUrl.hash !== currentURL.hash) {
-                asyncRemoteMain.emitRemoteEvent(ISessions.navigatedToHash, parsedUrl.hash, this._window.webContents);
-            }
+            asyncRemoteMain.emitRemoteEvent(ISessions.navigatedToHash, parsedUrl.hash, this._window.webContents);
         });
     }
 


### PR DESCRIPTION
Follow-up to #340 - it appears that the more cautious version that I committed did not solve the problem well. This is more strict (forbidding any navigation, which is needed to guarantee that the plain JupyterLab version won't get loaded) and also ensuring that hash navigation works without any prompt.