### PR TITLE
show TOC in Zen mode option

### DIFF
--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -414,7 +414,8 @@ export class JupyterApplication implements IApplication, IDisposable {
         uiMode: userSettings.getValue(SettingType.uiMode),
         uiModeForSingleFileOpen: userSettings.getValue(
           SettingType.uiModeForSingleFileOpen
-        )
+        ),
+        showTOCInZenMode: userSettings.getValue(SettingType.showTOCInZenMode)
       },
       this._registry
     );

--- a/src/main/config/settings.ts
+++ b/src/main/config/settings.ts
@@ -72,7 +72,8 @@ export enum SettingType {
   condaChannels = 'condaChannels',
 
   uiMode = 'uiMode',
-  uiModeForSingleFileOpen = 'uiModeForSingleFileOpen'
+  uiModeForSingleFileOpen = 'uiModeForSingleFileOpen',
+  showTOCInZenMode = 'showTOCInZenMode'
 }
 
 export const serverLaunchArgsFixed = [
@@ -174,7 +175,8 @@ export class UserSettings {
       uiMode: new Setting<UIMode>(UIMode.ManagedByWebApp, {
         wsOverridable: true
       }),
-      uiModeForSingleFileOpen: new Setting<UIMode>(UIMode.Zen)
+      uiModeForSingleFileOpen: new Setting<UIMode>(UIMode.Zen),
+      showTOCInZenMode: new Setting<boolean>(false)
     };
 
     if (readSettings) {

--- a/src/main/labview/labview.ts
+++ b/src/main/labview/labview.ts
@@ -282,9 +282,9 @@ export class LabView implements IDisposable {
 
     await this._view.webContents.executeJavaScript(`
     {
-      jlabDesktop_setUIMode('${this._uiMode}', ${userSettings.getValue(
-      SettingType.showTOCInZenMode
-    )});
+      jlabDesktop_setUIMode('${this._uiMode}', {
+        showTOCInZenMode: ${userSettings.getValue(SettingType.showTOCInZenMode)}
+      });
     }
   `);
   }
@@ -465,7 +465,7 @@ export class LabView implements IDisposable {
           });
         }
 
-        async function jlabDesktop_setUIMode(uiMode, showTOCInZenMode) {
+        async function jlabDesktop_setUIMode(uiMode, options) {
           const lab = await jlabDesktop_getLab();
           const labShell = lab.shell;
           const statusBar = labShell.widgets('bottom').find(widget => widget.id === 'jp-main-statusbar');
@@ -520,7 +520,7 @@ export class LabView implements IDisposable {
                 statusBar.setHidden(true);
               }
             }
-            if (showTOCInZenMode) {
+            if (options?.showTOCInZenMode) {
               labShell.activateById('table-of-contents');
             }
           }
@@ -529,9 +529,14 @@ export class LabView implements IDisposable {
         jlabDesktop_getLab().then((lab) => {
           ${
             setToSingleFileUIMode
-              ? `jlabDesktop_setUIMode('${userSettings.getValue(
-                  SettingType.uiModeForSingleFileOpen
-                )}', ${userSettings.getValue(SettingType.showTOCInZenMode)});`
+              ? `jlabDesktop_setUIMode(
+                  '${userSettings.getValue(
+                    SettingType.uiModeForSingleFileOpen
+                  )}', {
+                    showTOCInZenMode: ${userSettings.getValue(
+                      SettingType.showTOCInZenMode
+                    )}
+                  });`
               : ''
           }
           lab.restored.then(() => {

--- a/src/main/labview/labview.ts
+++ b/src/main/labview/labview.ts
@@ -282,7 +282,9 @@ export class LabView implements IDisposable {
 
     await this._view.webContents.executeJavaScript(`
     {
-      jlabDesktop_setUIMode('${this._uiMode}');
+      jlabDesktop_setUIMode('${this._uiMode}', ${userSettings.getValue(
+      SettingType.showTOCInZenMode
+    )});
     }
   `);
   }
@@ -463,7 +465,7 @@ export class LabView implements IDisposable {
           });
         }
 
-        async function jlabDesktop_setUIMode(uiMode) {
+        async function jlabDesktop_setUIMode(uiMode, showTOCInZenMode) {
           const lab = await jlabDesktop_getLab();
           const labShell = lab.shell;
           const statusBar = labShell.widgets('bottom').find(widget => widget.id === 'jp-main-statusbar');
@@ -518,6 +520,9 @@ export class LabView implements IDisposable {
                 statusBar.setHidden(true);
               }
             }
+            if (showTOCInZenMode) {
+              labShell.activateById('table-of-contents');
+            }
           }
         }
 
@@ -526,7 +531,7 @@ export class LabView implements IDisposable {
             setToSingleFileUIMode
               ? `jlabDesktop_setUIMode('${userSettings.getValue(
                   SettingType.uiModeForSingleFileOpen
-                )}');`
+                )}', ${userSettings.getValue(SettingType.showTOCInZenMode)});`
               : ''
           }
           lab.restored.then(() => {

--- a/src/main/settingsdialog/settingsdialog.ts
+++ b/src/main/settingsdialog/settingsdialog.ts
@@ -44,7 +44,8 @@ export class SettingsDialog {
       serverEnvVars,
       ctrlWBehavior,
       uiMode,
-      uiModeForSingleFileOpen
+      uiModeForSingleFileOpen,
+      showTOCInZenMode
     } = options;
     const installUpdatesAutomaticallyEnabled = process.platform === 'darwin';
     const installUpdatesAutomatically =
@@ -194,6 +195,10 @@ export class SettingsDialog {
                       </jp-select>
                     </div>
                   </div>
+                </div>
+                
+                <div class="row">
+                  <jp-checkbox id='checkbox-show-toc-in-zen-mode' type='checkbox' <%= showTOCInZenMode ? 'checked' : '' %>>Show Table of Contents in Zen Mode</jp-checkbox>
                 </div>
               </div>
               
@@ -519,6 +524,7 @@ export class SettingsDialog {
             updateBundledEnvAutomatically: updateBundledEnvAutomaticallyCheckbox.checked,
             uiMode: document.getElementById('ui-mode').value,
             uiModeForSingleFileOpen: document.getElementById('ui-mode-for-single-file-open').value,
+            showTOCInZenMode: document.getElementById('checkbox-show-toc-in-zen-mode').checked
           });
 
           window.electronAPI.setDefaultWorkingDirectory(workingDirectoryInput.value);
@@ -562,7 +568,8 @@ export class SettingsDialog {
       ctrlWBehavior,
       cliCommandIsSetup,
       uiMode,
-      uiModeForSingleFileOpen
+      uiModeForSingleFileOpen,
+      showTOCInZenMode
     });
   }
 
@@ -604,5 +611,6 @@ export namespace SettingsDialog {
     ctrlWBehavior: CtrlWBehavior;
     uiMode: UIMode;
     uiModeForSingleFileOpen: UIMode;
+    showTOCInZenMode: boolean;
   }
 }


### PR DESCRIPTION
Option to show Table of Contents panel in Zen Mode
<img width="812" alt="toc-in-zen-mode" src="https://github.com/jupyterlab/jupyterlab-desktop/assets/40003442/d9e3cc76-52d0-4263-8540-6aeeeb1034dd">


<img width="1136" alt="lab-toc-in-zen-mode" src="https://github.com/jupyterlab/jupyterlab-desktop/assets/40003442/75ca4a85-aad1-4cbc-930e-46cba4c6ceda">

fixes https://github.com/jupyterlab/jupyterlab-desktop/issues/795