### PR TITLE
Fix deprecation warnings on `publish` action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,32 +26,14 @@ jobs:
       - uses: s-weigand/setup-conda@v1
 
       - name: Install node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '14.x'
-
-      - name: Get yarn cache directory path on Windows
-        id: yarn-cache-dir-path
-        if: runner.os == 'Windows'
-        run: echo "dir=$(yarn cache dir)" >> $env:GITHUB_OUTPUT
-
-      - name: Get yarn cache directory path on other OS
-        id: yarn-cache-dir-path
-        if: runner.os != 'Windows'
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache yarn
-        uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-${{ matrix.cfg.platform }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.cfg.platform }}-yarn-
+          cache: 'yarn'
 
       - name: Install dependencies
         run: |
-          npm install --global yarn
+          npm install --global yarn --prefer-offline
           conda install -c conda-forge constructor
           yarn install
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,13 +51,13 @@ jobs:
         run: echo "version=$(python scripts/get_package_version.py)" >> $GITHUB_OUTPUT
 
       - name: 'Find Release with tag v${{ steps.package-info.outputs.version}}'
-        uses: actions/github-script@v4
+        uses: actions/github-script@v6
         id: release-exists
         env:
           APP_VERSION: ${{ steps.package-info.outputs.version}}
         with:
           script: |
-            const releases = await github.repos.listReleases({
+            const releases = await github.rest.repos.listReleases({
               owner: context.repo.owner,
               repo: context.repo.repo
             })

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Cache yarn
         uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,8 +46,9 @@ jobs:
           yarn lint:check
 
       - name: Get package info
+        shell: bash
         id: package-info
-        uses: codex-team/action-nodejs-package-info@v1
+        run: echo "version=$(python scripts/get_package_version.py)" >> $GITHUB_OUTPUT
 
       - name: 'Find Release with tag v${{ steps.package-info.outputs.version}}'
         uses: actions/github-script@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,9 +30,16 @@ jobs:
         with:
           node-version: '14.x'
 
-      - name: Get yarn cache directory path
+      - name: Get yarn cache directory path on Windows
         id: yarn-cache-dir-path
+        if: runner.os == 'Windows'
+        run: echo "dir=$(yarn cache dir)" >> $env:GITHUB_OUTPUT
+
+      - name: Get yarn cache directory path on other OS
+        id: yarn-cache-dir-path
+        if: runner.os != 'Windows'
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+
       - name: Cache yarn
         uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)

--- a/scripts/get_package_version.py
+++ b/scripts/get_package_version.py
@@ -1,0 +1,11 @@
+import json
+
+
+def get_package_version(path):
+    """Extract version from given `package.json` file."""
+    with open(path) as f:
+        package = json.load(f)
+        return package['version']
+
+if __name__ == '__main__':   
+    print(get_package_version(path='package.json'))


### PR DESCRIPTION
Seen on #508.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/