### PR TITLE
calculate executable path using bash in macOS

### DIFF
--- a/dist-resources/darwin/jlab.sh
+++ b/dist-resources/darwin/jlab.sh
@@ -12,8 +12,8 @@ real_path() (
 )
 
 # calculate application path from this script's path
-SELF_DIR=$(dirname $(real_path $0))
-APP_CONTENTS_DIR=$(dirname $(dirname $SELF_DIR))
+SELF_DIR=$(dirname "$(real_path "$0")")
+APP_CONTENTS_DIR=$(dirname "$(dirname "$SELF_DIR")")
 JLAB_PATH="$APP_CONTENTS_DIR"/MacOS/JupyterLab
 
 $JLAB_PATH "$@"

--- a/dist-resources/darwin/jlab.sh
+++ b/dist-resources/darwin/jlab.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 # calculate application path from this script's path
-JLAB_PATH=$(python -c "import sys; from os import path; self_path=path.realpath(sys.argv[1]); print(path.normpath(path.join(self_path, '../../../MacOS/JupyterLab')));" "${BASH_SOURCE[0]}");
+JLAB_PATH=$(python3 -c "import sys; from os import path; self_path=path.realpath(sys.argv[1]); print(path.normpath(path.join(self_path, '../../../MacOS/JupyterLab')));" "${BASH_SOURCE[0]}");
 $JLAB_PATH "$@"
 exit $?

--- a/dist-resources/darwin/jlab.sh
+++ b/dist-resources/darwin/jlab.sh
@@ -1,6 +1,20 @@
 #!/usr/bin/env bash
 
+real_path() (
+  cd "$(dirname "$1")"
+  LINK=$(readlink "$(basename "$1")")
+  while [ "$LINK" ]; do
+    cd "$(dirname "$LINK")"
+    LINK=$(readlink "$(basename "$1")")
+  done
+  REALPATH="$PWD/$(basename "$1")"
+  echo "$REALPATH"
+)
+
 # calculate application path from this script's path
-JLAB_PATH=$(python3 -c "import sys; from os import path; self_path=path.realpath(sys.argv[1]); print(path.normpath(path.join(self_path, '../../../MacOS/JupyterLab')));" "${BASH_SOURCE[0]}");
+SELF_DIR=$(dirname $(real_path $0))
+APP_CONTENTS_DIR=$(dirname $(dirname $SELF_DIR))
+JLAB_PATH="$APP_CONTENTS_DIR"/MacOS/JupyterLab
+
 $JLAB_PATH "$@"
 exit $?

--- a/electron-builder-scripts/postinstall
+++ b/electron-builder-scripts/postinstall
@@ -2,6 +2,7 @@
 
 "$2/JupyterLab.app/Contents/Resources/env_installer/JupyterLabDesktopAppServer-3.2.5-1-MacOSX-x86_64.sh" -b -p "$2/JupyterLab.app/Contents/Resources/jlab_server"
 
+mkdir -p /usr/local/bin
 ln -s "$2/JupyterLab.app/Contents/Resources/app/jlab" /usr/local/bin/jlab
 chmod 755 "$2/JupyterLab.app/Contents/Resources/app/jlab"
 

--- a/electron-builder-scripts/postinstall
+++ b/electron-builder-scripts/postinstall
@@ -2,7 +2,6 @@
 
 "$2/JupyterLab.app/Contents/Resources/env_installer/JupyterLabDesktopAppServer-3.2.5-1-MacOSX-x86_64.sh" -b -p "$2/JupyterLab.app/Contents/Resources/jlab_server"
 
-mkdir -p /usr/local/bin
 ln -s "$2/JupyterLab.app/Contents/Resources/app/jlab" /usr/local/bin/jlab
 chmod 755 "$2/JupyterLab.app/Contents/Resources/app/jlab"
 


### PR DESCRIPTION
Use python3 to launch the application with `jlab` command. Fixes https://github.com/jupyterlab/jupyterlab-desktop/issues/315