### PR TITLE
remote JupyterLab server connection

### DIFF
--- a/scripts/buildutil.js
+++ b/scripts/buildutil.js
@@ -176,20 +176,6 @@ if (cli.flags.checkVersionMatch) {
     process.exit(1);
   }
 
-  // check JupyterLab versions in scripts
-  let searchString = `"appVersion": "${appVersion}",`;
-  if (
-    !searchTextInFile(
-      path.resolve(__dirname, `../src/browser/index.html`),
-      searchString
-    )
-  ) {
-    console.error(
-      `src/index.html doesn't contain correct Application version ${appVersion}`
-    );
-    process.exit(1);
-  }
-
   checkExtensionImports();
 
   console.log('JupyterLab version match satisfied!');

--- a/scripts/buildutil.js
+++ b/scripts/buildutil.js
@@ -37,17 +37,6 @@ const cli = meow(
   }
 );
 
-function searchTextInFile(filePath, text) {
-  try {
-    const fileContent = fs.readFileSync(filePath, 'utf8');
-    return fileContent.includes(text);
-  } catch (e) {
-    console.error('Error searching for file content', e);
-  }
-
-  return false;
-}
-
 // remove ~ or ^ prefix from semver version
 function makeVersionAbsolute(version) {
   if (version.length > 0 && (version[0] === '^' || version[0] === '~')) {

--- a/src/browser/app.tsx
+++ b/src/browser/app.tsx
@@ -58,12 +58,13 @@ export class Application extends React.Component<
         remotes: []
       };
 
-      asyncRemoteRenderer.runRemoteMethod(IServerFactory.getServerInfo, undefined)
-      .then(data => {
-        this._serverReady({
-          data
+      asyncRemoteRenderer
+        .runRemoteMethod(IServerFactory.getServerInfo, undefined)
+        .then(data => {
+          this._serverReady({
+            data
+          });
         });
-      });
     } else {
       this.state = {
         renderSplash: this._renderEmpty,

--- a/src/browser/app.tsx
+++ b/src/browser/app.tsx
@@ -58,7 +58,10 @@ export class Application extends React.Component<
     };
 
     asyncRemoteRenderer
-      .runRemoteMethod<void, IServerFactory.IServerStarted>(IServerFactory.getServerInfo, undefined)
+      .runRemoteMethod<void, IServerFactory.IServerStarted>(
+        IServerFactory.getServerInfo,
+        undefined
+      )
       .then(data => {
         this._serverReady(data);
       });
@@ -123,8 +126,9 @@ export class Application extends React.Component<
     const config: any = data.pageConfig;
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    __webpack_public_path__ = config.hasOwnProperty('fullStaticUrl') ?
-      config['fullStaticUrl'] + '/' : data.url;
+    __webpack_public_path__ = config.hasOwnProperty('fullStaticUrl')
+      ? config['fullStaticUrl'] + '/'
+      : data.url;
 
     for (let key in config) {
       if (config.hasOwnProperty(key)) {

--- a/src/browser/app.tsx
+++ b/src/browser/app.tsx
@@ -51,27 +51,17 @@ export class Application extends React.Component<
     this._changeEnvironment = this._changeEnvironment.bind(this);
     this._splash = React.createRef<SplashScreen>();
 
-    if (this.props.options.serverState === 'local') {
-      this.state = {
-        renderSplash: this._renderEmpty,
-        renderState: this._renderEmpty,
-        remotes: []
-      };
+    this.state = {
+      renderSplash: this._renderEmpty,
+      renderState: this._renderEmpty,
+      remotes: []
+    };
 
-      asyncRemoteRenderer
-        .runRemoteMethod(IServerFactory.getServerInfo, undefined)
-        .then(data => {
-          this._serverReady({
-            data
-          });
-        });
-    } else {
-      this.state = {
-        renderSplash: this._renderEmpty,
-        renderState: this._renderServerManager,
-        remotes: []
-      };
-    }
+    asyncRemoteRenderer
+      .runRemoteMethod(IServerFactory.getServerInfo, undefined)
+      .then(data => {
+        this._serverReady(data);
+      });
 
     this._serverState = new StateDB(/*{namespace: Application.STATE_NAMESPACE}*/);
     this._serverState
@@ -134,7 +124,7 @@ export class Application extends React.Component<
       token: data.token,
       url: data.url,
       name: 'Local',
-      type: 'local'
+      type: data.type
     };
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -151,6 +141,9 @@ export class Application extends React.Component<
         );
       }
     }
+
+    PageConfig.setOption('jupyterlab-desktop-server-type', data.type);
+    PageConfig.setOption('jupyterlab-desktop-server-url', data.labUrl);
 
     // correctly set the base URL so that relative paths can be used
     // (relative paths are used by upstream JupyterLab, e.g. for kernelspec

--- a/src/browser/extensions/desktop-extension/envStatus.tsx
+++ b/src/browser/extensions/desktop-extension/envStatus.tsx
@@ -4,7 +4,18 @@
 import { VDomModel, VDomRenderer } from '@jupyterlab/apputils';
 import React from 'react';
 import { GroupItem, interactiveItem, TextItem } from '@jupyterlab/statusbar';
-import { pythonIcon } from '@jupyterlab/ui-components';
+import { LabIcon } from '@jupyterlab/ui-components';
+
+const serverIconSvgStr = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="jp-icon2" fill="#333333" d="M480 160H32c-17.673 0-32-14.327-32-32V64c0-17.673 14.327-32 32-32h448c17.673 0 32 14.327 32 32v64c0 17.673-14.327 32-32 32zm-48-88c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm-64 0c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm112 248H32c-17.673 0-32-14.327-32-32v-64c0-17.673 14.327-32 32-32h448c17.673 0 32 14.327 32 32v64c0 17.673-14.327 32-32 32zm-48-88c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm-64 0c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm112 248H32c-17.673 0-32-14.327-32-32v-64c0-17.673 14.327-32 32-32h448c17.673 0 32 14.327 32 32v64c0 17.673-14.327 32-32 32zm-48-88c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24zm-64 0c-13.255 0-24 10.745-24 24s10.745 24 24 24 24-10.745 24-24-10.745-24-24-24z"/></svg>
+<!--
+Font Awesome Free 5.2.0 by @fontawesome - https://fontawesome.com
+License - https://fontawesome.com/license (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
+-->`;
+
+const serverIcon = new LabIcon({
+  name: 'server-icon',
+  svgstr: serverIconSvgStr
+});
 
 /**
  * A pure functional component for rendering environment status.
@@ -18,7 +29,7 @@ function EnvironmentStatusComponent(
       spacing={2}
       title={props.description}
     >
-      <pythonIcon.react title={''} top={'2px'} stylesheet={'statusBar'} />
+      <serverIcon.react title={''} top={'2px'} stylesheet={'statusBar'} />
       <TextItem source={props.name} />
     </GroupItem>
   );

--- a/src/browser/extensions/index.ts
+++ b/src/browser/extensions/index.ts
@@ -193,12 +193,11 @@ export async function main() {
   const federatedStylePromises: any[] = [];
 
   let labExtensionUrl = PageConfig.getOption('fullLabextensionsUrl');
-  const baseUrl = PageConfig.getOption('baseUrl');
 
   const allFederatedExtensions = await Promise.allSettled(
     extension_data.map(async (data: any) => {
       await loadComponent(
-        URLExt.join(baseUrl, labExtensionUrl, data.name, data.load),
+        URLExt.join(labExtensionUrl, data.name, data.load),
         data.name
       );
       return data;

--- a/src/browser/index.html
+++ b/src/browser/index.html
@@ -7,14 +7,9 @@ Distributed under the terms of the Modified BSD License.
 
 <head>
   <meta charset="utf-8">
-
   <title>JupyterLab</title>
-
-  <script id="jupyter-config-data" type="application/json">{
-        "appVersion": "3.4.8-1",
-        "pageUrl": "lab/"
-    }</script>
-    <script type="text/javascript" src="browser.bundle.js"></script>
+  <script id="jupyter-config-data" type="application/json"><%- pageConfig %></script>
+  <script type="text/javascript" src="browser.bundle.js"></script>
 </head>
 
 <body>

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -228,7 +228,8 @@ export class JupyterApplication implements IApplication, IStatefulService {
         if (appState.remoteURL === undefined) {
           appState.remoteURL = '';
         }
-        appState.remoteURL = 'https://hub-binder.mybinder.ovh/user/binder-examples-jupyterlab-a5czynjk/lab?token=hqy6-CY8StuNneCqKlaFpQ';
+        appState.remoteURL =
+          'https://hub-binder.mybinder.ovh/user/binder-examples-jupyterlab-a5czynjk/lab?token=hqy6-CY8StuNneCqKlaFpQ';
 
         if (appState.remoteURL === '') {
           appConfig.isRemote = false;
@@ -239,19 +240,18 @@ export class JupyterApplication implements IApplication, IStatefulService {
 
             // start
             waitUntilServerIsUp(appConfig.url).then(() => {
-              loginAndGetServerInfo(appConfig.url.href).then((serverInfo) => {
+              loginAndGetServerInfo(appConfig.url.href).then(serverInfo => {
                 appConfig.pageConfig = serverInfo.pageConfig;
                 appConfig.cookies = serverInfo.cookies;
                 this._serverPageConfigSet = true;
               });
             });
-
           });
         } else {
           appConfig.isRemote = true;
           appConfig.url = new URL(appState.remoteURL);
           appConfig.token = appConfig.url.searchParams.get('token');
-          loginAndGetServerInfo(appConfig.url.href).then((serverInfo) => {
+          loginAndGetServerInfo(appConfig.url.href).then(serverInfo => {
             appConfig.pageConfig = serverInfo.pageConfig;
             appConfig.cookies = serverInfo.cookies;
             this._serverInfoStateSet = true;
@@ -283,14 +283,14 @@ export class JupyterApplication implements IApplication, IStatefulService {
   }
 
   getServerInfo(): Promise<JupyterServer.IInfo> {
-    return new Promise<JupyterServer.IInfo>((resolve) => {
+    return new Promise<JupyterServer.IInfo>(resolve => {
       const resolveInfo = () => {
         resolve({
           type: appConfig.isRemote ? 'remote' : 'local',
           url: appConfig.url.href,
           token: appConfig.token,
           environment: undefined
-        })
+        });
       };
 
       if (this._serverInfoStateSet) {
@@ -308,7 +308,7 @@ export class JupyterApplication implements IApplication, IStatefulService {
   }
 
   get pageConfigSet(): Promise<boolean> {
-    return new Promise<boolean>((resolve) => {
+    return new Promise<boolean>(resolve => {
       if (this._serverPageConfigSet) {
         resolve(true);
         return;
@@ -319,7 +319,7 @@ export class JupyterApplication implements IApplication, IStatefulService {
           clearInterval(timer);
           resolve(true);
         }
-      }, 200); 
+      }, 200);
     });
   }
 

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -782,6 +782,11 @@ export class JupyterApplication implements IApplication, IStatefulService {
       | 'invalid-env'
       | 'remote-connection-failure' = 'change'
   ) {
+    if (this._serverConnectionOptionsDialog) {
+      this._serverConnectionOptionsDialog.focus();
+      return;
+    }
+
     const dialog = new BrowserWindow({
       title: 'JupyterLab Server Configuration',
       width: 720,
@@ -1049,11 +1054,15 @@ export class JupyterApplication implements IApplication, IStatefulService {
       remoteServerUrl,
       persistSessionData
     });
+
+    this._serverConnectionOptionsDialog = dialog;
+
+    dialog.on('close', () => {
+      this._serverConnectionOptionsDialog = null;
+    });
+
     dialog.loadURL(`data:text/html;charset=utf-8,${pageSource}`);
   }
-
-  private _serverInfoStateSet = false;
-  private _serverPageConfigSet = false;
 
   private _checkForUpdates(showDialog: 'on-new-version' | 'always') {
     fetch(
@@ -1118,6 +1127,9 @@ export class JupyterApplication implements IApplication, IStatefulService {
    * The most recently focused window
    */
   private _window: Electron.BrowserWindow;
+  private _serverInfoStateSet = false;
+  private _serverPageConfigSet = false;
+  private _serverConnectionOptionsDialog: BrowserWindow;
 }
 
 export namespace JupyterApplication {

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -256,7 +256,8 @@ export class JupyterApplication implements IApplication, IStatefulService {
         } else {
           appConfig.isRemote = true;
           appConfig.persistSessionData = appState.persistSessionData;
-          appConfig.clearSessionDataOnNextLaunch = appState.clearSessionDataOnNextLaunch === true;
+          appConfig.clearSessionDataOnNextLaunch =
+            appState.clearSessionDataOnNextLaunch === true;
           // reset the flag
           appState.clearSessionDataOnNextLaunch = false;
           try {
@@ -270,10 +271,14 @@ export class JupyterApplication implements IApplication, IStatefulService {
                 this._serverPageConfigSet = true;
               })
               .catch(() => {
-                this._showServerConnectionOptionsDialog('remote-connection-failure');
+                this._showServerConnectionOptionsDialog(
+                  'remote-connection-failure'
+                );
               });
           } catch (error) {
-            this._showServerConnectionOptionsDialog('remote-connection-failure');
+            this._showServerConnectionOptionsDialog(
+              'remote-connection-failure'
+            );
           }
         }
       }

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -242,7 +242,7 @@ export class JupyterApplication implements IApplication, IStatefulService {
             this._serverInfoStateSet = true;
 
             waitUntilServerIsUp(appConfig.url).then(() => {
-              loginAndGetServerInfo(appConfig.url.href, {showDialog: false})
+              loginAndGetServerInfo(appConfig.url.href, { showDialog: false })
                 .then(serverInfo => {
                   appConfig.pageConfig = serverInfo.pageConfig;
                   appConfig.cookies = serverInfo.cookies;
@@ -259,7 +259,7 @@ export class JupyterApplication implements IApplication, IStatefulService {
           try {
             appConfig.url = new URL(appState.remoteURL);
             appConfig.token = appConfig.url.searchParams.get('token');
-            loginAndGetServerInfo(appConfig.url.href, {showDialog: true})
+            loginAndGetServerInfo(appConfig.url.href, { showDialog: true })
               .then(serverInfo => {
                 appConfig.pageConfig = serverInfo.pageConfig;
                 appConfig.cookies = serverInfo.cookies;
@@ -448,7 +448,7 @@ export class JupyterApplication implements IApplication, IStatefulService {
   }
 
   private _validateRemoteServerUrl(url: string): Promise<IJupyterServerInfo> {
-    return loginAndGetServerInfo(url, {showDialog: true, incognito: true});
+    return loginAndGetServerInfo(url, { showDialog: true, incognito: true });
   }
 
   private _clearSessionData(): Promise<void> {
@@ -586,21 +586,25 @@ export class JupyterApplication implements IApplication, IStatefulService {
 
     ipcMain.handle('validate-remote-server-url', (event, url) => {
       return new Promise<any>((resolve, reject) => {
-        this._validateRemoteServerUrl(url).then((value) => {
-          resolve({result: 'valid'});
-        }).catch((error) => {
-          resolve({result: 'invalid', error: error.message});
-        });
+        this._validateRemoteServerUrl(url)
+          .then(value => {
+            resolve({ result: 'valid' });
+          })
+          .catch(error => {
+            resolve({ result: 'invalid', error: error.message });
+          });
       });
     });
 
-    ipcMain.handle('clear-session-data', (event) => {
+    ipcMain.handle('clear-session-data', event => {
       return new Promise<any>((resolve, reject) => {
-        this._clearSessionData().then(() => {
-          resolve({result: 'success'});
-        }).catch((error) => {
-          resolve({result: 'error', error: error.message});
-        });
+        this._clearSessionData()
+          .then(() => {
+            resolve({ result: 'success' });
+          })
+          .catch(error => {
+            resolve({ result: 'error', error: error.message });
+          });
       });
     });
 

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -228,8 +228,8 @@ export class JupyterApplication implements IApplication, IStatefulService {
         if (appState.remoteURL === undefined) {
           appState.remoteURL = '';
         }
-        appState.remoteURL =
-          'https://hub-binder.mybinder.ovh/user/binder-examples-jupyterlab-a5czynjk/lab?token=hqy6-CY8StuNneCqKlaFpQ';
+        // appState.remoteURL =
+        //   'https://hub-binder.mybinder.ovh/user/binder-examples-jupyterlab-a5czynjk/lab?token=hqy6-CY8StuNneCqKlaFpQ';
 
         if (appState.remoteURL === '') {
           appConfig.isRemote = false;

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -840,6 +840,8 @@ export class JupyterApplication implements IApplication, IStatefulService {
               .footer-row {margin-bottom: 10px;}
               .progress-message {margin-right: 5px; line-height: 24px; visibility: hidden;}
               .progress-animation {margin-right: 5px; visibility: hidden;}
+              %23server-url { outline: none; }
+              %23server-url:invalid { border-color: red; }
             </style>
             <h2>JupyterLab Server Configuration</h2>
             <div style="height: 100%; display: flex; flex-direction: column; row-gap: 5px;">
@@ -896,7 +898,7 @@ export class JupyterApplication implements IApplication, IStatefulService {
                 </div>
                 <div class="row">
                     <div style="flex-grow: 1;">
-                        <input type="text" id="server-url" value="<%= remoteServerUrl %>" placeholder="https://example.org/lab?token=abcde" style="width: 100%;" spellcheck="false">
+                        <input type="url" pattern="https?://.*/lab.*" id="server-url" value="<%= remoteServerUrl %>" placeholder="https://example.org/lab?token=abcde" style="width: 100%;" spellcheck="false" required>
                     </div>
                     <div>
                         <button id='validate-server-url' onclick='handleValidateServerUrl(this);'>Validate</button>

--- a/src/main/connect.ts
+++ b/src/main/connect.ts
@@ -110,7 +110,9 @@ export async function connectAndGetServerInfo(
                   }
 
                   const hostname = urlObj.hostname;
-                  const domainCookies = cookies.filter(cookie => cookie.domain === hostname);
+                  const domainCookies = cookies.filter(
+                    cookie => cookie.domain === hostname
+                  );
 
                   window.close();
                   resolve({
@@ -137,7 +139,8 @@ export async function connectAndGetServerInfo(
     window.setMenuBarVisibility(false);
     window.center();
 
-    const clearUserSession = !appConfig.persistSessionData || appConfig.clearSessionDataOnNextLaunch;
+    const clearUserSession =
+      !appConfig.persistSessionData || appConfig.clearSessionDataOnNextLaunch;
 
     if (clearUserSession) {
       clearSession(window.webContents.session).then(() => {

--- a/src/main/login.ts
+++ b/src/main/login.ts
@@ -1,0 +1,44 @@
+import {
+  BrowserWindow, Cookie
+} from 'electron';
+
+export let loginWindow: BrowserWindow;
+
+export interface IJupyterServerInfo {
+  cookies: Cookie[];
+  pageConfig?: any;
+}
+
+export async function loginAndGetServerInfo(url: string, showDialog: boolean = true): Promise<IJupyterServerInfo> {
+  return new Promise<IJupyterServerInfo>((resolve, reject) => {
+    const window = new BrowserWindow({
+      show: showDialog,
+      title: 'JupyterLab Remote Server Login',
+    });
+
+    loginWindow = window;
+
+    window.setMenuBarVisibility(false);
+    window.center();
+    window.loadURL(url);
+
+    window.webContents.on('did-navigate', (event: Event, navigationUrl) => {
+      if (navigationUrl.startsWith(url)) {
+        window.webContents.executeJavaScript(`
+            const config = document.getElementById('jupyter-config-data');
+            JSON.parse(config ? config.textContent : '{}');
+          `).then((config: any) => {
+          window.webContents.session.cookies.get({}).then((cookies) => {
+            window.close();
+            resolve({
+              pageConfig: config,
+              cookies: cookies
+            });
+          }).catch((error) => {
+            console.log(error)
+          });
+        })
+      }
+    });
+  });
+}

--- a/src/main/login.ts
+++ b/src/main/login.ts
@@ -24,7 +24,6 @@ export async function loginAndGetServerInfo(
   options?: IRemoteServerLoginOptions
 ): Promise<IJupyterServerInfo> {
   return new Promise<IJupyterServerInfo>((resolve, reject) => {
-
     try {
       new URL(url);
     } catch (error) {
@@ -44,7 +43,7 @@ export async function loginAndGetServerInfo(
         partition: `partition-${Date.now()}`
       };
     }
-    
+
     const window = new BrowserWindow(browserOptions);
 
     const timeout = options?.timeout || 30000;
@@ -58,7 +57,9 @@ export async function loginAndGetServerInfo(
       }
       reject({
         type: 'timeout',
-        message: `Failed to connect to JupyterLab server in ${(timeout / 1000).toFixed(1)} s`
+        message: `Failed to connect to JupyterLab server in ${(
+          timeout / 1000
+        ).toFixed(1)} s`
       } as ILoginError);
     };
 

--- a/src/main/login.ts
+++ b/src/main/login.ts
@@ -1,6 +1,4 @@
-import {
-  BrowserWindow, Cookie
-} from 'electron';
+import { BrowserWindow, Cookie } from 'electron';
 
 export let loginWindow: BrowserWindow;
 
@@ -9,11 +7,14 @@ export interface IJupyterServerInfo {
   pageConfig?: any;
 }
 
-export async function loginAndGetServerInfo(url: string, showDialog: boolean = true): Promise<IJupyterServerInfo> {
+export async function loginAndGetServerInfo(
+  url: string,
+  showDialog: boolean = true
+): Promise<IJupyterServerInfo> {
   return new Promise<IJupyterServerInfo>((resolve, reject) => {
     const window = new BrowserWindow({
       show: showDialog,
-      title: 'JupyterLab Remote Server Login',
+      title: 'JupyterLab Remote Server Login'
     });
 
     loginWindow = window;
@@ -24,20 +25,27 @@ export async function loginAndGetServerInfo(url: string, showDialog: boolean = t
 
     window.webContents.on('did-navigate', (event: Event, navigationUrl) => {
       if (navigationUrl.startsWith(url)) {
-        window.webContents.executeJavaScript(`
+        window.webContents
+          .executeJavaScript(
+            `
             const config = document.getElementById('jupyter-config-data');
             JSON.parse(config ? config.textContent : '{}');
-          `).then((config: any) => {
-          window.webContents.session.cookies.get({}).then((cookies) => {
-            window.close();
-            resolve({
-              pageConfig: config,
-              cookies: cookies
-            });
-          }).catch((error) => {
-            console.log(error)
+          `
+          )
+          .then((config: any) => {
+            window.webContents.session.cookies
+              .get({})
+              .then(cookies => {
+                window.close();
+                resolve({
+                  pageConfig: config,
+                  cookies: cookies
+                });
+              })
+              .catch(error => {
+                console.log(error);
+              });
           });
-        })
       }
     });
   });

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,10 +1,7 @@
 import {
   app,
-  BrowserWindow,
-  dialog,
   Menu,
-  MenuItem,
-  WebContents
+  MenuItem
 } from 'electron';
 
 const Bottle = require('bottlejs');
@@ -222,41 +219,6 @@ app.on('ready', () => {
       log.error(e);
       app.quit();
     });
-});
-
-app.on('web-contents-created', (_event: any, webContents: WebContents) => {
-  // Prevent navigation to local links on the same page and external links
-  // webContents.on('will-navigate', (event: Event, navigationUrl) => {
-  //   const jlabBaseUrl = `http://localhost:${appConfig.jlabPort}/`;
-  //   if (
-  //     !(
-  //       navigationUrl.startsWith(jlabBaseUrl) &&
-  //       navigationUrl.indexOf('#') === -1
-  //     )
-  //   ) {
-  //     console.warn(
-  //       `Navigation is not allowed; attempted navigation to: ${navigationUrl}`
-  //     );
-  //     event.preventDefault();
-  //   }
-  // });
-
-  // handle page's beforeunload prompt natively
-  webContents.on('will-prevent-unload', (event: Event) => {
-    const win = BrowserWindow.fromWebContents(webContents);
-    const choice = dialog.showMessageBoxSync(win, {
-      type: 'warning',
-      message: 'Do you want to leave?',
-      detail: 'Changes you made may not be saved.',
-      buttons: ['Leave', 'Stay'],
-      defaultId: 1,
-      cancelId: 1
-    });
-
-    if (choice === 0) {
-      event.preventDefault();
-    }
-  });
 });
 
 /**

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,8 +1,4 @@
-import {
-  app,
-  Menu,
-  MenuItem
-} from 'electron';
+import { app, Menu, MenuItem } from 'electron';
 
 const Bottle = require('bottlejs');
 import log from 'electron-log';

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -12,46 +12,8 @@ import log from 'electron-log';
 import * as yargs from 'yargs';
 import * as path from 'path';
 import * as fs from 'fs';
-import { randomBytes } from 'crypto';
-import { AddressInfo, createServer } from 'net';
-
-import { appConfig, getAppDir, isDevMode } from './utils';
+import { getAppDir, isDevMode } from './utils';
 import { execSync } from 'child_process';
-
-async function getFreePort(): Promise<number> {
-  return new Promise<number>(resolve => {
-    const getPort = () => {
-      const server = createServer(socket => {
-        socket.write('Echo server\r\n');
-        socket.pipe(socket);
-      });
-
-      server.on('error', function (e) {
-        getPort();
-      });
-      server.on('listening', function (e: any) {
-        const port = (server.address() as AddressInfo).port;
-        server.close();
-
-        resolve(port);
-      });
-
-      server.listen(0, '127.0.0.1');
-    };
-
-    getPort();
-  });
-}
-
-async function setAppConfig(): Promise<void> {
-  return new Promise<void>(resolve => {
-    getFreePort().then(port => {
-      appConfig.jlabPort = port;
-      appConfig.token = randomBytes(24).toString('hex');
-      resolve();
-    });
-  });
-}
 
 // handle opening file or directory with command-line arguments
 if (process.argv.length > 1) {
@@ -238,8 +200,7 @@ function setApplicationMenu() {
 app.on('ready', () => {
   setApplicationMenu();
 
-  Promise.all([setAppConfig(), handOverArguments()])
-    .then(() => {
+    handOverArguments().then(() => {
       setupJLabCommand();
       let serviceManager = new Bottle();
       let autostarts: string[] = [];
@@ -264,20 +225,20 @@ app.on('ready', () => {
 
 app.on('web-contents-created', (_event: any, webContents: WebContents) => {
   // Prevent navigation to local links on the same page and external links
-  webContents.on('will-navigate', (event: Event, navigationUrl) => {
-    const jlabBaseUrl = `http://localhost:${appConfig.jlabPort}/`;
-    if (
-      !(
-        navigationUrl.startsWith(jlabBaseUrl) &&
-        navigationUrl.indexOf('#') === -1
-      )
-    ) {
-      console.warn(
-        `Navigation is not allowed; attempted navigation to: ${navigationUrl}`
-      );
-      event.preventDefault();
-    }
-  });
+  // webContents.on('will-navigate', (event: Event, navigationUrl) => {
+  //   const jlabBaseUrl = `http://localhost:${appConfig.jlabPort}/`;
+  //   if (
+  //     !(
+  //       navigationUrl.startsWith(jlabBaseUrl) &&
+  //       navigationUrl.indexOf('#') === -1
+  //     )
+  //   ) {
+  //     console.warn(
+  //       `Navigation is not allowed; attempted navigation to: ${navigationUrl}`
+  //     );
+  //     event.preventDefault();
+  //   }
+  // });
 
   // handle page's beforeunload prompt natively
   webContents.on('will-prevent-unload', (event: Event) => {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -200,7 +200,8 @@ function setApplicationMenu() {
 app.on('ready', () => {
   setApplicationMenu();
 
-    handOverArguments().then(() => {
+  handOverArguments()
+    .then(() => {
       setupJLabCommand();
       let serviceManager = new Bottle();
       let autostarts: string[] = [];

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -406,6 +406,7 @@ export namespace JupyterServer {
     token: string;
     environment: IPythonEnvironment;
     version?: string;
+    pageConfig?: any;
   }
 }
 
@@ -451,9 +452,11 @@ export interface IServerFactory {
 export namespace IServerFactory {
   export interface IServerStarted {
     readonly factoryId: number;
+    type: 'local' | 'remote';
     url: string;
     token: string;
     error?: Error;
+    pageConfig?: any;
   }
 
   export interface IServerStop {
@@ -742,6 +745,7 @@ export class JupyterServerFactory implements IServerFactory, IClosingService {
   ): IServerFactory.IServerStarted {
     let info = data.server.info;
     return {
+      type: 'local',
       factoryId: data.factoryId,
       url: info.url,
       token: info.token
@@ -750,6 +754,7 @@ export class JupyterServerFactory implements IServerFactory, IClosingService {
 
   private _errorToIPC(e: Error): IServerFactory.IServerStarted {
     return {
+      type: 'local',
       factoryId: -1,
       url: null,
       token: null,

--- a/src/main/sessions.ts
+++ b/src/main/sessions.ts
@@ -664,29 +664,32 @@ export class JupyterLabSession {
     });
 
     // Prevent navigation to local links on the same page and external links
-    this._window.webContents.on('will-navigate', (event: Event, navigationUrl) => {
-      const jlabBaseUrl = `${appConfig.url.protocol}//${appConfig.url.host}`;
-      if (
-        !(
-          navigationUrl.startsWith(jlabBaseUrl) &&
-          navigationUrl.indexOf('#') === -1
-        )
-      ) {
-        console.warn(
-          `Navigation is not allowed; attempted navigation to: ${navigationUrl}`
+    this._window.webContents.on(
+      'will-navigate',
+      (event: Event, navigationUrl) => {
+        const jlabBaseUrl = `${appConfig.url.protocol}//${appConfig.url.host}`;
+        if (
+          !(
+            navigationUrl.startsWith(jlabBaseUrl) &&
+            navigationUrl.indexOf('#') === -1
+          )
+        ) {
+          console.warn(
+            `Navigation is not allowed; attempted navigation to: ${navigationUrl}`
+          );
+          event.preventDefault();
+          return;
+        }
+
+        const parsedUrl = new URL(navigationUrl);
+
+        asyncRemoteMain.emitRemoteEvent(
+          ISessions.navigatedToHash,
+          parsedUrl.hash,
+          this._window.webContents
         );
-        event.preventDefault();
-        return;
       }
-
-      const parsedUrl = new URL(navigationUrl);
-
-      asyncRemoteMain.emitRemoteEvent(
-        ISessions.navigatedToHash,
-        parsedUrl.hash,
-        this._window.webContents
-      );
-    });
+    );
 
     // handle page's beforeunload prompt natively
     this._window.webContents.on('will-prevent-unload', (event: Event) => {

--- a/src/main/sessions.ts
+++ b/src/main/sessions.ts
@@ -38,7 +38,8 @@ import { request as httpsRequest } from 'https';
 // file name to variables map
 const templateAssetPaths = new Map([
   [
-    'index.html', () => {
+    'index.html',
+    () => {
       return {
         pageConfig: JSON.stringify(appConfig.pageConfig)
       };
@@ -126,7 +127,7 @@ export class JupyterLabSessions
       .then((state: JupyterLabSession.IState) => {
         this._lastWindowState = state;
 
-        app.getServerInfo().then((serverInfo) => {
+        app.getServerInfo().then(serverInfo => {
           if (serverInfo.type === 'local') {
             if (this._registry.getCurrentPythonEnvironment()) {
               this.createSession().then(() => {
@@ -141,7 +142,7 @@ export class JupyterLabSessions
         });
       })
       .catch(() => {
-        app.getServerInfo().then((serverInfo) => {
+        app.getServerInfo().then(serverInfo => {
           this.createSession().then(() => {
             this._startingSession = null;
           });
@@ -495,12 +496,17 @@ export class JupyterLabSession {
       if (assetFilePath.indexOf(appAssetsDir) === 0) {
         // TODO: handle file not found case
         if (!fs.existsSync(assetFilePath)) {
-          callback({statusCode: 404});
+          callback({ statusCode: 404 });
           return;
         }
         let assetContent = fs.readFileSync(assetFilePath);
         if (templateAssetPaths.has(assetPath)) {
-          assetContent = Buffer.from(ejs.render(assetContent.toString(), templateAssetPaths.get(assetPath)()));
+          assetContent = Buffer.from(
+            ejs.render(
+              assetContent.toString(),
+              templateAssetPaths.get(assetPath)()
+            )
+          );
         }
 
         callback(assetContent);
@@ -517,10 +523,13 @@ export class JupyterLabSession {
         Authorization: `token ${appConfig.token}`
       };
 
-      if (appConfig.url && req.url.startsWith(`${appConfig.url.protocol}//${appConfig.url.host}`)) {
+      if (
+        appConfig.url &&
+        req.url.startsWith(`${appConfig.url.protocol}//${appConfig.url.host}`)
+      ) {
         let cookieArray: string[] = [];
         if (appConfig.cookies) {
-          appConfig.cookies.forEach((cookie) => {
+          appConfig.cookies.forEach(cookie => {
             if (cookie.domain === appConfig.url.hostname) {
               cookieArray.push(`${cookie.name}=${cookie.value}`);
               if (cookie.name === '_xsrf') {
@@ -533,7 +542,9 @@ export class JupyterLabSession {
       }
 
       const remoteUrl = req.url;
-      const requestFn = remoteUrl.startsWith('https') ? httpsRequest : httpRequest;
+      const requestFn = remoteUrl.startsWith('https')
+        ? httpsRequest
+        : httpRequest;
 
       const request = requestFn(remoteUrl, {
         headers: headers,
@@ -580,7 +591,10 @@ export class JupyterLabSession {
       request.end();
     };
 
-    const handleInterceptBufferProtocol = (req: Electron.ProtocolRequest, callback: (response: Buffer | Electron.ProtocolResponse) => void) => {
+    const handleInterceptBufferProtocol = (
+      req: Electron.ProtocolRequest,
+      callback: (response: Buffer | Electron.ProtocolResponse) => void
+    ) => {
       // TODO: this check is not enough to decide desktop asset. (e.g. relative image files ./test.png on notebook)
       if (req.url.startsWith(desktopAppAssetsPrefix)) {
         handleDesktopAppAssetRequest(req, callback);
@@ -590,11 +604,13 @@ export class JupyterLabSession {
     };
 
     this._window.webContents.session.protocol.interceptBufferProtocol(
-      'http', handleInterceptBufferProtocol
+      'http',
+      handleInterceptBufferProtocol
     );
 
     this._window.webContents.session.protocol.interceptBufferProtocol(
-      'https', handleInterceptBufferProtocol
+      'https',
+      handleInterceptBufferProtocol
     );
 
     const filter = {
@@ -609,7 +625,7 @@ export class JupyterLabSession {
         };
         if (cookies.size > 0) {
           requestHeaders['Cookie'] = Array.from(cookies.values()).join('; ');
-          requestHeaders['Host'] =  appConfig.url.host ;
+          requestHeaders['Host'] = appConfig.url.host;
           requestHeaders['Origin'] = appConfig.url.origin;
         }
         callback({ cancel: false, requestHeaders });
@@ -651,7 +667,9 @@ export class JupyterLabSession {
 
     sessionManager.app.pageConfigSet.then(() => {
       this._window.loadURL(
-        `${appConfig.url.protocol}//${appConfig.url.host}${appConfig.url.pathname}${DESKTOP_APP_ASSETS_PATH}/index.html?${encodeURIComponent(
+        `${appConfig.url.protocol}//${appConfig.url.host}${
+          appConfig.url.pathname
+        }${DESKTOP_APP_ASSETS_PATH}/index.html?${encodeURIComponent(
           JSON.stringify(this.info)
         )}`
       );

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -26,6 +26,7 @@ export interface IAppConfiguration {
   pageConfig?: any;
   cookies?: Electron.Cookie[];
   persistSessionData: boolean;
+  clearSessionDataOnNextLaunch?: boolean;
 }
 
 export const appConfig: IAppConfiguration = {

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -20,12 +20,16 @@ import { app } from 'electron';
 import { IPythonEnvironment } from './tokens';
 
 export interface IAppConfiguration {
-  jlabPort: number;
+  isRemote: boolean;
+  url: URL;
   token: string;
+  pageConfig?: any;
+  cookies?: Electron.Cookie[];
 }
 
 export const appConfig: IAppConfiguration = {
-  jlabPort: 8888,
+  isRemote: false,
+  url: undefined,
   token: 'jlab-token'
 };
 

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -25,12 +25,14 @@ export interface IAppConfiguration {
   token: string;
   pageConfig?: any;
   cookies?: Electron.Cookie[];
+  persistSessionData: boolean;
 }
 
 export const appConfig: IAppConfiguration = {
   isRemote: false,
   url: undefined,
-  token: 'jlab-token'
+  token: 'jlab-token',
+  persistSessionData: true
 };
 
 export interface ISaveOptions {
@@ -393,17 +395,19 @@ export function getEnvironmentPath(environment: IPythonEnvironment): string {
   return envPath;
 }
 
-export function clearSession(webContents: Electron.WebContents): Promise<void> {
-  return new Promise(resolve => {
-    webContents.clearHistory();
-    const session = webContents.session;
-    Promise.all([
-      session.clearCache(),
-      session.clearAuthCache(),
-      session.clearStorageData()
-    ]).then(() => {
-      resolve();
-    });
+export function clearSession(session: Electron.Session): Promise<void> {
+  return new Promise((resolve, reject) => {
+    try {
+      Promise.all([
+        session.clearCache(),
+        session.clearAuthCache(),
+        session.clearStorageData()
+      ]).then(() => {
+        resolve();
+      });
+    } catch (error) {
+      reject();
+    }
   });
 }
 

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -393,6 +393,20 @@ export function getEnvironmentPath(environment: IPythonEnvironment): string {
   return envPath;
 }
 
+export function clearSession(webContents: Electron.WebContents): Promise<void> {
+  return new Promise(resolve => {
+    webContents.clearHistory();
+    const session = webContents.session;
+    Promise.all([
+      session.clearCache(),
+      session.clearAuthCache(),
+      session.clearStorageData()
+    ]).then(() => {
+      resolve();
+    });
+  });
+}
+
 let service: IService = {
   requirements: ['IApplication'],
   provides: 'IElectronDataConnector',

--- a/tbump.toml
+++ b/tbump.toml
@@ -27,9 +27,6 @@ search = 'version: {current_version}'
 src = "env_installer/construct.yaml"
 version_template = "{major}.{minor}.{patch}"
 search = '- jupyterlab {current_version}'
-[[file]]
-src = "src/browser/index.html"
-search = '"appVersion": "{current_version}"'
 
 #  [[before_commit]]
 #  name = "check changelog"


### PR DESCRIPTION
This PR adds ability to connect to remote JupyterLab Servers as backend of the desktop application instead of launching a server locally.
- Supports connection to JupyterLab servers requiring authentication such as SSO
- Selected remote URL is saved as part of user settings and connection is restored at next launch

Here is how it works: Application first tries to connect to the remote server in a separate window and user enters credentials as needed. This populates session data and cookies are captured. `jupyter-config-data` is also retrieved from the connected JupyterLab server. Then JupyterLab Desktop is loaded in the main window using the same session and data retrieved.

Server Configuration Dialog (previously environment setting dialog)
<img width="726" alt="server configuration dialog" src="https://user-images.githubusercontent.com/40003442/197371072-537d3152-8ebd-4411-adac-015589921fe4.png">

Example connection to a remote binder instance
![remote server connection](https://user-images.githubusercontent.com/40003442/197371084-db32fd73-8493-4226-8454-f9829f982ae6.gif)

Example connection to JupyterHub
![jupyter hub connection](https://user-images.githubusercontent.com/40003442/197371098-d9d7ee47-1d74-4ac4-b39c-47923151ff20.gif)

