### PR TITLE
security: fix CVE-2025-54991 and CVE-2025-55002 (entitlements + Node fuses)

### DIFF
--- a/dist-resources/darwin/entitlements.inherit.plist
+++ b/dist-resources/darwin/entitlements.inherit.plist
@@ -6,15 +6,7 @@
     <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
-    <key>com.apple.security.network.client</key>
-    <true/>
-    <key>com.apple.security.network.server</key>
-    <true/>
-    <key>com.apple.security.files.user-selected.read-only</key>
-    <true/>
     <key>com.apple.security.inherit</key>
-    <true/>
-    <key>com.apple.security.automation.apple-events</key>
     <true/>
   </dict>
 </plist>

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
       "env_installer/jlab_server.tar.gz",
       "env_installer/sign*.txt"
     ],
+    "afterPack": "scripts/afterPack.js",
     "afterSign": "scripts/notarize.js",
     "linux": {
       "target": [
@@ -107,7 +108,7 @@
       "base": "core22",
       "environment": {
         "SHELL": "/bin/bash",
-        "GTK_USE_PORTAL":"1"
+        "GTK_USE_PORTAL": "1"
       },
       "hooks": "build/snap-hooks"
     },
@@ -152,7 +153,7 @@
         }
       ],
       "entitlements": "build/entitlements.plist",
-      "entitlementsInherit": "build/entitlements.plist",
+      "entitlementsInherit": "build/entitlements.inherit.plist",
       "darkModeSupport": true,
       "hardenedRuntime": true,
       "gatekeeperAssess": false,
@@ -181,7 +182,9 @@
   "repository": "https://github.com/jupyterlab/jupyterlab-desktop",
   "license": "BSD-3-Clause",
   "devDependencies": {
+    "@electron/fuses": "^2.1.1",
     "@jupyter-notebook/web-components": "0.9.1",
+    "@leeoniya/ufuzzy": "1.0.14",
     "@types/ejs": "^3.1.0",
     "@types/js-yaml": "^4.0.3",
     "@types/node": "^14.14.31",
@@ -193,7 +196,6 @@
     "@types/yargs": "^17.0.18",
     "@typescript-eslint/eslint-plugin": "~5.28.0",
     "@typescript-eslint/parser": "~5.28.0",
-    "@leeoniya/ufuzzy": "1.0.14",
     "electron": "^27.0.2",
     "electron-builder": "^24.9.1",
     "electron-notarize": "^1.2.2",

--- a/scripts/afterPack.js
+++ b/scripts/afterPack.js
@@ -1,0 +1,23 @@
+const { flipFuses, FuseVersion, FuseV1Options } = require('@electron/fuses');
+const path = require('path');
+
+exports.default = async function afterPack(context) {
+  const { electronPlatformName, appOutDir } = context;
+  const appName = context.packager.appInfo.productFilename;
+
+  let electronPath;
+  if (electronPlatformName === 'darwin') {
+    electronPath = path.join(appOutDir, `${appName}.app`, 'Contents', 'MacOS', appName);
+  } else if (electronPlatformName === 'win32') {
+    electronPath = path.join(appOutDir, `${appName}.exe`);
+  } else {
+    electronPath = path.join(appOutDir, appName);
+  }
+
+  await flipFuses(electronPath, {
+    version: FuseVersion.V1,
+    [FuseV1Options.RunAsNode]: false,
+    [FuseV1Options.EnableNodeOptionsEnvironmentVariable]: false,
+    [FuseV1Options.EnableNodeCliInspectArguments]: false,
+  });
+};

--- a/scripts/copyassets.js
+++ b/scripts/copyassets.js
@@ -81,6 +81,15 @@ function copyAssests() {
       ),
       path.join(buildDir, 'entitlements.plist')
     );
+    fs.copySync(
+      path.join(
+        path.resolve('./'),
+        'dist-resources',
+        'darwin',
+        'entitlements.inherit.plist'
+      ),
+      path.join(buildDir, 'entitlements.inherit.plist')
+    );
   } else if (platform === 'win32') {
     fs.copySync(
       path.join(

--- a/yarn.lock
+++ b/yarn.lock
@@ -71,6 +71,11 @@
     glob "^7.1.6"
     minimatch "^3.0.4"
 
+"@electron/fuses@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@electron/fuses/-/fuses-2.1.1.tgz#8b15eb91dcde51e20a2b3cefb5fb11adb43d237a"
+  integrity sha512-38ho27/mtUV/LpsZ1LCDJUomKBBSUZDk/qBH4FNNtoN5fmnkmWDcIp5pm1Kv3InqhRjKZKs7Jzx+wWZNMArHrA==
+
 "@electron/get@^2.0.0":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@electron/get/-/get-2.0.2.tgz#ae2a967b22075e9c25aaf00d5941cd79c21efd7e"


### PR DESCRIPTION
## Summary

Fixes two draft security advisories:

**CVE-2025-54991 — TCC bypass via insecure entitlements** (GHSA-8cvf-4977-r95v)
- Remove `allow-dyld-environment-variables` and `disable-library-validation` from `entitlements.plist` — these are the direct vectors for the reported dylib injection
- Remove `cs.debugger` (should not be present in production builds)
- Add `entitlements.inherit.plist` with minimal set for helper processes (GPU/Renderer/Crashpad): only `allow-jit`, `allow-unsigned-executable-memory`, `inherit` — previously helpers inherited all entitlements including network and automation
- Wire `entitlementsInherit` in electron-builder config to the new minimal plist

**CVE-2025-55002 — TCC bypass via misconfigured Node fuses** (GHSA-vrj4-r4fw-9rfh)
- Add `scripts/afterPack.js` using `@electron/fuses` to disable three fuses before code signing: `RunAsNode`, `EnableNodeOptionsEnvironmentVariable`, `EnableNodeCliInspectArguments`
- Wire `afterPack` hook in electron-builder config
- Add `@electron/fuses ^2.1.1` as devDependency

## Notes

- `afterPack` runs before code signing — fuse changes are locked in by the signature. Using `afterSign` would be too late.
- Disabling `RunAsNode` does not affect Python subprocess management. JupyterLab spawns Python via `child_process.spawn()`, not `ELECTRON_RUN_AS_NODE`.
- `allow-jit` and `allow-unsigned-executable-memory` are kept in the main entitlements — both required by Chromium/V8 for JIT compilation and WebAssembly.

## Test plan

- [ ] Build macOS installer (`yarn dist:osx-dev`) and verify signing succeeds
- [ ] Run `npx @electron/fuses read --app JupyterLab.app` — confirm RunAsNode/NodeOptions/NodeCLI show Disabled
- [ ] Verify Python kernel launches normally after fuse changes
- [ ] Verify JupyterLab UI loads (news feed, notebooks)

Note: AI-assisted (Claude Code). Changes reviewed against Electron security docs, `@electron/fuses` API reference, and the advisory PoCs from the reporters.

Closes GHSA-8cvf-4977-r95v · Closes GHSA-vrj4-r4fw-9rfh

🤖 Generated with [Claude Code](https://claude.com/claude-code)