### PR TITLE
Allow displaying hidden files

### DIFF
--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -81,7 +81,9 @@ class JupyterServer {
                 '--JupyterApp.config_file_name=""',
                 // use our token rather than any pre-configured password
                 '--ServerApp.password=""',
-                '--ServerApp.allow_origin="*"'
+                '--ServerApp.allow_origin="*"',
+                // enable hidden files (let user decide whether to display them)
+                '--ContentsManager.allow_hidden=True'
             ], {
                 cwd: home,
                 env: {


### PR DESCRIPTION
Fixes #361

Allows to display hidden files:

![Screenshot from 2021-12-03 20-55-49](https://user-images.githubusercontent.com/5832902/144672002-13375f96-d913-4f6e-8bce-c71d4793b491.png)

By default hidden files are **not** shown. User needs to go to the `View` menu and check `View Hidden Files`