### PR TITLE
Use a dedicated configuration directory to isolate settings & workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ JupyterLab Desktop sets File Browser's root directory based on the launch method
   - `jlab ../notebooks/test.ipynb` launch notebook with relative path
   - `jlab ../test.py` launch python file with relative path
 
+### Configuration files
+
+By default JupyterLab Desktop will only load and write to Jupyter configuration located in:
+- `%APPDATA%\jupyterlab-desktop` on Windows
+- `$XDG_CONFIG_HOME/jupyterlab-desktop` or `~/.config/jupyterlab-desktop` on Linux
+- `~/Library/Application Support/jupyterlab-desktop` on macOS
+
+ignoring any other Jupyter configuration which may be present in standard Jupyter paths as defined by `jupyter --paths`.
+This includes `jupyter-server` settings, `jupyterlab` settings and workspaces, and any other configuration which would
+normally be shared between Jupyter installation.
+This is necessary to prevent a clash between the Desktop and any previous Jupyter installation.
+
+You can change the configuration path by specifying `JLAB_DESKTOP_CONFIG_DIR` environment variable.
+
 ## Build dependencies
 
 - [conda](https://docs.conda.io)

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -86,7 +86,8 @@ class JupyterServer {
                 cwd: home,
                 env: {
                     PATH: this._registry.getAdditionalPathIncludesForPythonPath(this._info.environment.path),
-                    JUPYTER_TOKEN: this._info.token
+                    JUPYTER_TOKEN: this._info.token,
+                    JUPYTER_CONFIG_DIR: process.env.JLAB_DESKTOP_CONFIG_DIR || app.getPath('userData')
                 }
             });
 


### PR DESCRIPTION
- Fixes point 1 and point 2 of #226 (making the Desktop app use independent workspaces and independent settings from the system-wide installation)
- Fixes another failure mode causing server startup error (#238) which turned out to be caused by a competing configuration from previous installations: users would have different notebook settings in their home which were masking the settings that we wanted. This is a bit drastic step, so I also added an environment variable to allow to change it back to something else and documented it.
- Edit: this will also close #240 which was a case of a configuration from previous installation breaking JupyterLab Desktop UI
 
I am not sure if the documentation should go to `README` or `User guide` - this will be a prominent change for existing users so maybe README?