### PR TITLE
fix python path used on createLaunchScript

### DIFF
--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -61,7 +61,8 @@ function createLaunchScript(environment: IPythonEnvironment): string {
     // be followed by equals sign without a space; this can be
     // removed once jupyter_server requires traitlets>5.0
     const launchCmd = [
-        'python', '-m', 'jupyterlab',
+        // use the python path of the environment
+        `${pythonPath}`, '-m', 'jupyterlab',
         '--no-browser',
         // do not use any config file
         '--JupyterApp.config_file_name=""',
@@ -86,6 +87,7 @@ function createLaunchScript(environment: IPythonEnvironment): string {
                 CALL ${launchCmd}`;
         }
     } else {
+        // note: this will not work with newer versions of Anaconda
         script = `
             source ${envPath}/bin/activate
             ${launchCmd}`;


### PR DESCRIPTION
I created this pull request as a solution to issue #381 Jupyter Server Initialization Failed.

After analyzing the logs and the commands used on the processes called to execute the program, I figured that you were using the python of the console instead of the one on the environment, which wasn't allowing the app to launch properly.

To prevent the usage of the wrong python path I used the one that was stored on the constant **pythonPath**.

I also figured that it is being used `source env_path\bin\activate` to activate all types of environments on Linux desktops, which, if I am not wrong, can be the reason for the problem, since newer versions of Anaconda (and Miniconda) are not using the *activate* and *deactivate* binaries by default. I didn't change anything related to this problem (I just left a note comment) because the first solution was able to solve the main problem, however, I believe this needs to be revised.