### PR TITLE
Check if sub-environments directory exists before traversing it

### DIFF
--- a/src/main/registry.ts
+++ b/src/main/registry.ts
@@ -563,6 +563,10 @@ export class Registry implements IRegistry {
     let rootName = basename(rootPath);
 
     return new Promise((resolve, reject) => {
+      if (!fs.existsSync(subEnvironmentsFolder)) {
+        console.warn('No sub-environments in root: ' + rootPath);
+        return resolve([]);
+      }
       fs.readdir(subEnvironmentsFolder, (err, files) => {
         if (err) {
           reject(err);


### PR DESCRIPTION
Fix miniconda environments, see https://github.com/jupyterlab/jupyterlab-desktop/issues/438#issuecomment-1205087645. Briefly, miniconda does not set up `envs` as it does not support sub-environments. The common denominator of the reports was use of `miniconda` or `miniforge`.