### PR TITLE
Keep the environment variables when spawning the server

### DIFF
--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -87,6 +87,7 @@ class JupyterServer {
             ], {
                 cwd: home,
                 env: {
+                    ...process.env,
                     PATH: this._registry.getAdditionalPathIncludesForPythonPath(this._info.environment.path),
                     JUPYTER_TOKEN: this._info.token,
                     JUPYTER_CONFIG_DIR: process.env.JLAB_DESKTOP_CONFIG_DIR || app.getPath('userData')


### PR DESCRIPTION
Fixes #373.

Do we want to filter out any environment variables? Looking at https://www.electronjs.org/docs/latest/api/environment-variables there is nothing that we make use of that should not be forwarded to the server. In dev mode I see a lot of variables like:

```
npm_package_dependencies__jupyterlab_rendermime_extension=3.2.5
npm_package_build_directories_buildResources=dist-resources
npm_package_resolutions__jupyterlab_celltags=~3.2.5
npm_package_dependencies__jupyterlab_rendermime_interfaces=3.2.5
npm_package_devDependencies__types_react=~17.0.2
```

which might be just annoying noise (or a great way for debugging).