### PR TITLE
UI modes

### DIFF
--- a/src/main/config/settings.ts
+++ b/src/main/config/settings.ts
@@ -35,6 +35,13 @@ export enum CtrlWBehavior {
   DoNotClose = 'do-not-close'
 }
 
+export enum UIMode {
+  Custom = 'custom',
+  MultiDocument = 'multi-document',
+  SingleDocument = 'single-document',
+  SingleDocumentZen = 'single-document-zen'
+}
+
 export type KeyValueMap = { [key: string]: string };
 
 export enum SettingType {
@@ -62,7 +69,9 @@ export enum SettingType {
   condaPath = 'condaPath',
   systemPythonPath = 'systemPythonPath',
   pythonEnvsPath = 'pythonEnvsPath',
-  condaChannels = 'condaChannels'
+  condaChannels = 'condaChannels',
+
+  uiMode = 'uiMode'
 }
 
 export const serverLaunchArgsFixed = [
@@ -159,7 +168,9 @@ export class UserSettings {
       condaPath: new Setting<string>(''),
       systemPythonPath: new Setting<string>(''),
       pythonEnvsPath: new Setting<string>(''),
-      condaChannels: new Setting<string[]>(['conda-forge'])
+      condaChannels: new Setting<string[]>(['conda-forge']),
+
+      uiMode: new Setting<UIMode>(UIMode.MultiDocument, { wsOverridable: true })
     };
 
     if (readSettings) {

--- a/src/main/sessionwindow/sessionwindow.ts
+++ b/src/main/sessionwindow/sessionwindow.ts
@@ -17,6 +17,7 @@ import {
   DEFAULT_WIN_HEIGHT,
   DEFAULT_WIN_WIDTH,
   SettingType,
+  UIMode,
   userSettings,
   WorkspaceSettings
 } from '../config/settings';
@@ -420,6 +421,8 @@ export class SessionWindow implements IDisposable {
         showServerNotificationBadge
       );
     }
+
+    this._setUIMode(this._wsSettings.getValue(SettingType.uiMode));
   }
 
   get titleBarView(): TitleBarView {
@@ -861,6 +864,56 @@ export class SessionWindow implements IDisposable {
             this._newWindow();
           }
         },
+        {
+          label: 'UI Mode',
+          visible:
+            this._contentViewType === ContentViewType.Lab &&
+            !this._progressViewVisible,
+          type: 'submenu',
+          submenu: [
+            {
+              label: 'Zen Mode',
+              click: () => {
+                this._setUIMode(UIMode.SingleDocumentZen);
+              },
+              type: 'checkbox',
+              checked:
+                this._contentViewType === ContentViewType.Lab &&
+                this._labView.uiMode === UIMode.SingleDocumentZen
+            },
+            {
+              label: 'Single document IDE',
+              click: () => {
+                this._setUIMode(UIMode.SingleDocument);
+              },
+              type: 'checkbox',
+              checked:
+                this._contentViewType === ContentViewType.Lab &&
+                this._labView.uiMode === UIMode.SingleDocument
+            },
+            {
+              label: 'Multi document IDE',
+              click: () => {
+                this._setUIMode(UIMode.MultiDocument);
+              },
+              type: 'checkbox',
+              checked:
+                this._contentViewType === ContentViewType.Lab &&
+                this._labView.uiMode === UIMode.MultiDocument
+            },
+            {
+              label: 'Custom',
+              click: () => {
+                this._setUIMode(UIMode.Custom);
+              },
+              type: 'checkbox',
+              checked:
+                this._contentViewType === ContentViewType.Lab &&
+                this._labView.uiMode === UIMode.Custom
+            }
+          ]
+        },
+        { type: 'separator' },
         {
           label: 'Close Session',
           visible:
@@ -1562,6 +1615,13 @@ export class SessionWindow implements IDisposable {
 
     this._contentViewType = ContentViewType.Welcome;
     this._updateContentView();
+  }
+
+  private async _setUIMode(uiMode: UIMode) {
+    await this._labView.labUIReady;
+    this._wsSettings.setValue(SettingType.uiMode, uiMode);
+    this._wsSettings.save();
+    this._labView.setUIMode(uiMode);
   }
 
   private _newWindow() {


### PR DESCRIPTION
- Adds UI mode switch to session menu. UI mode is saved per project (working directory).
- Zen Mode is the simplified Single document mode. It is an alternative to Classic Notebook view.
- Custom mode is the default mode that comes with JupyterLab and restores user's layout configuration. Other modes reset the layout based on the selection whenever a new session is created.

- [x] Introduce UI modes
- [ ] Expose UI modes in settings dialog and CLI
- [ ] Make Zen Mode default for opening single notebook files by double clicking or from CLI

cc. @bollwyvl I looked into supporting Jupyter Notebook mode but it was not feasible. It didn't seem to worth the effort. The Zen Mode introduced in this PR is a good alternative for Classic Notebook view fans.

![ui-modes-2](https://github.com/jupyterlab/jupyterlab-desktop/assets/40003442/722a8201-67c9-4931-aada-3984151935dc)
