### PR TITLE
server launch customization

### DIFF
--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -376,7 +376,8 @@ export class JupyterApplication implements IApplication, IDisposable {
         serverArgs: userSettings.getValue(SettingType.serverArgs),
         overrideDefaultServerArgs: userSettings.getValue(
           SettingType.overrideDefaultServerArgs
-        )
+        ),
+        serverEnvVars: userSettings.getValue(SettingType.serverEnvVars)
       },
       this._registry
     );
@@ -780,6 +781,13 @@ export class JupyterApplication implements IApplication, IDisposable {
           SettingType.overrideDefaultServerArgs,
           overrideDefaultServerArgs
         );
+      }
+    );
+
+    this._evm.registerEventHandler(
+      EventTypeMain.SetServerEnvVars,
+      (_event, serverEnvVars: any) => {
+        userSettings.setValue(SettingType.serverEnvVars, serverEnvVars || {});
       }
     );
 

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -372,7 +372,11 @@ export class JupyterApplication implements IApplication, IDisposable {
         ),
         defaultPythonPath: userSettings.getValue(SettingType.pythonPath),
         logLevel: userSettings.getValue(SettingType.logLevel),
-        activateTab: activateTab
+        activateTab: activateTab,
+        serverArgs: userSettings.getValue(SettingType.serverArgs),
+        overrideDefaultServerArgs: userSettings.getValue(
+          SettingType.overrideDefaultServerArgs
+        )
       },
       this._registry
     );
@@ -765,6 +769,17 @@ export class JupyterApplication implements IApplication, IDisposable {
       EventTypeMain.SetLogLevel,
       (_event, logLevel: LogLevel) => {
         userSettings.setValue(SettingType.logLevel, logLevel);
+      }
+    );
+
+    this._evm.registerEventHandler(
+      EventTypeMain.SetServerLaunchArgs,
+      (_event, serverArgs: string, overrideDefaultServerArgs: boolean) => {
+        userSettings.setValue(SettingType.serverArgs, serverArgs || '');
+        userSettings.setValue(
+          SettingType.overrideDefaultServerArgs,
+          overrideDefaultServerArgs
+        );
       }
     );
 

--- a/src/main/config/settings.ts
+++ b/src/main/config/settings.ts
@@ -33,6 +33,8 @@ export enum LogLevel {
   Debug = 'debug'
 }
 
+export type KeyValueMap = { [key: string]: string };
+
 export enum SettingType {
   checkForUpdatesAutomatically = 'checkForUpdatesAutomatically',
   installUpdatesAutomatically = 'installUpdatesAutomatically',
@@ -46,6 +48,7 @@ export enum SettingType {
   pythonPath = 'pythonPath',
   serverArgs = 'serverArgs',
   overrideDefaultServerArgs = 'overrideDefaultServerArgs',
+  serverEnvVars = 'serverEnvVars',
 
   startupMode = 'startupMode',
 
@@ -130,6 +133,7 @@ export class UserSettings {
       overrideDefaultServerArgs: new Setting<boolean>(false, {
         wsOverridable: true
       }),
+      serverEnvVars: new Setting<KeyValueMap>({}, { wsOverridable: true }),
 
       startupMode: new Setting<StartupMode>(StartupMode.WelcomePage),
 

--- a/src/main/config/settings.ts
+++ b/src/main/config/settings.ts
@@ -44,11 +44,30 @@ export enum SettingType {
 
   defaultWorkingDirectory = 'defaultWorkingDirectory',
   pythonPath = 'pythonPath',
+  serverArgs = 'serverArgs',
+  overrideDefaultServerArgs = 'overrideDefaultServerArgs',
 
   startupMode = 'startupMode',
 
   logLevel = 'logLevel'
 }
+
+export const serverLaunchArgsFixed = [
+  '--no-browser',
+  '--expose-app-in-browser',
+  `--ServerApp.port={port}`,
+  // use our token rather than any pre-configured password
+  '--ServerApp.password=""',
+  `--ServerApp.token="{token}"`,
+  '--LabApp.quit_button=False'
+];
+
+export const serverLaunchArgsDefault = [
+  // do not use any config file
+  '--JupyterApp.config_file_name=""',
+  // enable hidden files (let user decide whether to display them)
+  '--ContentsManager.allow_hidden=True'
+];
 
 export class Setting<T> {
   constructor(defaultValue: T, options?: Setting.IOptions) {
@@ -107,6 +126,10 @@ export class UserSettings {
 
       defaultWorkingDirectory: new Setting<string>(''),
       pythonPath: new Setting<string>('', { wsOverridable: true }),
+      serverArgs: new Setting<string>('', { wsOverridable: true }),
+      overrideDefaultServerArgs: new Setting<boolean>(false, {
+        wsOverridable: true
+      }),
 
       startupMode: new Setting<StartupMode>(StartupMode.WelcomePage),
 

--- a/src/main/eventtypes.ts
+++ b/src/main/eventtypes.ts
@@ -53,7 +53,8 @@ export enum EventTypeMain {
   ClearHistory = 'clear-history',
   ShowInvalidPythonPathMessage = 'show-invalid-python-path-message',
   SetLogLevel = 'set-log-level',
-  SetServerLaunchArgs = 'set-server-launch-args'
+  SetServerLaunchArgs = 'set-server-launch-args',
+  SetServerEnvVars = 'set-server-env-vars'
 }
 
 // events sent to Renderer process

--- a/src/main/eventtypes.ts
+++ b/src/main/eventtypes.ts
@@ -52,7 +52,8 @@ export enum EventTypeMain {
   IsDarkTheme = 'is-dark-theme',
   ClearHistory = 'clear-history',
   ShowInvalidPythonPathMessage = 'show-invalid-python-path-message',
-  SetLogLevel = 'set-log-level'
+  SetLogLevel = 'set-log-level',
+  SetServerLaunchArgs = 'set-server-launch-args'
 }
 
 // events sent to Renderer process

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -265,6 +265,16 @@ export class JupyterServer {
           'desktop-workspaces'
         );
 
+        const serverEnvVars = { ...this._info.serverEnvVars };
+
+        // allow modifying PATH without replacing by using {PATH} variable
+        if (process.env.PATH && 'PATH' in serverEnvVars) {
+          serverEnvVars.PATH = serverEnvVars.PATH.replace(
+            '{PATH}',
+            process.env.PATH
+          );
+        }
+
         const execOptions = {
           cwd: this._info.workingDirectory,
           shell: isWin ? 'cmd.exe' : '/bin/bash',
@@ -274,7 +284,7 @@ export class JupyterServer {
               process.env.JLAB_DESKTOP_CONFIG_DIR || getUserDataDir(),
             JUPYTERLAB_WORKSPACES_DIR:
               process.env.JLAB_DESKTOP_WORKSPACES_DIR || jlabWorkspacesDir,
-            ...this._info.serverEnvVars
+            ...serverEnvVars
           }
         };
 

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -18,6 +18,7 @@ import {
 } from './utils';
 import {
   FrontEndMode,
+  KeyValueMap,
   serverLaunchArgsDefault,
   serverLaunchArgsFixed,
   SettingType,
@@ -168,6 +169,7 @@ export class JupyterServer {
     this._info.overrideDefaultServerArgs = wsSettings.getValue(
       SettingType.overrideDefaultServerArgs
     );
+    this._info.serverEnvVars = wsSettings.getValue(SettingType.serverEnvVars);
   }
 
   get info(): JupyterServer.IInfo {
@@ -268,6 +270,7 @@ export class JupyterServer {
           cwd: this._info.workingDirectory,
           shell: isWin ? 'cmd.exe' : '/bin/bash',
           env: {
+            ...this._info.serverEnvVars,
             ...process.env,
             JUPYTER_CONFIG_DIR:
               process.env.JLAB_DESKTOP_CONFIG_DIR || getUserDataDir(),
@@ -491,6 +494,7 @@ export class JupyterServer {
     environment: null,
     serverArgs: '',
     overrideDefaultServerArgs: false,
+    serverEnvVars: {},
     version: null
   };
   private _registry: IRegistry;
@@ -515,6 +519,7 @@ export namespace JupyterServer {
     workingDirectory: string;
     serverArgs: string;
     overrideDefaultServerArgs: boolean;
+    serverEnvVars: KeyValueMap;
     version?: string;
     pageConfig?: any;
   }

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -74,7 +74,6 @@ function createLaunchScript(
   if (
     userSettings.getValue(SettingType.frontEndMode) === FrontEndMode.ClientApp
   ) {
-    // launchArgs.push('--ServerApp.allow_origin="*"');
     launchArgs.push(`--LabServerApp.schemas_dir="${schemasDir}"`);
   }
 
@@ -270,12 +269,12 @@ export class JupyterServer {
           cwd: this._info.workingDirectory,
           shell: isWin ? 'cmd.exe' : '/bin/bash',
           env: {
-            ...this._info.serverEnvVars,
             ...process.env,
             JUPYTER_CONFIG_DIR:
               process.env.JLAB_DESKTOP_CONFIG_DIR || getUserDataDir(),
             JUPYTERLAB_WORKSPACES_DIR:
-              process.env.JLAB_DESKTOP_WORKSPACES_DIR || jlabWorkspacesDir
+              process.env.JLAB_DESKTOP_WORKSPACES_DIR || jlabWorkspacesDir,
+            ...this._info.serverEnvVars
           }
         };
 

--- a/src/main/settingsdialog/preload.ts
+++ b/src/main/settingsdialog/preload.ts
@@ -89,6 +89,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
   setLogLevel: (level: string) => {
     ipcRenderer.send(EventTypeMain.SetLogLevel, level);
+  },
+  setServerLaunchArgs: (
+    serverArgs: string,
+    overrideDefaultServerArgs: boolean
+  ) => {
+    ipcRenderer.send(
+      EventTypeMain.SetServerLaunchArgs,
+      serverArgs,
+      overrideDefaultServerArgs
+    );
   }
 });
 

--- a/src/main/settingsdialog/preload.ts
+++ b/src/main/settingsdialog/preload.ts
@@ -99,6 +99,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
       serverArgs,
       overrideDefaultServerArgs
     );
+  },
+  setServerEnvVars: (serverEnvVars: any) => {
+    ipcRenderer.send(EventTypeMain.SetServerEnvVars, serverEnvVars);
   }
 });
 

--- a/src/main/settingsdialog/settingsdialog.ts
+++ b/src/main/settingsdialog/settingsdialog.ts
@@ -452,7 +452,6 @@ export class SettingsDialog {
               handleEnvTypeChange();
               <%- !bundledEnvInstallationExists ? 'showBundledEnvWarning("does-not-exist");' : '' %> 
               <%- (bundledEnvInstallationExists && !bundledEnvInstallationLatest) ? 'showBundledEnvWarning("not-latest");' : '' %>
-              updateServerLaunchCommandPreview();
               </script>
             </jp-tab-panel>
 

--- a/src/main/settingsdialog/settingsdialog.ts
+++ b/src/main/settingsdialog/settingsdialog.ts
@@ -394,23 +394,30 @@ export class SettingsDialog {
                     }
                   }
 
+                  let valid = true;
+
                   if (serverEnvVars !== '' && Object.keys(envVars).length < lines.length) {
-                    return undefined;
+                    valid = false;
                   }
 
-                  return envVars;
+                  return { valid, envVars };
                 } catch (error) {
-                  return undefined;
+                  return { valid: false, envVars: {} };
                 }
               }
 
               function updateServerEnvVarsValidity() {
-                if (parseServerEnvVars() === undefined) {
-                  additionalServerEnvVars.classList.add('invalid');
-                } else {
+                if (parseServerEnvVars().valid) {
                   additionalServerEnvVars.classList.remove('invalid');
+                } else {
+                  additionalServerEnvVars.classList.add('invalid');
                 }
               }
+
+              document.addEventListener("DOMContentLoaded", () => {
+                updateServerLaunchCommandPreview();
+                updateServerEnvVarsValidity();
+              });
 
               window.electronAPI.onInstallBundledPythonEnvStatus((status) => {
                 const message = status === 'STARTED' ?
@@ -579,7 +586,7 @@ export class SettingsDialog {
           window.electronAPI.setDefaultWorkingDirectory(workingDirectoryInput.value);
 
           window.electronAPI.setServerLaunchArgs(additionalServerArgs.value, overrideDefaultServerArgs.checked);
-          window.electronAPI.setServerEnvVars(parseServerEnvVars());
+          window.electronAPI.setServerEnvVars(parseServerEnvVars().envVars);
 
           if (defaultPythonEnvChanged) {
             if (bundledEnvRadio.checked) {


### PR DESCRIPTION
- support server launch args customization
- support adding server env vars
- allow prepending to path env using `{PATH}`. i.e. `PATH="/Users/username/somedir:{PATH}"`
<img width="1162" alt="server launch customization" src="https://user-images.githubusercontent.com/40003442/219976929-082710dc-e3c7-4580-adf9-4b3de55c28ed.png">

fixes https://github.com/jupyterlab/jupyterlab-desktop/issues/583, https://github.com/jupyterlab/jupyterlab-desktop/issues/573, https://github.com/jupyterlab/jupyterlab-desktop/issues/393, https://github.com/jupyterlab/jupyterlab-desktop/issues/268, https://github.com/jupyterlab/jupyterlab-desktop/issues/437
