### PR TITLE
Add winget publish github action

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,16 @@
+name: Publish to WinGet
+on:
+  release:
+    types: [released]
+jobs:
+  publish:
+    # Action can only be run on windows
+    runs-on: windows-latest
+    steps:
+      - uses: vedantmgoyal2009/winget-releaser@v2
+        # https://github.com/vedantmgoyal2009/winget-releaser
+        with:
+          identifier: ProjectJupyter.JupyterLab
+          release-tag: ${{ steps.package-info.outputs.version}}
+          version: ${{ steps.package-info.outputs.version}}
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -11,6 +11,4 @@ jobs:
         # https://github.com/vedantmgoyal2009/winget-releaser
         with:
           identifier: ProjectJupyter.JupyterLab
-          release-tag: ${{ steps.package-info.outputs.version}}
-          version: ${{ steps.package-info.outputs.version}}
           token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
This adds a github action to publish the windows version to the winget-pkgs repo.  The winget-releaser github action requires a personal token as `WINGET_TOKEN`.  Details for configuration are here: https://github.com/vedantmgoyal2009/winget-releaser

For now, I have also submitted a PR to winget-pkgs to update to the current version, using the underlying tool utilized by this action.

This is my first attempt at configuring this as an action, so please let me know if there are any questions, concerns, or issues.

Thanks!