### PR TITLE
activate conda env using base conda env

### DIFF
--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -36,6 +36,10 @@ export interface IApplication {
   saveState: (service: IStatefulService, data: JSONValue) => Promise<void>;
 
   getPythonEnvironment(): Promise<IPythonEnvironment>;
+
+  setCondaRootPath(condaRootPath: string): void;
+
+  getCondaRootPath(): Promise<string>;
 }
 
 /**
@@ -127,7 +131,8 @@ export class JupyterApplication implements IApplication, IStatefulService {
 
     this._applicationState = {
       checkForUpdatesAutomatically: true,
-      pythonPath: ''
+      pythonPath: '',
+      condaRootPath: ''
     };
 
     this.registerStatefulService(this).then(
@@ -164,6 +169,18 @@ export class JupyterApplication implements IApplication, IStatefulService {
     return new Promise<IPythonEnvironment>((resolve, _reject) => {
       this._appState.then((state: JSONObject) => {
         resolve(this._registry.getCurrentPythonEnvironment());
+      });
+    });
+  }
+
+  setCondaRootPath(condaRootPath: string): void {
+    this._applicationState.condaRootPath = condaRootPath;
+  }
+
+  getCondaRootPath(): Promise<string> {
+    return new Promise<string>((resolve, _reject) => {
+      this._appState.then((state: JSONObject) => {
+        resolve(this._applicationState.condaRootPath);
       });
     });
   }
@@ -630,6 +647,7 @@ export namespace JupyterApplication {
   export interface IState extends JSONObject {
     checkForUpdatesAutomatically?: boolean;
     pythonPath?: string;
+    condaRootPath?: string;
   }
 }
 

--- a/src/main/env_info.py
+++ b/src/main/env_info.py
@@ -7,7 +7,8 @@ if (getattr(sys, "base_prefix", None) or getattr(sys, "real_prefix", None) or sy
   env_type = 'venv'
 
 if env_type != 'venv' and os.path.exists(os.path.join(sys.prefix, "conda-meta")):
-  env_type = 'conda'
+  is_root = os.path.exists(os.path.join(sys.prefix, "condabin"))
+  env_type = 'conda-root' if is_root else 'conda-env'
 
 if env_type != 'system':
   env_name = os.path.basename(sys.prefix)

--- a/src/main/registry.ts
+++ b/src/main/registry.ts
@@ -512,12 +512,17 @@ export class Registry implements IRegistry {
       Registry.COMMON_CONDA_LOCATIONS
     );
 
-    const bundledEnvPath = join(dirname(app.getAppPath()), 'jlab_server');
     let allCondas = [
-      Promise.resolve([bundledEnvPath]),
       pathCondas,
       commonCondas
     ];
+
+    // add bundled conda env to the list of base conda envs
+    const bundledEnvPath = path.join(dirname(app.getAppPath()), 'jlab_server');
+    if (fs.existsSync(path.join(bundledEnvPath, 'condabin'))) {
+      allCondas.unshift(Promise.resolve([bundledEnvPath]));
+    }
+
     if (process.platform === 'win32') {
       allCondas.push(this._getWindowsRegistryCondas());
     }

--- a/src/main/registry.ts
+++ b/src/main/registry.ts
@@ -512,10 +512,7 @@ export class Registry implements IRegistry {
       Registry.COMMON_CONDA_LOCATIONS
     );
 
-    let allCondas = [
-      pathCondas,
-      commonCondas
-    ];
+    let allCondas = [pathCondas, commonCondas];
 
     // add bundled conda env to the list of base conda envs
     const bundledEnvPath = path.join(dirname(app.getAppPath()), 'jlab_server');

--- a/src/main/registry.ts
+++ b/src/main/registry.ts
@@ -513,7 +513,11 @@ export class Registry implements IRegistry {
     );
 
     const bundledEnvPath = join(dirname(app.getAppPath()), 'jlab_server');
-    let allCondas = [Promise.resolve([bundledEnvPath]), pathCondas, commonCondas];
+    let allCondas = [
+      Promise.resolve([bundledEnvPath]),
+      pathCondas,
+      commonCondas
+    ];
     if (process.platform === 'win32') {
       allCondas.push(this._getWindowsRegistryCondas());
     }

--- a/src/main/registry.ts
+++ b/src/main/registry.ts
@@ -15,6 +15,7 @@ import { ArrayExt } from '@lumino/algorithm';
 import * as fs from 'fs';
 import log from 'electron-log';
 import {
+  EnvironmentTypeName,
   IEnvironmentType,
   IPythonEnvironment,
   IVersionContainer
@@ -38,6 +39,8 @@ export interface IRegistry {
 
   getEnvironmentList: () => Promise<IPythonEnvironment[]>;
 
+  getCondaEnvironments(): Promise<IPythonEnvironment[]>;
+
   addEnvironment: (path: string) => Promise<IPythonEnvironment>;
 
   getUserJupyterPath: () => Promise<IPythonEnvironment>;
@@ -45,6 +48,8 @@ export interface IRegistry {
   getBundledPythonPath: () => string;
 
   validatePythonEnvironmentAtPath: (path: string) => boolean;
+
+  validateCondaBaseEnvironmentAtPath: (envPath: string) => boolean;
 
   setDefaultPythonPath: (path: string) => void;
 
@@ -130,6 +135,7 @@ export class Registry implements IRegistry {
           this._setDefaultEnvironment(undefined);
         });
     } else {
+      this._condaEnvironments = this._loadCondaEnvironments();
       this._registryBuilt = Promise.resolve();
     }
   }
@@ -257,6 +263,14 @@ export class Registry implements IRegistry {
   }
 
   /**
+   * Retrieve the list of conda environments, once they have been resolved
+   * @returns a promise that resolves to a list of conda environments
+   */
+  getCondaEnvironments(): Promise<IPythonEnvironment[]> {
+    return this._condaEnvironments;
+  }
+
+  /**
    * Create a new environment from a python executable, without waiting for the
    * entire registry to be resolved first.
    * @param path The location of the python executable to create an environment from
@@ -317,6 +331,16 @@ export class Registry implements IRegistry {
     return true;
   }
 
+  validateCondaBaseEnvironmentAtPath(envPath: string): boolean {
+    const isWin = process.platform === 'win32';
+    const condaBinPath = path.join(
+      envPath,
+      'condabin',
+      isWin ? 'conda.bat' : 'conda'
+    );
+    return fs.existsSync(condaBinPath) && fs.lstatSync(condaBinPath).isFile();
+  }
+
   getEnvironmentInfo(pythonPath: string): IPythonEnvironment {
     const runOptions = {
       env: { PATH: this.getAdditionalPathIncludesForPythonPath(pythonPath) }
@@ -339,13 +363,16 @@ export class Registry implements IRegistry {
     );
     const envInfoOut = this._runCommandSync(pythonPath, ['-c', envInfoPyCode]);
     const envInfo = JSON.parse(envInfoOut.trim());
-    const envName = `${envInfo.type}: ${envInfo.name}`;
+    const envType =
+      envInfo.type === 'conda-root'
+        ? IEnvironmentType.CondaRoot
+        : envInfo.type === 'conda-env'
+        ? IEnvironmentType.CondaEnv
+        : IEnvironmentType.VirtualEnv;
+    const envName = `${EnvironmentTypeName[envType]}: ${envInfo.name}`;
 
     return {
-      type:
-        envInfo.type === 'conda'
-          ? IEnvironmentType.CondaEnv
-          : IEnvironmentType.VirtualEnv,
+      type: envType,
       name: envName,
       path: pythonPath,
       versions: { python: pythonVersion, jupyterlab: jlabVersion },
@@ -1100,6 +1127,8 @@ export class Registry implements IRegistry {
   }
 
   private _environments: IPythonEnvironment[] = [];
+
+  private _condaEnvironments: Promise<IPythonEnvironment[]>;
 
   private _default: IPythonEnvironment;
 

--- a/src/main/registry.ts
+++ b/src/main/registry.ts
@@ -512,7 +512,8 @@ export class Registry implements IRegistry {
       Registry.COMMON_CONDA_LOCATIONS
     );
 
-    let allCondas = [pathCondas, commonCondas];
+    const bundledEnvPath = join(dirname(app.getAppPath()), 'jlab_server');
+    let allCondas = [Promise.resolve([bundledEnvPath]), pathCondas, commonCondas];
     if (process.platform === 'win32') {
       allCondas.push(this._getWindowsRegistryCondas());
     }

--- a/src/main/tokens.ts
+++ b/src/main/tokens.ts
@@ -30,7 +30,7 @@ export enum IEnvironmentType {
   VirtualEnv = 'venv'
 }
 
-export const EnvironmentTypeName = {
+export const EnvironmentTypeName: { [key in IEnvironmentType]: string } = {
   [IEnvironmentType.PATH]: 'system',
   [IEnvironmentType.CondaRoot]: 'conda',
   [IEnvironmentType.CondaEnv]: 'conda',

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -17,6 +17,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import log from 'electron-log';
 import { app } from 'electron';
+import { IPythonEnvironment } from './tokens';
 
 export interface IAppConfiguration {
   jlabPort: number;
@@ -365,6 +366,17 @@ export function getSchemasDir(): string {
   }
 
   return path.normalize(path.join(appDir, './build/schemas'));
+}
+
+export function getEnvironmentPath(environment: IPythonEnvironment): string {
+  const isWin = process.platform === 'win32';
+  const pythonPath = environment.path;
+  let envPath = path.dirname(pythonPath);
+  if (!isWin) {
+    envPath = path.normalize(path.join(envPath, '../'));
+  }
+
+  return envPath;
 }
 
 let service: IService = {


### PR DESCRIPTION
- activates non-base conda environments using a base/root conda environment on the machine. if a base environment is not auto-detected, user is prompted to choose base environment path
- fixes https://github.com/jupyterlab/jupyterlab-desktop/issues/423

special thanks to @anaximeno for reporting this issue with a patch proposal https://github.com/jupyterlab/jupyterlab-desktop/pull/415 and debugging efforts.