### PR TITLE
launch JupyterLab server via a script to activate the environment properly

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,7 +21,7 @@
         "cwd": "${workspaceFolder}",
         "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron",
         "windows": {
-          "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron.cmd"
+          "runtimeExecutable": "${workspaceFolder}\\node_modules\\.bin\\electron.cmd"
         },
         "args" : ["."],
         "outputCapture": "std"

--- a/package.json
+++ b/package.json
@@ -68,8 +68,7 @@
     },
     "win": {
       "target": [
-        "nsis",
-        "portable"
+        "nsis"
       ],
       "extraFiles": [
         {

--- a/src/main/registry.ts
+++ b/src/main/registry.ts
@@ -277,7 +277,7 @@ export class Registry implements IRegistry {
         const envName = `${envInfo.type}: ${envInfo.name}`;
 
         return {
-            type: IEnvironmentType.PATH,
+            type: envInfo.type === 'conda' ? IEnvironmentType.CondaEnv : IEnvironmentType.VirtualEnv,
             name: envName,
             path: pythonPath,
             versions: { 'python': pythonVersion, 'jupyterlab': jlabVersion },

--- a/src/main/registry.ts
+++ b/src/main/registry.ts
@@ -316,7 +316,7 @@ export class Registry implements IRegistry {
         if (platform === 'win32') {
             path_env = `${envPath};${envPath}\\Library\\mingw-w64\\bin;${envPath}\\Library\\usr\\bin;${envPath}\\Library\\bin;${envPath}\\Scripts;${envPath}\\bin;${process.env['PATH']}`;
         } else {
-            path_env = `${envPath}:${process.env['PATH']}`;
+            path_env = `${envPath}:${envPath}/bin:${process.env['PATH']}`;
         }
         
         return path_env;

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -63,7 +63,7 @@ function createLaunchScript(environment: IPythonEnvironment): string {
     if (isWin) {
         script = `
             CALL ${envPath}\\condabin\\activate
-            START ${launchCmd}`;
+            CALL ${launchCmd}`;
     } else {
         script = `
             ${envPath}/bin/activate

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -163,6 +163,7 @@ class JupyterServer {
 
         this._startServer = new Promise<JupyterServer.IInfo>((resolve, reject) => {
             const home = process.env.JLAB_DESKTOP_HOME || app.getPath('home');
+            const isWin = process.platform === 'win32';
             const pythonPath = this._info.environment.path;
             if (!fs.existsSync(pythonPath)) {
                 dialog.showMessageBox({message: `Environment not found at: ${pythonPath}`, type: 'error' });
@@ -175,7 +176,7 @@ class JupyterServer {
 
             this._nbServer = execFile(launchScriptPath, {
                 cwd: home,
-                shell: true,
+                shell: isWin ? 'cmd.exe' : '/bin/bash',
                 env: {
                     ...process.env,
                     JUPYTER_TOKEN: appConfig.token,

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -86,7 +86,7 @@ function createLaunchScript(environment: IPythonEnvironment): string {
         }
     } else {
         script = `
-            ${envPath}/bin/activate
+            source ${envPath}/bin/activate
             ${launchCmd}`;
     }
 
@@ -175,7 +175,7 @@ class JupyterServer {
 
             this._nbServer = execFile(launchScriptPath, {
                 cwd: home,
-                shell: "cmd.exe",
+                shell: true,
                 env: {
                     ...process.env,
                     JUPYTER_TOKEN: appConfig.token,

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -62,8 +62,7 @@ function createLaunchScript(environment: IPythonEnvironment): string {
 
     if (isWin) {
         script = `
-            CALL ${envPath}\\condabin\\activate
-            CALL ${launchCmd}`;
+            CALL ${envPath}\\condabin\\activate && ${launchCmd}`;
     } else {
         script = `
             ${envPath}/bin/activate

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -1,5 +1,5 @@
 import {
-    ChildProcess, exec, execFile
+    ChildProcess, execFile
 } from 'child_process';
 
 import {
@@ -30,9 +30,12 @@ import log from 'electron-log';
 
 import * as fs from 'fs';
 import * as os from 'os';
-import * as  path from 'path';
-import { IPythonEnvironment } from './tokens';
+import * as path from 'path';
+import * as http from 'http';
+import { IEnvironmentType, IPythonEnvironment } from './tokens';
 import { appConfig } from './utils';
+
+const SERVER_LAUNCH_TIMEOUT = 30000; // milliseconds
 
 function createTempFile(fileName = 'temp', data = '', encoding: BufferEncoding = 'utf8') {
     const tempDirPath = path.join(os.tmpdir(), 'jlab_desktop');
@@ -56,13 +59,31 @@ function createLaunchScript(environment: IPythonEnvironment): string {
     // note: traitlets<5.0 require fully specified arguments to
     // be followed by equals sign without a space; this can be
     // removed once jupyter_server requires traitlets>5.0
-    const launchCmd = `python -m jupyterlab --no-browser --JupyterApp.config_file_name="" --ServerApp.port=${appConfig.jlabPort} --ServerApp.password="" --ServerApp.allow_origin="*" --ContentsManager.allow_hidden=True`;
+    const launchCmd = [
+        'python', '-m', 'jupyterlab',
+        '--no-browser',
+        // do not use any config file
+        '--JupyterApp.config_file_name=""',
+        `--ServerApp.port=${appConfig.jlabPort}`,
+        // use our token rather than any pre-configured password
+        '--ServerApp.password=""',
+        '--ServerApp.allow_origin="*"',
+        // enable hidden files (let user decide whether to display them)
+        '--ContentsManager.allow_hidden=True'
+    ].join(' ');
 
     let script: string;
 
     if (isWin) {
-        script = `
-            CALL ${envPath}\\condabin\\activate && ${launchCmd}`;
+        if (environment.type === IEnvironmentType.CondaEnv) {
+            script = `
+                CALL ${envPath}\\condabin\\activate.bat
+                CALL ${launchCmd}`;
+        } else {
+            script = `
+                CALL ${envPath}\\activate.bat
+                CALL ${launchCmd}`;
+        }
     } else {
         script = `
             ${envPath}/bin/activate
@@ -79,12 +100,49 @@ function createLaunchScript(environment: IPythonEnvironment): string {
     return scriptPath;
 }
 
+async function waitForDuration(duration: number): Promise<boolean> {
+    return new Promise(resolve => {
+        setTimeout(() => {
+            resolve(false);
+        }, duration);
+    });
+}
+
+async function checkIfUrlExists(url: URL): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+        const req = http.request(url, function(r) {
+            resolve(r.statusCode >= 200 && r.statusCode < 400);
+        });
+        req.on('error', function(err) {
+            resolve(false);
+        });
+        req.end();
+    });
+}
+
+async function waitUntilServerIsUp(port: number): Promise<boolean> {
+    const url = new URL(`http://localhost:${port}`);
+    return new Promise<boolean>(async (resolve) => {
+        async function checkUrl() {
+            const exists = await checkIfUrlExists(url);
+            if (exists) {
+                return resolve(true);
+            } else {
+                setTimeout(async () => {
+                    await checkUrl();
+                }, 500);
+            }
+        }
+
+        await checkUrl();
+    });
+}
+
 export
 class JupyterServer {
 
-    constructor(options: JupyterServer.IOptions, registry: IRegistry) {
+    constructor(options: JupyterServer.IOptions) {
         this._info.environment = options.environment;
-        this._registry = registry;
     }
 
     get info(): JupyterServer.IInfo {
@@ -104,8 +162,6 @@ class JupyterServer {
         let started = false;
 
         this._startServer = new Promise<JupyterServer.IInfo>((resolve, reject) => {
-            let urlRegExp = /https?:\/\/localhost:\d+\/\S*/g;
-            let serverVersionPattern = /Jupyter Server (?<version>.*) is running at/g;
             const home = process.env.JLAB_DESKTOP_HOME || app.getPath('home');
             const pythonPath = this._info.environment.path;
             if (!fs.existsSync(pythonPath)) {
@@ -114,16 +170,30 @@ class JupyterServer {
             }
             this._info.url = `http://localhost:${appConfig.jlabPort}`;
             this._info.token = appConfig.token;
-
+            
             const launchScriptPath = createLaunchScript(this._info.environment); 
 
-            this._nbServer = exec(launchScriptPath, {
+            this._nbServer = execFile(launchScriptPath, {
                 cwd: home,
+                shell: "cmd.exe",
                 env: {
                     ...process.env,
-                    PATH: this._registry.getAdditionalPathIncludesForPythonPath(this._info.environment.path),
                     JUPYTER_TOKEN: appConfig.token,
                     JUPYTER_CONFIG_DIR: process.env.JLAB_DESKTOP_CONFIG_DIR || app.getPath('userData')
+                }
+            });
+            
+            Promise.race([
+                waitUntilServerIsUp(appConfig.jlabPort),
+                waitForDuration(SERVER_LAUNCH_TIMEOUT)
+            ])
+            .then((up: boolean) => {
+                this._cleanupListeners();
+                if (up) {
+                    fs.unlinkSync(launchScriptPath);
+                    resolve(this._info);
+                } else {
+                    reject(new Error('Failed to launch Jupyter Server'));
                 }
             });
 
@@ -143,23 +213,6 @@ class JupyterServer {
                     this._serverStartFailed();
                     reject(err);
                 }
-            });
-
-            this._nbServer.stderr.on('data', (serverBuff: string | Buffer) => {
-                const line = serverBuff.toString();
-                let urlMatch = line.match(urlRegExp);
-                let versionMatch = serverVersionPattern.exec(line);
-
-                if (versionMatch) {
-                    this._info.version = versionMatch.groups.version;
-                }
-                if (urlMatch) {
-                    started = true;
-                    this._cleanupListeners();
-                    fs.unlinkSync(launchScriptPath);
-                    return resolve(this._info);
-                }
-                console.log('Jupyter Server initialization message:', serverBuff);
             });
         });
 
@@ -215,8 +268,6 @@ class JupyterServer {
     private _startServer: Promise<JupyterServer.IInfo> = null;
 
     private _info: JupyterServer.IInfo = { url: null, token: null, environment: null, version: null };
-
-    private _registry: IRegistry;
 }
 
 export
@@ -483,7 +534,7 @@ class JupyterServerFactory implements IServerFactory, IClosingService {
     private _createServer(opts: JupyterServer.IOptions): JupyterServerFactory.IFactoryItem {
         let item: JupyterServerFactory.IFactoryItem = {
             factoryId: this._nextId++,
-            server: new JupyterServer(opts, this._registry),
+            server: new JupyterServer(opts),
             closing: null,
             used: false
         };


### PR DESCRIPTION
- creates a temporary script file that activates the conda / venv environment properly and launches JupyterLab server
- follows @bollwyvl 's suggestion in https://github.com/jupyterlab/jupyterlab-desktop/pull/317#issuecomment-962683018
- tested on Windows, macOS, Ubuntu and Fedora
fixes https://github.com/jupyterlab/jupyterlab-desktop/issues/401 https://github.com/jupyterlab/jupyterlab-desktop/issues/388 https://github.com/jupyterlab/jupyterlab-desktop/issues/381 https://github.com/jupyterlab/jupyterlab-desktop/issues/386