### PR TITLE
Gate jlabCLICommandIsSetup to packaged builds only

### DIFF
--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -741,6 +741,10 @@ export function getJlabCLICommandTargetPath(): string {
 }
 
 export function jlabCLICommandIsSetup(): boolean {
+  if (!app.isPackaged) {
+    return true;
+  }
+
   if (process.platform !== 'darwin') {
     return true;
   }


### PR DESCRIPTION
## Change

- Updated jlabCLICommandIsSetup() in utils.ts to return true early when !app.isPackaged.
- This gates CLI checks to packaged builds only.

## Reasoning

- In dev mode (yarn start), the CLI binary /app/jlab is not bundled, so the previous logic tried to check a non-existent path and logged errors: App CLI is not executable … /app/jlab

## Effect

- 	Removes noisy errors during development.
- 	Keeps CLI setup/validation untouched for packaged apps.
- 	No behavior change for end-users or production builds.

## Why needed

- 	Prevents false negatives in dev logs.
- 	Makes it easier for contributors to run and test JupyterLab Desktop locally without confusion.
- 	Keeps the CLI check strictly where it matters (packaged app).