### PR TITLE
Pass explicit schema path to the JupyterLab server

### DIFF
--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -48,7 +48,7 @@ function createTempFile(fileName = 'temp', data = '', encoding: BufferEncoding =
     return tmpFilePath;
 }
 
-function createLaunchScript(environment: IPythonEnvironment): string {
+function createLaunchScript(environment: IPythonEnvironment, appPath: string): string {
     const platform = process.platform;
     const isWin = platform === 'win32';
     const pythonPath = environment.path;
@@ -56,6 +56,7 @@ function createLaunchScript(environment: IPythonEnvironment): string {
     if (!isWin) {
         envPath = path.normalize(path.join(envPath, '../'));
     }
+    const schemasDir = path.normalize(path.join(appPath, 'build/schemas'));
 
     // note: traitlets<5.0 require fully specified arguments to
     // be followed by equals sign without a space; this can be
@@ -63,6 +64,7 @@ function createLaunchScript(environment: IPythonEnvironment): string {
     const launchCmd = [
         'python', '-m', 'jupyterlab',
         '--no-browser',
+        `--LabServerApp.schemas_dir="${schemasDir}"`,
         // do not use any config file
         '--JupyterApp.config_file_name=""',
         `--ServerApp.port=${appConfig.jlabPort}`,
@@ -173,7 +175,10 @@ class JupyterServer {
             this._info.url = `http://localhost:${appConfig.jlabPort}`;
             this._info.token = appConfig.token;
             
-            const launchScriptPath = createLaunchScript(this._info.environment); 
+            const launchScriptPath = createLaunchScript(
+                this._info.environment,
+                app.getAppPath()
+            );
 
             this._nbServer = execFile(launchScriptPath, {
                 cwd: home,


### PR DESCRIPTION
https://github.com/jupyterlab/jupyterlab-desktop/pull/413#issuecomment-1057670346 highlighted an issue with schemas not being properly loaded (and hence toolbars not working) when upgrading to 3.3. It appears that the server was resolving the path to `json` schema files not to our assets, but to the assets in the selected user environment; if users had an old JupyterLab version installed, they would get old assets (missing required toolbar definitions, or absent altogether):

```
Failed to load toolbar items for factory Notebook from @jupyterlab/notebook-extension:panel Error: Schema not found: my-environment-of-choice-path/share/jupyter/lab/schemas/@jupyterlab/notebook-extension/panel.json
    at Function.create (browser.bundle.js:104932)
    at async SettingManager.fetch (browser.bundle.js:105995)
```

To reiterate, it was looking in `my-environment-of-choice-path` rather than in the path where JupyterLab Desktop is installed.

This PR solves the issue for now. It is not clear to me if this is the optimal approach.