### PR TITLE
Release v3.4.5-1

### DIFF
--- a/src/main/registry.ts
+++ b/src/main/registry.ts
@@ -68,7 +68,7 @@ export class Registry implements IRegistry {
         name: 'jupyterlab',
         moduleName: 'jupyterlab',
         commands: ['--version'],
-        versionRange: new semver.Range('>=3.4.3')
+        versionRange: new semver.Range('>=3.4.5')
       }
     ];
 


### PR DESCRIPTION
- Upgrade to JupyterLab 3.4.5
- Upgrade to ipywidgets 8.0.1 (required for Windows build)