### PR TITLE
Allow to edit environment path in selection dialog manually

### DIFF
--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -597,7 +597,7 @@ export class JupyterApplication implements IApplication, IStatefulService {
 
                     <div class="row">
                         <div style="flex-grow: 1;">
-                            <input type="text" id="python-path" value="<%= pythonPath %>" readonly style="width: 100%;"></input>
+                            <input type="text" id="python-path" value="<%= pythonPath %>" style="width: 100%;"></input>
                         </div>
                         <div>
                             <button id='select-python-path' onclick='handleSelectPythonPath(this);'>Select Python path</button>


### PR DESCRIPTION
I was annoyed by this limitation for quite some time (especially because of lack of support for multiple instances #476). #477 also brought this point:

> Before I opened the file browser, I wondered why I couldn't paste the path from my clipboard directly into the field with an orange border. It looks like a text input field by the way of having an I-beam cursor when moving the mouse over it, but activating it and hitting command-V did nothing. If it's not a text input field then maybe it should be styled differently.

For it is the difference between substituting `a_name` in `~/.pyenv/versions/a_name/bin/python` for `b_name` (super quick) vs navigating two directories up, and then two directories down (6 clicks more).

No changes are needed on scripting logic.