### PR TITLE
Add dependabot configuraiton

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -7,6 +7,9 @@ updates:
     ignore:
       # we have our custom bot for updating jupyterlab dependencies when needed
       - dependency-name: "@jupyterlab/*"
+      # we only want automated minor and patch updates, major updates of electron usually require manual action
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "pip"
     directory: "/"
     schedule:

--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      # we have our custom bot for updating jupyterlab dependencies when needed
+      - dependency-name: "@jupyterlab/*"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      # we have our custom bot for updating jupyterlab dependencies when needed
+      - dependency-name: "jupyterlab*"


### PR DESCRIPTION
Proposing to add dependabot for keeping Electron dependencies up to date. If any package updates are too aggressive we can add more `ignore` rules or adjust version bumping strategy.

This does not affect the security updates.