### PR TITLE
Fix a typo in the issue template, mention `renderer.log`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -67,7 +67,7 @@ Paste the output from the DevTools JavaScript console here, if applicable.
 <!--on macOS: ~/Library/Logs/jupyterlab-desktop/main.log-->
 <!--on Windows: %USERPROFILE%\AppData\Roaming\jupyterlab-desktop\logs\main.log-->
 <pre>
-Paste the logs from the mian.log file here.
+Paste the logs from the `main.log` file here (optionally also from `renderer.log`).
 
 </pre>
 </details>


### PR DESCRIPTION
Fix a typo, mention `renderer.log`