### PR TITLE
fix: replace node-fetch with Electron net.fetch in main process

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,14 +27,12 @@ jobs:
       - name: Build app
         run: yarn build
 
-      - name: Install Playwright browsers
+      - name: Install Playwright Chromium + system deps
         run: npx playwright install --with-deps chromium
 
-      # Electron needs a display on Linux
+      # xvfb-maybe auto-detects headless Linux and wraps with xvfb-run
       - name: Run E2E tests
-        uses: coactions/setup-xvfb@v1
-        with:
-          run: yarn test:e2e
+        run: yarn test:e2e
         env:
           CI: true
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,47 @@
+name: E2E Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    name: 'E2E smoke tests'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build app
+        run: yarn build
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      # Electron needs a display on Linux
+      - name: Run E2E tests
+        uses: coactions/setup-xvfb@v1
+        with:
+          run: yarn test:e2e
+        env:
+          CI: true
+
+      - name: Upload test results on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-test-results
+          path: test-results/
+          retention-days: 7

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,20 @@ on:
   workflow_dispatch:
 
 jobs:
+  test:
+    name: 'Unit tests'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile
+      - run: yarn test:unit
+
   publish:
+    needs: test
     strategy:
       matrix:
         cfg:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,14 @@ jobs:
           node-version: '20.x'
           cache: 'yarn'
       - run: yarn install --frozen-lockfile
-      - run: yarn test:unit
+      - name: Run unit tests with coverage
+        run: yarn test:unit:coverage
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-coverage
+          path: coverage/
+          retention-days: 14
 
   publish:
     needs: test

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/dist-resources/darwin/entitlements.inherit.plist
+++ b/dist-resources/darwin/entitlements.inherit.plist
@@ -6,15 +6,7 @@
     <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
-    <key>com.apple.security.network.client</key>
-    <true/>
-    <key>com.apple.security.network.server</key>
-    <true/>
-    <key>com.apple.security.files.user-selected.read-only</key>
-    <true/>
     <key>com.apple.security.inherit</key>
-    <true/>
-    <key>com.apple.security.automation.apple-events</key>
     <true/>
   </dict>
 </plist>

--- a/dist-resources/darwin/entitlements.plist
+++ b/dist-resources/darwin/entitlements.plist
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
-    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
-    <true/>
-    <key>com.apple.security.cs.disable-library-validation</key>
-    <true/>
     <key>com.apple.security.cs.allow-jit</key>
     <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
         }
       ],
       "entitlements": "build/entitlements.plist",
-      "entitlementsInherit": "build/entitlements.plist",
+      "entitlementsInherit": "build/entitlements.inherit.plist",
       "darkModeSupport": true,
       "hardenedRuntime": true,
       "gatekeeperAssess": false,

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
       "env_installer/jlab_server.tar.gz",
       "env_installer/sign*.txt"
     ],
+    "afterPack": "scripts/afterPack.js",
     "afterSign": "scripts/notarize.js",
     "linux": {
       "target": [
@@ -186,6 +187,7 @@
   "repository": "https://github.com/jupyterlab/jupyterlab-desktop",
   "license": "BSD-3-Clause",
   "devDependencies": {
+    "@electron/fuses": "^2.1.1",
     "@jupyter-notebook/web-components": "0.9.1",
     "@leeoniya/ufuzzy": "1.0.14",
     "@playwright/test": "^1.59.1",
@@ -253,7 +255,7 @@
   "lint-staged": {
     "*.{ts,tsx}": [
       "eslint --cache --fix",
-      "vitest run --related --reporter=dot"
+      "vitest related --run --reporter=dot"
     ],
     "*.{ts,tsx,js,jsx,css,json,md}": [
       "prettier --write"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "yarn test:unit",
     "test:unit": "vitest run",
     "test:unit:watch": "vitest",
-    "test:e2e": "playwright test",
+    "test:e2e": "xvfb-maybe playwright test",
     "clean": "rimraf build dist",
     "watch:tsc": "tsc -w",
     "watch:assets": "node ./scripts/extract.js && node ./scripts/copyassets.js watch",
@@ -56,7 +56,9 @@
     "prettier:check": "prettier --check \"**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}\"",
     "stylelint": "yarn stylelint:check --fix",
     "stylelint:check": "stylelint \"**/*.css\"",
-    "update-ufuzzy": "shx cp node_modules/@leeoniya/ufuzzy/dist/uFuzzy.iife.min.js src/assets/"
+    "update-ufuzzy": "shx cp node_modules/@leeoniya/ufuzzy/dist/uFuzzy.iife.min.js src/assets/",
+    "prepare": "husky",
+    "test:unit:coverage": "vitest run --coverage"
   },
   "build": {
     "appId": "org.jupyter.jupyterlab-desktop",
@@ -208,7 +210,9 @@
     "eslint-plugin-prettier": "~4.0.0",
     "eslint-plugin-react": "~7.29.4",
     "fs-extra": "~9.1.0",
+    "husky": "^9.1.7",
     "istextorbinary": "^6.0.0",
+    "lint-staged": "^16.4.0",
     "meow": "^6.0.1",
     "mini-css-extract-plugin": "^1.3.9",
     "node-watch": "^0.7.4",
@@ -224,7 +228,8 @@
     "typescript": "~4.2.2",
     "vitest": "^4.1.5",
     "webpack": "^5.76.0",
-    "webpack-cli": "^4.5.0"
+    "webpack-cli": "^4.5.0",
+    "xvfb-maybe": "^0.2.1"
   },
   "resolutions": {
     "serialize-javascript": "^6.0.2",
@@ -244,5 +249,14 @@
     "which": "^2.0.2",
     "winreg": "^1.2.4",
     "yargs": "^17.6.2"
+  },
+  "lint-staged": {
+    "*.{ts,tsx}": [
+      "eslint --cache --fix",
+      "vitest run --related --reporter=dot"
+    ],
+    "*.{ts,tsx,js,jsx,css,json,md}": [
+      "prettier --write"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "main": "./build/out/main/main.js",
   "scripts": {
     "start": "electron .",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "yarn test:unit",
+    "test:unit": "vitest run",
+    "test:unit:watch": "vitest",
+    "test:e2e": "playwright test",
     "clean": "rimraf build dist",
     "watch:tsc": "tsc -w",
     "watch:assets": "node ./scripts/extract.js && node ./scripts/copyassets.js watch",
@@ -107,7 +110,7 @@
       "base": "core22",
       "environment": {
         "SHELL": "/bin/bash",
-        "GTK_USE_PORTAL":"1"
+        "GTK_USE_PORTAL": "1"
       },
       "hooks": "build/snap-hooks"
     },
@@ -182,6 +185,8 @@
   "license": "BSD-3-Clause",
   "devDependencies": {
     "@jupyter-notebook/web-components": "0.9.1",
+    "@leeoniya/ufuzzy": "1.0.14",
+    "@playwright/test": "^1.59.1",
     "@types/ejs": "^3.1.0",
     "@types/js-yaml": "^4.0.3",
     "@types/node": "^14.14.31",
@@ -193,10 +198,11 @@
     "@types/yargs": "^17.0.18",
     "@typescript-eslint/eslint-plugin": "~5.28.0",
     "@typescript-eslint/parser": "~5.28.0",
-    "@leeoniya/ufuzzy": "1.0.14",
+    "@vitest/coverage-v8": "^4.1.5",
     "electron": "^27.0.2",
     "electron-builder": "^24.9.1",
     "electron-notarize": "^1.2.2",
+    "electron-playwright-helpers": "^2.1.0",
     "eslint": "~8.17.0",
     "eslint-config-prettier": "~8.5.0",
     "eslint-plugin-prettier": "~4.0.0",
@@ -216,14 +222,19 @@
     "stylelint-config-standard": "~24.0.0",
     "stylelint-prettier": "^2.0.0",
     "typescript": "~4.2.2",
+    "vitest": "^4.1.5",
     "webpack": "^5.76.0",
     "webpack-cli": "^4.5.0"
+  },
+  "resolutions": {
+    "serialize-javascript": "^6.0.2",
+    "micromatch": "^4.0.8"
   },
   "dependencies": {
     "@lumino/signaling": "^1.10.0",
     "ejs": "^3.1.10",
     "electron-log": "^4.4.8",
-    "fast-xml-parser": "^4.2.5",
+    "fast-xml-parser": "^5.7.0",
     "fix-path": "^3.0.0",
     "js-yaml": "^4.1.0",
     "node-fetch": "^2.6.7",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from '@playwright/test';
+import path from 'path';
+
+export default defineConfig({
+  testDir: './test/e2e',
+  timeout: 60000,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? 'github' : 'list',
+  use: {
+    trace: 'on-first-retry',
+    video: 'on-first-retry'
+  },
+  projects: [
+    {
+      name: 'electron',
+      testMatch: '**/*.test.ts'
+    }
+  ],
+  outputDir: 'test-results/'
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,11 +1,13 @@
 import { defineConfig } from '@playwright/test';
-import path from 'path';
 
 export default defineConfig({
   testDir: './test/e2e',
+  // Each test launches a real Electron process — keep timeout generous
   timeout: 60000,
   retries: process.env.CI ? 2 : 0,
   reporter: process.env.CI ? 'github' : 'list',
+  // Run tests sequentially: parallel Electron launches on CI are flaky
+  workers: 1,
   use: {
     trace: 'on-first-retry',
     video: 'on-first-retry'

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "onboarding": false,
+  "requireConfig": "optional",
   "schedule": ["every weekend"],
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": ["config:recommended"],
   "onboarding": false,
   "requireConfig": "optional",
-  "schedule": ["every weekend"],
+  "schedule": ["at any time"],
   "packageRules": [
     {
       "description": "Group Electron + related packages — major bumps need Phase 3 review",

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "schedule": ["every weekend"],
+  "packageRules": [
+    {
+      "description": "Group Electron + related packages — major bumps need Phase 3 review",
+      "matchPackageNames": [
+        "electron",
+        "electron-builder",
+        "electron-log",
+        "electron-updater"
+      ],
+      "groupName": "electron core",
+      "labels": ["dependencies", "electron"]
+    },
+    {
+      "description": "Group test tooling updates together",
+      "matchPackageNames": [
+        "vitest",
+        "@vitest/coverage-v8",
+        "@playwright/test",
+        "electron-playwright-helpers",
+        "husky",
+        "lint-staged",
+        "xvfb-maybe"
+      ],
+      "groupName": "test tooling",
+      "labels": ["dependencies", "testing"]
+    },
+    {
+      "description": "Group TypeScript + ESLint updates",
+      "matchPackageNames": [
+        "typescript",
+        "@typescript-eslint/eslint-plugin",
+        "@typescript-eslint/parser",
+        "eslint",
+        "eslint-config-prettier",
+        "eslint-plugin-prettier",
+        "eslint-plugin-react",
+        "prettier"
+      ],
+      "groupName": "linting & types",
+      "labels": ["dependencies", "lint"]
+    },
+    {
+      "description": "Auto-merge minor/patch GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "automerge": true,
+      "automergeType": "pr",
+      "matchUpdateTypes": ["minor", "patch"]
+    }
+  ],
+  "ignorePaths": ["env_installer/**", "workflow_env/**"]
+}

--- a/scripts/afterPack.js
+++ b/scripts/afterPack.js
@@ -1,0 +1,29 @@
+const { flipFuses, FuseVersion, FuseV1Options } = require('@electron/fuses');
+const path = require('path');
+
+exports.default = async function afterPack(context) {
+  const { electronPlatformName, appOutDir } = context;
+  const appName = context.packager.appInfo.productFilename;
+
+  let electronPath;
+  if (electronPlatformName === 'darwin') {
+    electronPath = path.join(
+      appOutDir,
+      `${appName}.app`,
+      'Contents',
+      'MacOS',
+      appName
+    );
+  } else if (electronPlatformName === 'win32') {
+    electronPath = path.join(appOutDir, `${appName}.exe`);
+  } else {
+    electronPath = path.join(appOutDir, appName);
+  }
+
+  await flipFuses(electronPath, {
+    version: FuseVersion.V1,
+    [FuseV1Options.RunAsNode]: false,
+    [FuseV1Options.EnableNodeOptionsEnvironmentVariable]: false,
+    [FuseV1Options.EnableNodeCliInspectArguments]: false
+  });
+};

--- a/scripts/copyassets.js
+++ b/scripts/copyassets.js
@@ -81,6 +81,15 @@ function copyAssests() {
       ),
       path.join(buildDir, 'entitlements.plist')
     );
+    fs.copySync(
+      path.join(
+        path.resolve('./'),
+        'dist-resources',
+        'darwin',
+        'entitlements.inherit.plist'
+      ),
+      path.join(buildDir, 'entitlements.inherit.plist')
+    );
   } else if (platform === 'win32') {
     fs.copySync(
       path.join(

--- a/test/e2e/smoke.test.ts
+++ b/test/e2e/smoke.test.ts
@@ -1,73 +1,75 @@
 import { test, expect, _electron as electron } from '@playwright/test';
+import { ElectronApplication } from '@playwright/test';
 import { stubAllDialogs } from 'electron-playwright-helpers';
 import { mkdtempSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
-let tempUserData: string;
-
-test.beforeEach(() => {
-  tempUserData = mkdtempSync(join(tmpdir(), 'jlab-e2e-'));
-});
-
-test.afterEach(async () => {
-  rmSync(tempUserData, { recursive: true, force: true });
-});
-
-test('app launches and shows a window', async () => {
+async function launchApp(
+  overrideEnv: Record<string, string> = {}
+): Promise<{ app: ElectronApplication; tempDir: string }> {
+  const tempDir = mkdtempSync(join(tmpdir(), 'jlab-e2e-'));
   const app = await electron.launch({
     args: ['.'],
     env: {
       ...process.env,
-      JLAB_DESKTOP_HOME: tempUserData,
-      ELECTRON_IS_TEST: '1'
+      JLAB_DESKTOP_HOME: tempDir,
+      ...overrideEnv
     }
   });
-
   await stubAllDialogs(app);
-  const window = await app.firstWindow();
-  await window.waitForLoadState('domcontentloaded');
+  return { app, tempDir };
+}
 
-  expect(app.windows().length).toBeGreaterThan(0);
-  await app.close();
+async function cleanup(app: ElectronApplication, tempDir: string) {
+  await app.close().catch(() => undefined);
+  rmSync(tempDir, { recursive: true, force: true });
+}
+
+test('app launches and shows at least one window', async () => {
+  const { app, tempDir } = await launchApp();
+  try {
+    await app.firstWindow();
+    expect(app.windows().length).toBeGreaterThan(0);
+  } finally {
+    await cleanup(app, tempDir);
+  }
 });
 
-test('app exits with code 0', async () => {
-  const app = await electron.launch({
-    args: ['.'],
-    env: {
-      ...process.env,
-      JLAB_DESKTOP_HOME: tempUserData,
-      ELECTRON_IS_TEST: '1'
-    }
-  });
-
-  await stubAllDialogs(app);
-  await app.firstWindow();
-
-  const exitCode = await app.close();
-  expect(exitCode).toBe(0);
+test('app exits cleanly with code 0', async () => {
+  const { app, tempDir } = await launchApp();
+  try {
+    await app.firstWindow();
+    const exitCode = await app.close();
+    expect(exitCode).toBe(0);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
 });
 
-test('first-run shows env selection when no env configured', async () => {
-  const app = await electron.launch({
-    args: ['.'],
-    env: {
-      ...process.env,
-      JLAB_DESKTOP_HOME: tempUserData,
-      ELECTRON_IS_TEST: '1',
-      // empty userData = no prior config = first run
-      APPDATA: tempUserData
-    }
-  });
+test('first window reaches domcontentloaded within 30s', async () => {
+  const { app, tempDir } = await launchApp();
+  try {
+    const window = await app.firstWindow();
+    await window.waitForLoadState('domcontentloaded');
+    const title = await window.title();
+    // JupyterLab Desktop windows always have a non-empty title
+    expect(typeof title).toBe('string');
+  } finally {
+    await cleanup(app, tempDir);
+  }
+});
 
-  await stubAllDialogs(app);
-  const window = await app.firstWindow();
-
-  // welcome view or env select should appear within 15s
-  await expect(
-    window.locator('#welcome-view, #env-select-dialog, [data-testid="env-select"]')
-  ).toBeVisible({ timeout: 15000 });
-
-  await app.close();
+test('app responds to evaluate (main process accessible)', async () => {
+  const { app, tempDir } = await launchApp();
+  try {
+    await app.firstWindow();
+    const version = await app.evaluate(({ app: electronApp }) =>
+      electronApp.getVersion()
+    );
+    expect(typeof version).toBe('string');
+    expect(version.length).toBeGreaterThan(0);
+  } finally {
+    await cleanup(app, tempDir);
+  }
 });

--- a/test/e2e/smoke.test.ts
+++ b/test/e2e/smoke.test.ts
@@ -1,0 +1,73 @@
+import { test, expect, _electron as electron } from '@playwright/test';
+import { stubAllDialogs } from 'electron-playwright-helpers';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+let tempUserData: string;
+
+test.beforeEach(() => {
+  tempUserData = mkdtempSync(join(tmpdir(), 'jlab-e2e-'));
+});
+
+test.afterEach(async () => {
+  rmSync(tempUserData, { recursive: true, force: true });
+});
+
+test('app launches and shows a window', async () => {
+  const app = await electron.launch({
+    args: ['.'],
+    env: {
+      ...process.env,
+      JLAB_DESKTOP_HOME: tempUserData,
+      ELECTRON_IS_TEST: '1'
+    }
+  });
+
+  await stubAllDialogs(app);
+  const window = await app.firstWindow();
+  await window.waitForLoadState('domcontentloaded');
+
+  expect(app.windows().length).toBeGreaterThan(0);
+  await app.close();
+});
+
+test('app exits with code 0', async () => {
+  const app = await electron.launch({
+    args: ['.'],
+    env: {
+      ...process.env,
+      JLAB_DESKTOP_HOME: tempUserData,
+      ELECTRON_IS_TEST: '1'
+    }
+  });
+
+  await stubAllDialogs(app);
+  await app.firstWindow();
+
+  const exitCode = await app.close();
+  expect(exitCode).toBe(0);
+});
+
+test('first-run shows env selection when no env configured', async () => {
+  const app = await electron.launch({
+    args: ['.'],
+    env: {
+      ...process.env,
+      JLAB_DESKTOP_HOME: tempUserData,
+      ELECTRON_IS_TEST: '1',
+      // empty userData = no prior config = first run
+      APPDATA: tempUserData
+    }
+  });
+
+  await stubAllDialogs(app);
+  const window = await app.firstWindow();
+
+  // welcome view or env select should appear within 15s
+  await expect(
+    window.locator('#welcome-view, #env-select-dialog, [data-testid="env-select"]')
+  ).toBeVisible({ timeout: 15000 });
+
+  await app.close();
+});

--- a/test/setup/electron-mock.ts
+++ b/test/setup/electron-mock.ts
@@ -1,0 +1,53 @@
+import { vi } from 'vitest';
+
+const userDataPath = '/tmp/jlab-test-userdata';
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn((name: string) => `${userDataPath}/${name}`),
+    getVersion: vi.fn(() => '4.4.7'),
+    getName: vi.fn(() => 'JupyterLab'),
+    isPackaged: false,
+    whenReady: vi.fn(() => Promise.resolve())
+  },
+  ipcMain: {
+    on: vi.fn(),
+    handle: vi.fn(),
+    removeHandler: vi.fn(),
+    removeAllListeners: vi.fn(),
+    emit: vi.fn()
+  },
+  dialog: {
+    showOpenDialog: vi.fn(),
+    showMessageBox: vi.fn(),
+    showMessageBoxSync: vi.fn(() => 0)
+  },
+  BrowserWindow: vi.fn().mockImplementation(() => ({
+    loadURL: vi.fn(),
+    webContents: { send: vi.fn(), on: vi.fn() },
+    on: vi.fn(),
+    once: vi.fn(),
+    show: vi.fn(),
+    close: vi.fn(),
+    isDestroyed: vi.fn(() => false)
+  })),
+  shell: { openExternal: vi.fn(), openPath: vi.fn() },
+  nativeTheme: { shouldUseDarkColors: false },
+  screen: { getPrimaryDisplay: vi.fn(() => ({ workAreaSize: { width: 1920, height: 1080 } })) }
+}));
+
+vi.mock('electron-log', () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    transports: {
+      file: {
+        level: 'info',
+        getFile: () => ({ path: '/tmp/test.log' })
+      },
+      console: { level: false }
+    }
+  }
+}));

--- a/test/setup/electron-mock.ts
+++ b/test/setup/electron-mock.ts
@@ -2,9 +2,16 @@ import { vi } from 'vitest';
 
 const userDataPath = '/tmp/jlab-test-userdata';
 
+// isDevMode() in utils.ts calls require.main.filename. In vitest's ESM context
+// require.main is undefined; patch it so unit tests can call getAppDir() on darwin.
+if (typeof require !== 'undefined' && !(require as any).main) {
+  (require as any).main = { filename: '/test/vitest-runner.js' };
+}
+
 vi.mock('electron', () => ({
   app: {
     getPath: vi.fn((name: string) => `${userDataPath}/${name}`),
+    getAppPath: vi.fn(() => `${userDataPath}/app`),
     getVersion: vi.fn(() => '4.4.7'),
     getName: vi.fn(() => 'JupyterLab'),
     isPackaged: false,

--- a/test/setup/electron-mock.ts
+++ b/test/setup/electron-mock.ts
@@ -21,8 +21,19 @@ vi.mock('electron', () => ({
     on: vi.fn(),
     handle: vi.fn(),
     removeHandler: vi.fn(),
+    removeListener: vi.fn(),
     removeAllListeners: vi.fn(),
     emit: vi.fn()
+  },
+  ipcRenderer: {
+    on: vi.fn(),
+    send: vi.fn(),
+    invoke: vi.fn(),
+    removeListener: vi.fn(),
+    removeAllListeners: vi.fn()
+  },
+  contextBridge: {
+    exposeInMainWorld: vi.fn()
   },
   dialog: {
     showOpenDialog: vi.fn(),

--- a/test/unit/appdata.test.ts
+++ b/test/unit/appdata.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as fs from 'fs';
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: vi.fn(() => false),
+    readFileSync: vi.fn(() => { throw new Error('ENOENT'); }),
+    writeFileSync: vi.fn(),
+    mkdirSync: vi.fn()
+  };
+});
+
+import {
+  appData,
+  ApplicationData,
+  IRecentSession,
+  IRecentRemoteURL
+} from '../../../src/main/config/appdata';
+
+const mockFs = vi.mocked(fs);
+
+function resetAppData() {
+  appData.pythonPath = '';
+  appData.condaPath = '';
+  appData.systemPythonPath = '';
+  appData.recentRemoteURLs = [];
+  appData.recentSessions = [];
+  appData.discoveredPythonEnvs = [];
+  appData.userSetPythonEnvs = [];
+  appData.newsList = [];
+  appData.sessions = [];
+  appData.updateBundledEnvOnRestart = false;
+}
+
+describe('ApplicationData.getAppDataPath', () => {
+  it('returns a path ending with app-data.json', () => {
+    const p = ApplicationData.getAppDataPath();
+    expect(p).toMatch(/app-data\.json$/);
+  });
+
+  it('includes the userData directory', () => {
+    const p = ApplicationData.getAppDataPath();
+    expect(p).toContain('jlab-test-userdata');
+  });
+});
+
+describe('ApplicationData.read', () => {
+  beforeEach(() => {
+    resetAppData();
+  });
+
+  it('no-ops gracefully when file does not exist', () => {
+    mockFs.existsSync = vi.fn(() => false);
+    expect(() => appData.read()).not.toThrow();
+  });
+
+  it('reads pythonPath from JSON', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.readFileSync = vi.fn(() =>
+      Buffer.from(JSON.stringify({ pythonPath: '/usr/bin/python3' }))
+    );
+    appData.read();
+    expect(appData.pythonPath).toBe('/usr/bin/python3');
+  });
+
+  it('reads condaPath from JSON', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.readFileSync = vi.fn(() =>
+      Buffer.from(JSON.stringify({ condaPath: '/opt/conda/bin/conda' }))
+    );
+    appData.read();
+    expect(appData.condaPath).toBe('/opt/conda/bin/conda');
+  });
+
+  it('migrates legacy condaRootPath to condaPath', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.readFileSync = vi.fn(() =>
+      Buffer.from(JSON.stringify({ condaRootPath: '/opt/conda' }))
+    );
+    appData.read();
+    expect(appData.condaPath).toContain('conda');
+    expect(appData.condaPath).toContain('/opt/conda');
+  });
+
+  it('reads recentRemoteURLs list', () => {
+    const date = new Date('2024-01-01').toISOString();
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.readFileSync = vi.fn(() =>
+      Buffer.from(
+        JSON.stringify({
+          recentRemoteURLs: [{ url: 'https://example.com', date }]
+        })
+      )
+    );
+    appData.read();
+    expect(appData.recentRemoteURLs).toHaveLength(1);
+    expect(appData.recentRemoteURLs[0].url).toBe('https://example.com');
+  });
+
+  it('reads updateBundledEnvOnRestart flag', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.readFileSync = vi.fn(() =>
+      Buffer.from(JSON.stringify({ updateBundledEnvOnRestart: true }))
+    );
+    appData.read();
+    expect(appData.updateBundledEnvOnRestart).toBe(true);
+  });
+});
+
+describe('ApplicationData.save', () => {
+  beforeEach(() => {
+    resetAppData();
+    mockFs.existsSync = vi.fn(() => false);
+    mockFs.writeFileSync = vi.fn();
+  });
+
+  it('calls writeFileSync with app-data.json path', () => {
+    appData.save();
+    expect(mockFs.writeFileSync).toHaveBeenCalledOnce();
+    const [writePath] = (mockFs.writeFileSync as any).mock.calls[0];
+    expect(writePath).toMatch(/app-data\.json$/);
+  });
+
+  it('omits empty pythonPath from saved JSON', () => {
+    appData.pythonPath = '';
+    appData.save();
+    const content = (mockFs.writeFileSync as any).mock.calls[0][1] as string;
+    const json = JSON.parse(content);
+    expect(json).not.toHaveProperty('pythonPath');
+  });
+
+  it('includes non-empty pythonPath in saved JSON', () => {
+    appData.pythonPath = '/usr/bin/python3';
+    appData.save();
+    const content = (mockFs.writeFileSync as any).mock.calls[0][1] as string;
+    const json = JSON.parse(content);
+    expect(json.pythonPath).toBe('/usr/bin/python3');
+  });
+
+  it('saves recentRemoteURLs with ISO date strings', () => {
+    appData.recentRemoteURLs = [
+      { url: 'https://example.com', date: new Date('2024-06-01') }
+    ];
+    appData.save();
+    const content = (mockFs.writeFileSync as any).mock.calls[0][1] as string;
+    const json = JSON.parse(content);
+    expect(json.recentRemoteURLs).toHaveLength(1);
+    expect(json.recentRemoteURLs[0].url).toBe('https://example.com');
+    expect(typeof json.recentRemoteURLs[0].date).toBe('string');
+  });
+});
+
+describe('ApplicationData.addRemoteURLToRecents', () => {
+  beforeEach(() => {
+    appData.recentRemoteURLs = [];
+  });
+
+  it('adds a new URL', () => {
+    appData.addRemoteURLToRecents('https://example.com');
+    expect(appData.recentRemoteURLs).toHaveLength(1);
+    expect(appData.recentRemoteURLs[0].url).toBe('https://example.com');
+  });
+
+  it('new entry gets a date close to now', () => {
+    const before = Date.now();
+    appData.addRemoteURLToRecents('https://example.com');
+    expect(appData.recentRemoteURLs[0].date.valueOf()).toBeGreaterThanOrEqual(before);
+  });
+
+  it('updates date of existing URL without duplicating', () => {
+    const oldDate = new Date(Date.now() - 5000);
+    appData.recentRemoteURLs = [{ url: 'https://example.com', date: oldDate }];
+    appData.addRemoteURLToRecents('https://example.com');
+    expect(appData.recentRemoteURLs).toHaveLength(1);
+    expect(appData.recentRemoteURLs[0].date.valueOf()).toBeGreaterThan(
+      oldDate.valueOf()
+    );
+  });
+
+  it('treats different URLs as separate entries', () => {
+    appData.addRemoteURLToRecents('https://a.com');
+    appData.addRemoteURLToRecents('https://b.com');
+    expect(appData.recentRemoteURLs).toHaveLength(2);
+  });
+});
+
+describe('ApplicationData.removeRemoteURLFromRecents', () => {
+  beforeEach(() => {
+    appData.recentRemoteURLs = [
+      { url: 'https://a.com', date: new Date() },
+      { url: 'https://b.com', date: new Date() }
+    ];
+  });
+
+  it('removes the matching URL', () => {
+    appData.removeRemoteURLFromRecents('https://a.com');
+    expect(appData.recentRemoteURLs).toHaveLength(1);
+    expect(appData.recentRemoteURLs[0].url).toBe('https://b.com');
+  });
+
+  it('no-ops when URL is not in list', () => {
+    appData.removeRemoteURLFromRecents('https://missing.com');
+    expect(appData.recentRemoteURLs).toHaveLength(2);
+  });
+});
+
+describe('ApplicationData.addSessionToRecents', () => {
+  beforeEach(() => {
+    appData.recentSessions = [];
+  });
+
+  it('adds a new local session', async () => {
+    await appData.addSessionToRecents({
+      workingDirectory: '/data/nb',
+      filesToOpen: []
+    });
+    expect(appData.recentSessions).toHaveLength(1);
+    expect(appData.recentSessions[0].workingDirectory).toBe('/data/nb');
+  });
+
+  it('adds a new remote session', async () => {
+    await appData.addSessionToRecents({
+      remoteURL: 'https://hub.example.com',
+      filesToOpen: []
+    });
+    expect(appData.recentSessions).toHaveLength(1);
+    expect(appData.recentSessions[0].remoteURL).toBe('https://hub.example.com');
+  });
+
+  it('updates date of duplicate local session without duplicating', async () => {
+    const oldDate = new Date(Date.now() - 5000);
+    appData.recentSessions = [
+      {
+        workingDirectory: '/data/nb',
+        filesToOpen: [],
+        date: oldDate
+      }
+    ];
+    await appData.addSessionToRecents({
+      workingDirectory: '/data/nb',
+      filesToOpen: []
+    });
+    expect(appData.recentSessions).toHaveLength(1);
+    expect(appData.recentSessions[0].date.valueOf()).toBeGreaterThan(
+      oldDate.valueOf()
+    );
+  });
+
+  it('re-adding existing session updates date without duplicating', async () => {
+    await appData.addSessionToRecents({ workingDirectory: '/a', filesToOpen: [] });
+    const before = appData.recentSessions[0].date.valueOf();
+    // small delay so new Date() advances
+    await new Promise(r => setTimeout(r, 5));
+    await appData.addSessionToRecents({ workingDirectory: '/a', filesToOpen: [] });
+    expect(appData.recentSessions).toHaveLength(1);
+    expect(appData.recentSessions[0].date.valueOf()).toBeGreaterThanOrEqual(before);
+  });
+});
+
+describe('ApplicationData.removeSessionFromRecents', () => {
+  beforeEach(() => {
+    appData.recentSessions = [
+      { workingDirectory: '/a', filesToOpen: [], date: new Date() },
+      { workingDirectory: '/b', filesToOpen: [], date: new Date() }
+    ];
+  });
+
+  it('removes session at given index', async () => {
+    await appData.removeSessionFromRecents(0);
+    expect(appData.recentSessions).toHaveLength(1);
+    expect(appData.recentSessions[0].workingDirectory).toBe('/b');
+  });
+
+  it('no-ops for out-of-bounds index', async () => {
+    await appData.removeSessionFromRecents(99);
+    expect(appData.recentSessions).toHaveLength(2);
+  });
+
+  it('no-ops for negative index', async () => {
+    await appData.removeSessionFromRecents(-1);
+    expect(appData.recentSessions).toHaveLength(2);
+  });
+});

--- a/test/unit/cli-handlers.test.ts
+++ b/test/unit/cli-handlers.test.ts
@@ -1,0 +1,320 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: vi.fn(() => false),
+    writeFileSync: vi.fn(),
+    readFileSync: vi.fn(() => '{}'),
+    mkdirSync: vi.fn()
+  };
+});
+vi.mock('child_process', async () => {
+  const actual = await vi.importActual<typeof import('child_process')>(
+    'child_process'
+  );
+  return { ...actual, execFileSync: vi.fn(), spawn: vi.fn() };
+});
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => '/tmp/jlab-test'),
+    getVersion: vi.fn(() => '1.0.0'),
+    getName: vi.fn(() => 'JupyterLab')
+  },
+  shell: { openPath: vi.fn() }
+}));
+vi.mock('../../../src/main/config/appdata', () => ({
+  appData: {
+    userSetPythonEnvs: [],
+    save: vi.fn()
+  },
+  ApplicationData: { getSingleton: vi.fn() }
+}));
+vi.mock('../../../src/main/config/settings', () => ({
+  userSettings: {
+    getValue: vi.fn(() => ''),
+    setValue: vi.fn(),
+    save: vi.fn()
+  },
+  SettingType: {
+    pythonPath: 'pythonPath',
+    pythonEnvsPath: 'pythonEnvsPath',
+    condaPath: 'condaPath',
+    condaChannels: 'condaChannels',
+    systemPythonPath: 'systemPythonPath'
+  },
+  UserSettings: vi.fn(),
+  WorkspaceSettings: vi.fn()
+}));
+vi.mock('../../../src/main/utils', () => ({
+  getBundledPythonPath: vi.fn(() => '/bundled/python'),
+  getBundledPythonEnvPath: vi.fn(() => '/bundled/env'),
+  getBundledEnvInstallerPath: vi.fn(() => '/bundled/installer'),
+  getLogFilePath: vi.fn(() => '/tmp/jlab.log'),
+  pythonPathForEnvPath: vi.fn((envPath: string) => `${envPath}/bin/python`),
+  envPathForPythonPath: vi.fn((pythonPath: string) =>
+    pythonPath.replace('/bin/python', '')
+  ),
+  createCommandScriptInEnv: vi.fn(),
+  createTempFile: vi.fn(),
+  installCondaPackEnvironment: vi.fn(),
+  isBaseCondaEnv: vi.fn(() => false),
+  isEnvInstalledByDesktopApp: vi.fn(() => false),
+  markEnvironmentAsJupyterInstalled: vi.fn(),
+  EnvironmentInstallStatus: {
+    RemovingExistingInstallation: 'RemovingExistingInstallation',
+    Started: 'Started',
+    Cancelled: 'Cancelled',
+    Failure: 'Failure',
+    Success: 'Success'
+  }
+}));
+vi.mock('../../../src/main/env', () => ({
+  validateCondaPath: vi.fn(async () => ({ valid: true })),
+  validateSystemPythonPath: vi.fn(async () => ({ valid: true })),
+  validatePythonEnvironmentInstallDirectory: vi.fn(() => ({
+    valid: true,
+    message: ''
+  })),
+  getPythonEnvsDirectory: vi.fn(() => '/home/user/.jlab/envs'),
+  getCondaPath: vi.fn(() => ''),
+  getCondaChannels: vi.fn(() => []),
+  getSystemPythonPath: vi.fn(() => ''),
+  condaEnvPathForCondaExePath: vi.fn((p: string) => p),
+  runCommandInEnvironment: vi.fn(),
+  ICommandRunCallbacks: {}
+}));
+vi.mock('../../../src/main/registry', () => ({ Registry: vi.fn() }));
+
+import {
+  addUserSetEnvironment,
+  handleEnvSetCondaChannelsCommand,
+  handleEnvSetCondaPathCommand,
+  handleEnvSetPythonEnvsPathCommand,
+  handleEnvSetSystemPythonPathCommand
+} from '../../../src/main/cli';
+import { appData } from '../../../src/main/config/appdata';
+import { userSettings } from '../../../src/main/config/settings';
+import * as envModule from '../../../src/main/env';
+
+const mockFs = vi.mocked(fs);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (appData as any).userSetPythonEnvs = [];
+  (appData as any).save = vi.fn();
+  mockFs.existsSync = vi.fn(() => false);
+  (userSettings as any).getValue = vi.fn(() => '');
+  (userSettings as any).setValue = vi.fn();
+  (userSettings as any).save = vi.fn();
+  vi.spyOn(envModule, 'validateCondaPath').mockResolvedValue({ valid: true });
+  vi.spyOn(envModule, 'validateSystemPythonPath').mockResolvedValue({
+    valid: true
+  });
+  vi.spyOn(
+    envModule,
+    'validatePythonEnvironmentInstallDirectory'
+  ).mockReturnValue({ valid: true, message: '' });
+});
+
+// ─── addUserSetEnvironment ────────────────────────────────────────────────────
+
+describe('addUserSetEnvironment', () => {
+  it('pushes venv entry to appData.userSetPythonEnvs and saves', () => {
+    addUserSetEnvironment('/home/user/myenv', false);
+    expect(appData.userSetPythonEnvs).toHaveLength(1);
+    expect(appData.userSetPythonEnvs[0].name).toContain('venv');
+    expect(appData.save).toHaveBeenCalledOnce();
+  });
+
+  it('pushes conda entry when isConda=true', () => {
+    addUserSetEnvironment('/home/user/myconda', true);
+    expect(appData.userSetPythonEnvs[0].name).toContain('conda');
+  });
+
+  it('sets userSettings pythonPath when none configured and env python exists', () => {
+    (userSettings as any).getValue = vi.fn(() => '');
+    // true only for paths under the env dir; bundled python path won't match regardless of mock
+    mockFs.existsSync = vi.fn((p: fs.PathLike) =>
+      p.toString().startsWith('/home/user/myenv')
+    );
+    addUserSetEnvironment('/home/user/myenv', false);
+    expect(userSettings.setValue).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining('/home/user/myenv')
+    );
+    expect(userSettings.save).toHaveBeenCalledOnce();
+  });
+
+  it('does not override existing pythonPath', () => {
+    (userSettings as any).getValue = vi.fn(() => '/existing/python');
+    addUserSetEnvironment('/home/user/myenv', false);
+    expect(userSettings.setValue).not.toHaveBeenCalled();
+  });
+});
+
+// ─── handleEnvSetPythonEnvsPathCommand ───────────────────────────────────────
+
+describe('handleEnvSetPythonEnvsPathCommand', () => {
+  it('sets pythonEnvsPath when dir is valid', async () => {
+    vi.spyOn(
+      envModule,
+      'validatePythonEnvironmentInstallDirectory'
+    ).mockReturnValue({ valid: true, message: '' });
+    await handleEnvSetPythonEnvsPathCommand({
+      _: ['set-envs-path', '/my/envs']
+    });
+    expect(userSettings.setValue).toHaveBeenCalledWith(
+      expect.any(String),
+      '/my/envs'
+    );
+    expect(userSettings.save).toHaveBeenCalledOnce();
+  });
+
+  it('logs error and skips save when no path provided', async () => {
+    const spy = vi.spyOn(console, 'error').mockReturnValue(undefined);
+    await handleEnvSetPythonEnvsPathCommand({ _: ['set-envs-path'] });
+    expect(spy).toHaveBeenCalled();
+    expect(userSettings.setValue).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('logs error and skips save when path is invalid', async () => {
+    vi.spyOn(
+      envModule,
+      'validatePythonEnvironmentInstallDirectory'
+    ).mockReturnValue({
+      valid: false,
+      message: 'not a directory'
+    });
+    const spy = vi.spyOn(console, 'error').mockReturnValue(undefined);
+    await handleEnvSetPythonEnvsPathCommand({
+      _: ['set-envs-path', '/bad/path']
+    });
+    expect(spy).toHaveBeenCalledWith('not a directory');
+    expect(userSettings.setValue).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+
+// ─── handleEnvSetCondaChannelsCommand ────────────────────────────────────────
+
+describe('handleEnvSetCondaChannelsCommand', () => {
+  it('sets conda channels from argv slice', async () => {
+    await handleEnvSetCondaChannelsCommand({
+      _: ['set-conda-channels', 'conda-forge', 'defaults']
+    });
+    expect(userSettings.setValue).toHaveBeenCalledWith(expect.any(String), [
+      'conda-forge',
+      'defaults'
+    ]);
+    expect(userSettings.save).toHaveBeenCalledOnce();
+  });
+
+  it('sets empty array when no channels given', async () => {
+    await handleEnvSetCondaChannelsCommand({ _: ['set-conda-channels'] });
+    expect(userSettings.setValue).toHaveBeenCalledWith(expect.any(String), []);
+  });
+});
+
+// ─── handleEnvSetSystemPythonPathCommand ─────────────────────────────────────
+
+describe('handleEnvSetSystemPythonPathCommand', () => {
+  it('sets systemPythonPath when path is valid', async () => {
+    mockFs.existsSync = vi.fn(() => true);
+    vi.spyOn(envModule, 'validateSystemPythonPath').mockResolvedValue({
+      valid: true
+    });
+    await handleEnvSetSystemPythonPathCommand({
+      _: ['set-sys-python', '/usr/bin/python3']
+    });
+    expect(userSettings.setValue).toHaveBeenCalledWith(
+      expect.any(String),
+      '/usr/bin/python3'
+    );
+    expect(userSettings.save).toHaveBeenCalledOnce();
+  });
+
+  it('logs error when path does not exist', async () => {
+    mockFs.existsSync = vi.fn(() => false);
+    const spy = vi.spyOn(console, 'error').mockReturnValue(undefined);
+    await handleEnvSetSystemPythonPathCommand({
+      _: ['set-sys-python', '/no/python']
+    });
+    expect(spy).toHaveBeenCalled();
+    expect(userSettings.setValue).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('logs error when path fails validation', async () => {
+    mockFs.existsSync = vi.fn(() => true);
+    vi.spyOn(envModule, 'validateSystemPythonPath').mockResolvedValue({
+      valid: false,
+      message: 'not python'
+    });
+    const spy = vi.spyOn(console, 'error').mockReturnValue(undefined);
+    await handleEnvSetSystemPythonPathCommand({
+      _: ['set-sys-python', '/bad/python']
+    });
+    expect(spy).toHaveBeenCalled();
+    expect(userSettings.setValue).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('logs error when no path argument given', async () => {
+    const spy = vi.spyOn(console, 'error').mockReturnValue(undefined);
+    await handleEnvSetSystemPythonPathCommand({ _: ['set-sys-python'] });
+    expect(spy).toHaveBeenCalled();
+    expect(userSettings.setValue).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+
+// ─── handleEnvSetCondaPathCommand ────────────────────────────────────────────
+
+describe('handleEnvSetCondaPathCommand', () => {
+  it('sets condaPath when path exists and is valid', async () => {
+    mockFs.existsSync = vi.fn(() => true);
+    vi.spyOn(envModule, 'validateCondaPath').mockResolvedValue({ valid: true });
+    await handleEnvSetCondaPathCommand({
+      _: ['set-conda-path', '/usr/bin/conda']
+    });
+    expect(userSettings.setValue).toHaveBeenCalledWith(
+      expect.any(String),
+      '/usr/bin/conda'
+    );
+    expect(userSettings.save).toHaveBeenCalledOnce();
+  });
+
+  it('logs error when path does not exist', async () => {
+    mockFs.existsSync = vi.fn(() => false);
+    const spy = vi.spyOn(console, 'error').mockReturnValue(undefined);
+    await handleEnvSetCondaPathCommand({ _: ['set-conda-path', '/no/conda'] });
+    expect(spy).toHaveBeenCalled();
+    expect(userSettings.setValue).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('logs error when conda path fails validation', async () => {
+    mockFs.existsSync = vi.fn(() => true);
+    vi.spyOn(envModule, 'validateCondaPath').mockResolvedValue({
+      valid: false,
+      message: 'not conda'
+    });
+    const spy = vi.spyOn(console, 'error').mockReturnValue(undefined);
+    await handleEnvSetCondaPathCommand({ _: ['set-conda-path', '/bad/conda'] });
+    expect(spy).toHaveBeenCalled();
+    expect(userSettings.setValue).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('logs error when no path argument given', async () => {
+    const spy = vi.spyOn(console, 'error').mockReturnValue(undefined);
+    await handleEnvSetCondaPathCommand({ _: ['set-conda-path'] });
+    expect(spy).toHaveBeenCalled();
+    expect(userSettings.setValue).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+
+vi.mock('../../../src/main/config/settings', () => ({
+  userSettings: { getValue: vi.fn(() => null), setValue: vi.fn() },
+  SettingType: { condaPath: 'condaPath', pythonPath: 'pythonPath' }
+}));
+vi.mock('../../../src/main/config/appdata', () => ({
+  appData: { discoveredPythonPaths: [], userSetPythonEnvs: [] }
+}));
+vi.mock('../../../src/main/registry', () => ({
+  appRegistry: { getDefaultEnvironment: vi.fn() }
+}));
+vi.mock('../../../src/main/env', () => ({
+  updateDiscoveredPythonPaths: vi.fn(() => Promise.resolve()),
+  getCondaPath: vi.fn(() => null),
+  getPythonEnvsDirectory: vi.fn(() => '/tmp/envs')
+}));
+vi.mock('../../../src/main/utils', async () => {
+  const actual = await vi.importActual('../../../src/main/utils');
+  return {
+    ...actual,
+    getUserDataDir: vi.fn(() => '/tmp/test-userdata'),
+    getUserHomeDir: vi.fn(() => '/tmp/home'),
+    getAppDir: vi.fn(() => '/tmp/app')
+  };
+});
+
+import { parseCLIArgs } from '../../../src/main/cli';
+
+let exitSpy: ReturnType<typeof vi.spyOn>;
+
+beforeAll(() => {
+  exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+});
+afterAll(() => {
+  exitSpy.mockRestore();
+});
+
+async function parse(args: string[]) {
+  return parseCLIArgs(args);
+}
+
+describe('parseCLIArgs', () => {
+  it('parses --python-path', async () => {
+    const result = await parse(['--python-path', '/usr/bin/python3']);
+    expect(result['python-path']).toBe('/usr/bin/python3');
+  });
+
+  it('parses --working-dir', async () => {
+    const result = await parse(['--working-dir', '/home/user/notebooks']);
+    expect(result['working-dir']).toBe('/home/user/notebooks');
+  });
+
+  it('parses --log-level debug', async () => {
+    const result = await parse(['--log-level', 'debug']);
+    expect(result['log-level']).toBe('debug');
+  });
+
+  it('defaults log-level to warn', async () => {
+    const result = await parse([]);
+    expect(result['log-level']).toBe('warn');
+  });
+
+  it('defaults persist-session-data to true', async () => {
+    const result = await parse([]);
+    expect(result['persist-session-data']).toBe(true);
+  });
+
+  it('parses --no-persist-session-data', async () => {
+    const result = await parse(['--no-persist-session-data']);
+    expect(result['persist-session-data']).toBe(false);
+  });
+
+  it('parses positional file path', async () => {
+    const result = await parse(['/data/test.ipynb']);
+    expect(result._).toContain('/data/test.ipynb');
+  });
+
+  it('parses multiple positional paths', async () => {
+    const result = await parse(['/a.ipynb', '/b.ipynb']);
+    expect(result._).toContain('/a.ipynb');
+    expect(result._).toContain('/b.ipynb');
+  });
+
+  it('parses env subcommand', async () => {
+    const result = await parse(['env', 'list']);
+    expect(result._[0]).toBe('env');
+  });
+
+  it('invalid log-level calls process.exit', async () => {
+    await parse(['--log-level', 'invalid']);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/test/unit/env.test.ts
+++ b/test/unit/env.test.ts
@@ -6,8 +6,13 @@ vi.mock('fs', async () => {
   return {
     ...actual,
     existsSync: vi.fn(),
-    lstatSync: vi.fn()
+    lstatSync: vi.fn(),
+    statSync: vi.fn()
   };
+});
+vi.mock('child_process', async () => {
+  const actual = await vi.importActual<typeof import('child_process')>('child_process');
+  return { ...actual, execFileSync: vi.fn(), spawn: vi.fn() };
 });
 vi.mock('../../../src/main/config/settings', () => ({
   userSettings: {
@@ -37,10 +42,12 @@ import {
   getSystemPythonPath,
   condaExePathForEnvPath,
   condaEnvPathForCondaExePath,
-  getNextPythonEnvName
+  getNextPythonEnvName,
+  validatePythonPath
 } from '../../../src/main/env';
 import { appData } from '../../../src/main/config/appdata';
 import { userSettings } from '../../../src/main/config/settings';
+import * as childProcess from 'child_process';
 
 const mockFs = vi.mocked(fs);
 
@@ -293,5 +300,62 @@ describe('getNextPythonEnvName', () => {
     });
     const name = getNextPythonEnvName();
     expect(name).toMatch(/^env_[2-9]\d*$/);
+  });
+});
+
+describe('validatePythonPath', () => {
+  const mockExecFileSync = vi.mocked(childProcess.execFileSync);
+
+  beforeEach(() => {
+    mockFs.existsSync = vi.fn(() => false);
+    mockFs.lstatSync = vi.fn(() => ({ isFile: () => false, isSymbolicLink: () => false } as fs.Stats));
+    mockExecFileSync.mockReset();
+  });
+
+  it('returns invalid when path does not exist', async () => {
+    mockFs.existsSync = vi.fn(() => false);
+    const result = await validatePythonPath('/nonexistent/python');
+    expect(result.valid).toBe(false);
+    expect(result.message).toMatch(/does not exist/i);
+  });
+
+  it('returns invalid when path is not a file or symlink', async () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.lstatSync = vi.fn(() => ({ isFile: () => false, isSymbolicLink: () => false } as fs.Stats));
+    const result = await validatePythonPath('/some/dir');
+    expect(result.valid).toBe(false);
+    expect(result.message).toMatch(/not a valid file/i);
+  });
+
+  it('returns valid when file exists and execFileSync returns Python version', async () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.lstatSync = vi.fn(() => ({ isFile: () => true, isSymbolicLink: () => false } as fs.Stats));
+    mockExecFileSync.mockReturnValue(Buffer.from('Python 3.11.0\n'));
+    const result = await validatePythonPath('/usr/bin/python3');
+    expect(result.valid).toBe(true);
+  });
+
+  it('returns invalid when execFileSync does not return Python version string', async () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.lstatSync = vi.fn(() => ({ isFile: () => true, isSymbolicLink: () => false } as fs.Stats));
+    mockExecFileSync.mockReturnValue(Buffer.from('not a python binary\n'));
+    const result = await validatePythonPath('/usr/bin/ruby');
+    expect(result.valid).toBe(false);
+  });
+
+  it('returns invalid when execFileSync throws', async () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.lstatSync = vi.fn(() => ({ isFile: () => true, isSymbolicLink: () => false } as fs.Stats));
+    mockExecFileSync.mockImplementation(() => { throw new Error('spawn error'); });
+    const result = await validatePythonPath('/bad/python');
+    expect(result.valid).toBe(false);
+  });
+
+  it('accepts symlinks as valid path type', async () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.lstatSync = vi.fn(() => ({ isFile: () => false, isSymbolicLink: () => true } as fs.Stats));
+    mockExecFileSync.mockReturnValue(Buffer.from('Python 3.10.0\n'));
+    const result = await validatePythonPath('/usr/local/bin/python');
+    expect(result.valid).toBe(true);
   });
 });

--- a/test/unit/env.test.ts
+++ b/test/unit/env.test.ts
@@ -31,8 +31,16 @@ import {
   validateNewPythonEnvironmentName,
   validatePythonEnvironmentInstallDirectory,
   environmentSatisfiesRequirements,
-  validateCondaChannels
+  validateCondaChannels,
+  getCondaPath,
+  getCondaChannels,
+  getSystemPythonPath,
+  condaExePathForEnvPath,
+  condaEnvPathForCondaExePath,
+  getNextPythonEnvName
 } from '../../../src/main/env';
+import { appData } from '../../../src/main/config/appdata';
+import { userSettings } from '../../../src/main/config/settings';
 
 const mockFs = vi.mocked(fs);
 
@@ -149,5 +157,141 @@ describe('validateCondaChannels', () => {
   it('returns invalid for channels with special chars', () => {
     const result = validateCondaChannels('conda-forge; rm -rf /');
     expect(result.valid).toBe(false);
+  });
+});
+
+describe('condaExePathForEnvPath', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('returns bin/conda on posix', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    expect(condaExePathForEnvPath('/env')).toBe('/env/bin/conda');
+  });
+
+  it('returns Scripts/conda.exe on windows', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    expect(condaExePathForEnvPath('/env')).toContain('conda.exe');
+    expect(condaExePathForEnvPath('/env')).toContain('Scripts');
+  });
+});
+
+describe('condaEnvPathForCondaExePath', () => {
+  it('resolves parent directory of bin/conda', () => {
+    const result = condaEnvPathForCondaExePath('/opt/conda/bin/conda');
+    expect(result).toBe('/opt/conda');
+  });
+
+  it('resolves parent directory of Scripts/conda.exe', () => {
+    const result = condaEnvPathForCondaExePath('/opt/conda/Scripts/conda.exe');
+    expect(result).toBe('/opt/conda');
+  });
+});
+
+describe('getCondaChannels', () => {
+  beforeEach(() => {
+    (userSettings as any).getValue = vi.fn(() => null);
+  });
+
+  it('returns default conda-forge when no user setting', () => {
+    expect(getCondaChannels()).toEqual(['conda-forge']);
+  });
+
+  it('returns user-configured channels when set', () => {
+    (userSettings as any).getValue = vi.fn(() => ['defaults', 'conda-forge']);
+    expect(getCondaChannels()).toEqual(['defaults', 'conda-forge']);
+  });
+
+  it('falls back to default when setting is not an array', () => {
+    (userSettings as any).getValue = vi.fn(() => 'conda-forge');
+    expect(getCondaChannels()).toEqual(['conda-forge']);
+  });
+});
+
+describe('getCondaPath', () => {
+  beforeEach(() => {
+    mockFs.existsSync = vi.fn(() => false);
+    (userSettings as any).getValue = vi.fn(() => null);
+    (appData as any).condaPath = null;
+  });
+
+  afterEach(() => {
+    delete process.env['CONDA_EXE'];
+  });
+
+  it('returns undefined when no conda found', () => {
+    expect(getCondaPath()).toBeUndefined();
+  });
+
+  it('returns user setting path when it exists', () => {
+    (userSettings as any).getValue = vi.fn(() => '/usr/local/conda');
+    mockFs.existsSync = vi.fn(() => true);
+    expect(getCondaPath()).toBe('/usr/local/conda');
+  });
+
+  it('falls through to appData.condaPath when user setting file missing', () => {
+    (userSettings as any).getValue = vi.fn(() => '/missing/conda');
+    (appData as any).condaPath = '/appdata/conda';
+    mockFs.existsSync = vi.fn((p: fs.PathLike) => p.toString() === '/appdata/conda');
+    expect(getCondaPath()).toBe('/appdata/conda');
+  });
+
+  it('uses CONDA_EXE env var as last resort', () => {
+    process.env['CONDA_EXE'] = '/env/conda';
+    mockFs.existsSync = vi.fn((p: fs.PathLike) => p.toString() === '/env/conda');
+    expect(getCondaPath()).toBe('/env/conda');
+  });
+});
+
+describe('getSystemPythonPath', () => {
+  beforeEach(() => {
+    mockFs.existsSync = vi.fn(() => false);
+    (userSettings as any).getValue = vi.fn(() => null);
+    (appData as any).systemPythonPath = null;
+  });
+
+  it('returns undefined when not configured', () => {
+    expect(getSystemPythonPath()).toBeUndefined();
+  });
+
+  it('returns user setting when file exists', () => {
+    (userSettings as any).getValue = vi.fn(() => '/usr/bin/python3');
+    mockFs.existsSync = vi.fn(() => true);
+    expect(getSystemPythonPath()).toBe('/usr/bin/python3');
+  });
+
+  it('falls through to appData.systemPythonPath', () => {
+    (userSettings as any).getValue = vi.fn(() => '/missing/python');
+    (appData as any).systemPythonPath = '/appdata/python3';
+    mockFs.existsSync = vi.fn((p: fs.PathLike) => p.toString() === '/appdata/python3');
+    expect(getSystemPythonPath()).toBe('/appdata/python3');
+  });
+});
+
+describe('getNextPythonEnvName', () => {
+  beforeEach(() => {
+    (userSettings as any).getValue = vi.fn(() => null);
+  });
+
+  it('returns env_1 when no environments exist', () => {
+    mockFs.existsSync = vi.fn(() => false);
+    const name = getNextPythonEnvName();
+    expect(name).toMatch(/^env_\d+$/);
+  });
+
+  it('increments index when env_1 already exists', () => {
+    let envCheckCount = 0;
+    mockFs.existsSync = vi.fn((p: fs.PathLike) => {
+      if (p.toString().includes('env_')) {
+        envCheckCount++;
+        return envCheckCount === 1; // env_1 exists, env_2 does not
+      }
+      return true; // other paths (install dir etc.) exist
+    });
+    const name = getNextPythonEnvName();
+    expect(name).toMatch(/^env_[2-9]\d*$/);
   });
 });

--- a/test/unit/env.test.ts
+++ b/test/unit/env.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as fs from 'fs';
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    lstatSync: vi.fn()
+  };
+});
+vi.mock('../../../src/main/config/settings', () => ({
+  userSettings: {
+    getValue: vi.fn(() => null),
+    setValue: vi.fn()
+  },
+  SettingType: {
+    condaPath: 'condaPath',
+    pythonPath: 'pythonPath',
+    envType: 'envType'
+  }
+}));
+vi.mock('../../../src/main/config/appdata', () => ({
+  appData: {
+    discoveredPythonPaths: [],
+    condaPath: null
+  }
+}));
+
+import {
+  validateNewPythonEnvironmentName,
+  validatePythonEnvironmentInstallDirectory,
+  environmentSatisfiesRequirements,
+  validateCondaChannels
+} from '../../../src/main/env';
+
+const mockFs = vi.mocked(fs);
+
+describe('validateNewPythonEnvironmentName', () => {
+  beforeEach(() => {
+    mockFs.existsSync = vi.fn(() => false);
+  });
+
+  it.each([
+    ['valid-name', true],
+    ['valid_name_123', true],
+    ['MyEnv', true],
+    ['', false],
+    ['   ', false],
+    ['name with spaces', false],
+    ['name/slash', false],
+    ['name.dot', false],
+    ['name@at', false]
+  ])('"%s" → valid: %s', (name, expected) => {
+    expect(validateNewPythonEnvironmentName(name).valid).toBe(expected);
+  });
+
+  it('returns invalid when directory already exists', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    const result = validateNewPythonEnvironmentName('existing-env');
+    expect(result.valid).toBe(false);
+    expect(result.message).toMatch(/already exists/i);
+  });
+});
+
+describe('validatePythonEnvironmentInstallDirectory', () => {
+  it('returns invalid for non-existent directory', () => {
+    mockFs.existsSync = vi.fn(() => false);
+    const result = validatePythonEnvironmentInstallDirectory('/nonexistent');
+    expect(result.valid).toBe(false);
+    expect(result.message).toMatch(/does not exist/i);
+  });
+
+  it('returns invalid for a file (not directory)', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.lstatSync = vi.fn(() => ({ isDirectory: () => false } as fs.Stats));
+    const result = validatePythonEnvironmentInstallDirectory('/some/file.txt');
+    expect(result.valid).toBe(false);
+    expect(result.message).toMatch(/not a directory/i);
+  });
+
+  it('returns valid for existing directory', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.lstatSync = vi.fn(() => ({ isDirectory: () => true } as fs.Stats));
+    const result = validatePythonEnvironmentInstallDirectory('/valid/dir');
+    expect(result.valid).toBe(true);
+  });
+
+  it('returns invalid on fs error', () => {
+    mockFs.existsSync = vi.fn(() => { throw new Error('permission denied'); });
+    const result = validatePythonEnvironmentInstallDirectory('/bad/path');
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe('environmentSatisfiesRequirements', () => {
+  it('returns true when jupyterlab version satisfies minimum', () => {
+    const env = {
+      name: 'test',
+      path: '/env',
+      versions: { jupyterlab: '4.4.7' }
+    } as any;
+    expect(environmentSatisfiesRequirements(env)).toBe(true);
+  });
+
+  it('returns false when jupyterlab version too old', () => {
+    const env = {
+      name: 'test',
+      path: '/env',
+      versions: { jupyterlab: '2.9.9' }
+    } as any;
+    expect(environmentSatisfiesRequirements(env)).toBe(false);
+  });
+
+  it('returns false when version missing', () => {
+    const env = {
+      name: 'test',
+      path: '/env',
+      versions: {}
+    } as any;
+    expect(environmentSatisfiesRequirements(env)).toBe(false);
+  });
+
+  it('uses custom requirements when provided', () => {
+    const env = { name: 'test', path: '/env', versions: { mylib: '2.0.0' } } as any;
+    const reqs = [
+      {
+        name: 'mylib',
+        moduleName: 'mylib',
+        commands: ['--version'],
+        versionRange: new (require('semver').Range)('^2.0.0'),
+        pipCommand: 'mylib',
+        condaCommand: 'mylib'
+      }
+    ];
+    expect(environmentSatisfiesRequirements(env, reqs)).toBe(true);
+  });
+});
+
+describe('validateCondaChannels', () => {
+  it('returns valid for standard channel string', () => {
+    expect(validateCondaChannels('conda-forge defaults').valid).toBe(true);
+  });
+
+  it('returns valid for empty string (no extra channels)', () => {
+    expect(validateCondaChannels('').valid).toBe(true);
+  });
+
+  it('returns invalid for channels with special chars', () => {
+    const result = validateCondaChannels('conda-forge; rm -rf /');
+    expect(result.valid).toBe(false);
+  });
+});

--- a/test/unit/env.test.ts
+++ b/test/unit/env.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'fs';
 
 vi.mock('fs', async () => {
@@ -11,7 +11,9 @@ vi.mock('fs', async () => {
   };
 });
 vi.mock('child_process', async () => {
-  const actual = await vi.importActual<typeof import('child_process')>('child_process');
+  const actual = await vi.importActual<typeof import('child_process')>(
+    'child_process'
+  );
   return { ...actual, execFileSync: vi.fn(), spawn: vi.fn() };
 });
 vi.mock('../../../src/main/config/settings', () => ({
@@ -33,20 +35,21 @@ vi.mock('../../../src/main/config/appdata', () => ({
 }));
 
 import {
+  condaEnvPathForCondaExePath,
+  condaExePathForEnvPath,
+  environmentSatisfiesRequirements,
+  getAdditionalPathIncludesForPythonPath,
+  getCondaChannels,
+  getCondaPath,
+  getNextPythonEnvName,
+  getPythonEnvsDirectory,
+  getSystemPythonPath,
+  validateCondaChannels,
+  validateCondaPath,
   validateNewPythonEnvironmentName,
   validatePythonEnvironmentInstallDirectory,
-  environmentSatisfiesRequirements,
-  validateCondaChannels,
-  getCondaPath,
-  getCondaChannels,
-  getSystemPythonPath,
-  condaExePathForEnvPath,
-  condaEnvPathForCondaExePath,
-  getNextPythonEnvName,
   validatePythonPath,
-  validateCondaPath,
-  validateSystemPythonPath,
-  getAdditionalPathIncludesForPythonPath
+  validateSystemPythonPath
 } from '../../../src/main/env';
 import { appData } from '../../../src/main/config/appdata';
 import { userSettings } from '../../../src/main/config/settings';
@@ -106,7 +109,9 @@ describe('validatePythonEnvironmentInstallDirectory', () => {
   });
 
   it('returns invalid on fs error', () => {
-    mockFs.existsSync = vi.fn(() => { throw new Error('permission denied'); });
+    mockFs.existsSync = vi.fn(() => {
+      throw new Error('permission denied');
+    });
     const result = validatePythonEnvironmentInstallDirectory('/bad/path');
     expect(result.valid).toBe(false);
   });
@@ -141,7 +146,11 @@ describe('environmentSatisfiesRequirements', () => {
   });
 
   it('uses custom requirements when provided', () => {
-    const env = { name: 'test', path: '/env', versions: { mylib: '2.0.0' } } as any;
+    const env = {
+      name: 'test',
+      path: '/env',
+      versions: { mylib: '2.0.0' }
+    } as any;
     const reqs = [
       {
         name: 'mylib',
@@ -246,13 +255,17 @@ describe('getCondaPath', () => {
   it('falls through to appData.condaPath when user setting file missing', () => {
     (userSettings as any).getValue = vi.fn(() => '/missing/conda');
     (appData as any).condaPath = '/appdata/conda';
-    mockFs.existsSync = vi.fn((p: fs.PathLike) => p.toString() === '/appdata/conda');
+    mockFs.existsSync = vi.fn(
+      (p: fs.PathLike) => p.toString() === '/appdata/conda'
+    );
     expect(getCondaPath()).toBe('/appdata/conda');
   });
 
   it('uses CONDA_EXE env var as last resort', () => {
     process.env['CONDA_EXE'] = '/env/conda';
-    mockFs.existsSync = vi.fn((p: fs.PathLike) => p.toString() === '/env/conda');
+    mockFs.existsSync = vi.fn(
+      (p: fs.PathLike) => p.toString() === '/env/conda'
+    );
     expect(getCondaPath()).toBe('/env/conda');
   });
 });
@@ -277,7 +290,9 @@ describe('getSystemPythonPath', () => {
   it('falls through to appData.systemPythonPath', () => {
     (userSettings as any).getValue = vi.fn(() => '/missing/python');
     (appData as any).systemPythonPath = '/appdata/python3';
-    mockFs.existsSync = vi.fn((p: fs.PathLike) => p.toString() === '/appdata/python3');
+    mockFs.existsSync = vi.fn(
+      (p: fs.PathLike) => p.toString() === '/appdata/python3'
+    );
     expect(getSystemPythonPath()).toBe('/appdata/python3');
   });
 });
@@ -310,7 +325,9 @@ describe('getNextPythonEnvName', () => {
 describe('validatePythonPath', () => {
   beforeEach(() => {
     mockFs.existsSync = vi.fn(() => false);
-    mockFs.lstatSync = vi.fn(() => ({ isFile: () => false, isSymbolicLink: () => false } as fs.Stats));
+    mockFs.lstatSync = vi.fn(
+      () => ({ isFile: () => false, isSymbolicLink: () => false } as fs.Stats)
+    );
     mockExecFileSync.mockReset();
   });
 
@@ -323,7 +340,9 @@ describe('validatePythonPath', () => {
 
   it('returns invalid when path is not a file or symlink', async () => {
     mockFs.existsSync = vi.fn(() => true);
-    mockFs.lstatSync = vi.fn(() => ({ isFile: () => false, isSymbolicLink: () => false } as fs.Stats));
+    mockFs.lstatSync = vi.fn(
+      () => ({ isFile: () => false, isSymbolicLink: () => false } as fs.Stats)
+    );
     const result = await validatePythonPath('/some/dir');
     expect(result.valid).toBe(false);
     expect(result.message).toMatch(/not a valid file/i);
@@ -331,7 +350,9 @@ describe('validatePythonPath', () => {
 
   it('returns valid when file exists and execFileSync returns Python version', async () => {
     mockFs.existsSync = vi.fn(() => true);
-    mockFs.lstatSync = vi.fn(() => ({ isFile: () => true, isSymbolicLink: () => false } as fs.Stats));
+    mockFs.lstatSync = vi.fn(
+      () => ({ isFile: () => true, isSymbolicLink: () => false } as fs.Stats)
+    );
     mockExecFileSync.mockReturnValue(Buffer.from('Python 3.11.0\n'));
     const result = await validatePythonPath('/usr/bin/python3');
     expect(result.valid).toBe(true);
@@ -339,7 +360,9 @@ describe('validatePythonPath', () => {
 
   it('returns invalid when execFileSync does not return Python version string', async () => {
     mockFs.existsSync = vi.fn(() => true);
-    mockFs.lstatSync = vi.fn(() => ({ isFile: () => true, isSymbolicLink: () => false } as fs.Stats));
+    mockFs.lstatSync = vi.fn(
+      () => ({ isFile: () => true, isSymbolicLink: () => false } as fs.Stats)
+    );
     mockExecFileSync.mockReturnValue(Buffer.from('not a python binary\n'));
     const result = await validatePythonPath('/usr/bin/ruby');
     expect(result.valid).toBe(false);
@@ -347,15 +370,21 @@ describe('validatePythonPath', () => {
 
   it('returns invalid when execFileSync throws', async () => {
     mockFs.existsSync = vi.fn(() => true);
-    mockFs.lstatSync = vi.fn(() => ({ isFile: () => true, isSymbolicLink: () => false } as fs.Stats));
-    mockExecFileSync.mockImplementation(() => { throw new Error('spawn error'); });
+    mockFs.lstatSync = vi.fn(
+      () => ({ isFile: () => true, isSymbolicLink: () => false } as fs.Stats)
+    );
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('spawn error');
+    });
     const result = await validatePythonPath('/bad/python');
     expect(result.valid).toBe(false);
   });
 
   it('accepts symlinks as valid path type', async () => {
     mockFs.existsSync = vi.fn(() => true);
-    mockFs.lstatSync = vi.fn(() => ({ isFile: () => false, isSymbolicLink: () => true } as fs.Stats));
+    mockFs.lstatSync = vi.fn(
+      () => ({ isFile: () => false, isSymbolicLink: () => true } as fs.Stats)
+    );
     mockExecFileSync.mockReturnValue(Buffer.from('Python 3.10.0\n'));
     const result = await validatePythonPath('/usr/local/bin/python');
     expect(result.valid).toBe(true);
@@ -365,7 +394,9 @@ describe('validatePythonPath', () => {
 describe('validateSystemPythonPath', () => {
   beforeEach(() => {
     mockFs.existsSync = vi.fn(() => false);
-    mockFs.lstatSync = vi.fn(() => ({ isFile: () => false, isSymbolicLink: () => false } as fs.Stats));
+    mockFs.lstatSync = vi.fn(
+      () => ({ isFile: () => false, isSymbolicLink: () => false } as fs.Stats)
+    );
     mockExecFileSync.mockReset();
   });
 
@@ -377,7 +408,9 @@ describe('validateSystemPythonPath', () => {
 
   it('returns invalid when path is not a file or symlink', async () => {
     mockFs.existsSync = vi.fn(() => true);
-    mockFs.lstatSync = vi.fn(() => ({ isFile: () => false, isSymbolicLink: () => false } as fs.Stats));
+    mockFs.lstatSync = vi.fn(
+      () => ({ isFile: () => false, isSymbolicLink: () => false } as fs.Stats)
+    );
     const result = await validateSystemPythonPath('/some/dir');
     expect(result.valid).toBe(false);
     expect(result.message).toMatch(/not a valid file/i);
@@ -385,7 +418,9 @@ describe('validateSystemPythonPath', () => {
 
   it('returns valid when execFileSync returns :valid:', async () => {
     mockFs.existsSync = vi.fn(() => true);
-    mockFs.lstatSync = vi.fn(() => ({ isFile: () => true, isSymbolicLink: () => false } as fs.Stats));
+    mockFs.lstatSync = vi.fn(
+      () => ({ isFile: () => true, isSymbolicLink: () => false } as fs.Stats)
+    );
     mockExecFileSync.mockReturnValue(Buffer.from(':valid:\n'));
     const result = await validateSystemPythonPath('/usr/bin/python3');
     expect(result.valid).toBe(true);
@@ -393,7 +428,9 @@ describe('validateSystemPythonPath', () => {
 
   it('returns invalid when execFileSync output is wrong', async () => {
     mockFs.existsSync = vi.fn(() => true);
-    mockFs.lstatSync = vi.fn(() => ({ isFile: () => true, isSymbolicLink: () => false } as fs.Stats));
+    mockFs.lstatSync = vi.fn(
+      () => ({ isFile: () => true, isSymbolicLink: () => false } as fs.Stats)
+    );
     mockExecFileSync.mockReturnValue(Buffer.from('not python\n'));
     const result = await validateSystemPythonPath('/usr/bin/ruby');
     expect(result.valid).toBe(false);
@@ -401,15 +438,21 @@ describe('validateSystemPythonPath', () => {
 
   it('returns invalid when execFileSync throws', async () => {
     mockFs.existsSync = vi.fn(() => true);
-    mockFs.lstatSync = vi.fn(() => ({ isFile: () => true, isSymbolicLink: () => false } as fs.Stats));
-    mockExecFileSync.mockImplementation(() => { throw new Error('spawn error'); });
+    mockFs.lstatSync = vi.fn(
+      () => ({ isFile: () => true, isSymbolicLink: () => false } as fs.Stats)
+    );
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('spawn error');
+    });
     const result = await validateSystemPythonPath('/bad/python');
     expect(result.valid).toBe(false);
   });
 
   it('accepts symlinks', async () => {
     mockFs.existsSync = vi.fn(() => true);
-    mockFs.lstatSync = vi.fn(() => ({ isFile: () => false, isSymbolicLink: () => true } as fs.Stats));
+    mockFs.lstatSync = vi.fn(
+      () => ({ isFile: () => false, isSymbolicLink: () => true } as fs.Stats)
+    );
     mockExecFileSync.mockReturnValue(Buffer.from(':valid:\n'));
     const result = await validateSystemPythonPath('/usr/local/bin/python');
     expect(result.valid).toBe(true);
@@ -473,7 +516,38 @@ describe('getAdditionalPathIncludesForPythonPath', () => {
 
   it('uses semicolon separator on windows', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
-    const result = getAdditionalPathIncludesForPythonPath('C:\\envs\\myenv\\python.exe');
+    const result = getAdditionalPathIncludesForPythonPath(
+      'C:\\envs\\myenv\\python.exe'
+    );
     expect(result).toContain(';');
+  });
+});
+
+describe('getPythonEnvsDirectory', () => {
+  beforeEach(() => {
+    mockFs.existsSync = vi.fn(() => false);
+    (userSettings as any).getValue = vi.fn(() => null);
+  });
+
+  it('returns default envs dir when no user setting', () => {
+    const result = getPythonEnvsDirectory();
+    expect(typeof result).toBe('string');
+    expect(result).toContain('envs');
+  });
+
+  it('returns user setting path when it exists', () => {
+    (userSettings as any).getValue = vi.fn(() => '/custom/envs');
+    mockFs.existsSync = vi.fn(
+      (p: fs.PathLike) => p.toString() === '/custom/envs'
+    );
+    expect(getPythonEnvsDirectory()).toBe('/custom/envs');
+  });
+
+  it('falls back to default when user setting path does not exist', () => {
+    (userSettings as any).getValue = vi.fn(() => '/missing/envs');
+    mockFs.existsSync = vi.fn(() => false);
+    const result = getPythonEnvsDirectory();
+    expect(result).not.toBe('/missing/envs');
+    expect(result).toContain('envs');
   });
 });

--- a/test/unit/env.test.ts
+++ b/test/unit/env.test.ts
@@ -43,13 +43,17 @@ import {
   condaExePathForEnvPath,
   condaEnvPathForCondaExePath,
   getNextPythonEnvName,
-  validatePythonPath
+  validatePythonPath,
+  validateCondaPath,
+  validateSystemPythonPath,
+  getAdditionalPathIncludesForPythonPath
 } from '../../../src/main/env';
 import { appData } from '../../../src/main/config/appdata';
 import { userSettings } from '../../../src/main/config/settings';
 import * as childProcess from 'child_process';
 
 const mockFs = vi.mocked(fs);
+const mockExecFileSync = vi.mocked(childProcess.execFileSync);
 
 describe('validateNewPythonEnvironmentName', () => {
   beforeEach(() => {
@@ -304,8 +308,6 @@ describe('getNextPythonEnvName', () => {
 });
 
 describe('validatePythonPath', () => {
-  const mockExecFileSync = vi.mocked(childProcess.execFileSync);
-
   beforeEach(() => {
     mockFs.existsSync = vi.fn(() => false);
     mockFs.lstatSync = vi.fn(() => ({ isFile: () => false, isSymbolicLink: () => false } as fs.Stats));
@@ -357,5 +359,121 @@ describe('validatePythonPath', () => {
     mockExecFileSync.mockReturnValue(Buffer.from('Python 3.10.0\n'));
     const result = await validatePythonPath('/usr/local/bin/python');
     expect(result.valid).toBe(true);
+  });
+});
+
+describe('validateSystemPythonPath', () => {
+  beforeEach(() => {
+    mockFs.existsSync = vi.fn(() => false);
+    mockFs.lstatSync = vi.fn(() => ({ isFile: () => false, isSymbolicLink: () => false } as fs.Stats));
+    mockExecFileSync.mockReset();
+  });
+
+  it('returns invalid when path does not exist', async () => {
+    const result = await validateSystemPythonPath('/nonexistent/python');
+    expect(result.valid).toBe(false);
+    expect(result.message).toMatch(/does not exist/i);
+  });
+
+  it('returns invalid when path is not a file or symlink', async () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.lstatSync = vi.fn(() => ({ isFile: () => false, isSymbolicLink: () => false } as fs.Stats));
+    const result = await validateSystemPythonPath('/some/dir');
+    expect(result.valid).toBe(false);
+    expect(result.message).toMatch(/not a valid file/i);
+  });
+
+  it('returns valid when execFileSync returns :valid:', async () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.lstatSync = vi.fn(() => ({ isFile: () => true, isSymbolicLink: () => false } as fs.Stats));
+    mockExecFileSync.mockReturnValue(Buffer.from(':valid:\n'));
+    const result = await validateSystemPythonPath('/usr/bin/python3');
+    expect(result.valid).toBe(true);
+  });
+
+  it('returns invalid when execFileSync output is wrong', async () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.lstatSync = vi.fn(() => ({ isFile: () => true, isSymbolicLink: () => false } as fs.Stats));
+    mockExecFileSync.mockReturnValue(Buffer.from('not python\n'));
+    const result = await validateSystemPythonPath('/usr/bin/ruby');
+    expect(result.valid).toBe(false);
+  });
+
+  it('returns invalid when execFileSync throws', async () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.lstatSync = vi.fn(() => ({ isFile: () => true, isSymbolicLink: () => false } as fs.Stats));
+    mockExecFileSync.mockImplementation(() => { throw new Error('spawn error'); });
+    const result = await validateSystemPythonPath('/bad/python');
+    expect(result.valid).toBe(false);
+  });
+
+  it('accepts symlinks', async () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.lstatSync = vi.fn(() => ({ isFile: () => false, isSymbolicLink: () => true } as fs.Stats));
+    mockExecFileSync.mockReturnValue(Buffer.from(':valid:\n'));
+    const result = await validateSystemPythonPath('/usr/local/bin/python');
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe('validateCondaPath', () => {
+  beforeEach(() => {
+    mockFs.existsSync = vi.fn(() => false);
+    mockFs.lstatSync = vi.fn(() => ({ isFile: () => false } as fs.Stats));
+  });
+
+  it('returns invalid when conda executable does not exist', async () => {
+    mockFs.existsSync = vi.fn(() => false);
+    const result = await validateCondaPath('/nonexistent/conda');
+    expect(result.valid).toBe(false);
+    expect(result.message).toMatch(/does not exist/i);
+  });
+
+  it('returns invalid when path is not a file', async () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.lstatSync = vi.fn(() => ({ isFile: () => false } as fs.Stats));
+    const result = await validateCondaPath('/some/directory');
+    expect(result.valid).toBe(false);
+    expect(result.message).toMatch(/not a valid file/i);
+  });
+
+  it('returns invalid when not in a base conda environment', async () => {
+    // existsSync: conda exe exists but conda-meta/condabin don't → not a base env
+    mockFs.existsSync = vi.fn((p: fs.PathLike) => {
+      return p.toString() === '/opt/miniconda/bin/conda';
+    });
+    mockFs.lstatSync = vi.fn(() => ({ isFile: () => true } as fs.Stats));
+    const result = await validateCondaPath('/opt/miniconda/bin/conda');
+    expect(result.valid).toBe(false);
+    expect(result.message).toMatch(/base conda/i);
+  });
+});
+
+describe('getAdditionalPathIncludesForPythonPath', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('returns a non-empty PATH string on posix', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    const result = getAdditionalPathIncludesForPythonPath('/env/bin/python');
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
+    expect(result).toContain('/env');
+  });
+
+  it('includes env bin path on posix', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    const result = getAdditionalPathIncludesForPythonPath('/myenv/bin/python');
+    // envPath = /myenv, pathEnv = /myenv:/myenv/bin:...
+    expect(result).toContain('/myenv');
+  });
+
+  it('uses semicolon separator on windows', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    const result = getAdditionalPathIncludesForPythonPath('C:\\envs\\myenv\\python.exe');
+    expect(result).toContain(';');
   });
 });

--- a/test/unit/eventmanager.test.ts
+++ b/test/unit/eventmanager.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ipcMain } from 'electron';
+import { EventManager } from '../../src/main/eventmanager';
+import { EventTypeMain } from '../../src/main/eventtypes';
+
+const mockIpcMain = vi.mocked(ipcMain);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('EventManager.registerEventHandler', () => {
+  it('calls ipcMain.on with the event type and handler', () => {
+    const mgr = new EventManager();
+    const handler = vi.fn();
+    mgr.registerEventHandler(EventTypeMain.OpenFile, handler);
+    expect(mockIpcMain.on).toHaveBeenCalledWith(EventTypeMain.OpenFile, handler);
+  });
+
+  it('registers multiple handlers for same event type', () => {
+    const mgr = new EventManager();
+    const h1 = vi.fn();
+    const h2 = vi.fn();
+    mgr.registerEventHandler(EventTypeMain.OpenFile, h1);
+    mgr.registerEventHandler(EventTypeMain.OpenFile, h2);
+    expect(mockIpcMain.on).toHaveBeenCalledTimes(2);
+    expect(mockIpcMain.on).toHaveBeenCalledWith(EventTypeMain.OpenFile, h1);
+    expect(mockIpcMain.on).toHaveBeenCalledWith(EventTypeMain.OpenFile, h2);
+  });
+
+  it('registers handlers for different event types independently', () => {
+    const mgr = new EventManager();
+    const h1 = vi.fn();
+    const h2 = vi.fn();
+    mgr.registerEventHandler(EventTypeMain.OpenFile, h1);
+    mgr.registerEventHandler(EventTypeMain.OpenFolder, h2);
+    expect(mockIpcMain.on).toHaveBeenCalledWith(EventTypeMain.OpenFile, h1);
+    expect(mockIpcMain.on).toHaveBeenCalledWith(EventTypeMain.OpenFolder, h2);
+  });
+});
+
+describe('EventManager.registerSyncEventHandler', () => {
+  it('calls ipcMain.handle with the event type and handler', () => {
+    const mgr = new EventManager();
+    const handler = vi.fn();
+    mgr.registerSyncEventHandler(EventTypeMain.IsDarkTheme, handler);
+    expect(mockIpcMain.handle).toHaveBeenCalledWith(EventTypeMain.IsDarkTheme, handler);
+  });
+
+  it('registers multiple sync handlers for same event', () => {
+    const mgr = new EventManager();
+    const h1 = vi.fn();
+    const h2 = vi.fn();
+    mgr.registerSyncEventHandler(EventTypeMain.IsDarkTheme, h1);
+    mgr.registerSyncEventHandler(EventTypeMain.IsDarkTheme, h2);
+    expect(mockIpcMain.handle).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('EventManager.unregisterEventHandler', () => {
+  it('calls ipcMain.removeListener and removes from internal map', () => {
+    const mgr = new EventManager();
+    const handler = vi.fn();
+    mgr.registerEventHandler(EventTypeMain.OpenFile, handler);
+    vi.clearAllMocks();
+    mgr.unregisterEventHandler(EventTypeMain.OpenFile, handler);
+    expect(mockIpcMain.removeListener).toHaveBeenCalledWith(EventTypeMain.OpenFile, handler);
+  });
+
+  it('no-ops when event type was never registered', () => {
+    const mgr = new EventManager();
+    const handler = vi.fn();
+    expect(() => mgr.unregisterEventHandler(EventTypeMain.OpenFile, handler)).not.toThrow();
+    expect(mockIpcMain.removeListener).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when handler is not in the list', () => {
+    const mgr = new EventManager();
+    const h1 = vi.fn();
+    const h2 = vi.fn();
+    mgr.registerEventHandler(EventTypeMain.OpenFile, h1);
+    vi.clearAllMocks();
+    mgr.unregisterEventHandler(EventTypeMain.OpenFile, h2);
+    expect(mockIpcMain.removeListener).not.toHaveBeenCalled();
+  });
+
+  it('only removes the specified handler, leaves others intact', () => {
+    const mgr = new EventManager();
+    const h1 = vi.fn();
+    const h2 = vi.fn();
+    mgr.registerEventHandler(EventTypeMain.OpenFile, h1);
+    mgr.registerEventHandler(EventTypeMain.OpenFile, h2);
+    vi.clearAllMocks();
+    mgr.unregisterEventHandler(EventTypeMain.OpenFile, h1);
+    expect(mockIpcMain.removeListener).toHaveBeenCalledTimes(1);
+    expect(mockIpcMain.removeListener).toHaveBeenCalledWith(EventTypeMain.OpenFile, h1);
+  });
+});
+
+describe('EventManager.unregisterSyncEventHandler', () => {
+  it('calls ipcMain.removeListener for sync handler', () => {
+    const mgr = new EventManager();
+    const handler = vi.fn();
+    mgr.registerSyncEventHandler(EventTypeMain.IsDarkTheme, handler);
+    vi.clearAllMocks();
+    mgr.unregisterSyncEventHandler(EventTypeMain.IsDarkTheme, handler);
+    expect(mockIpcMain.removeListener).toHaveBeenCalledWith(EventTypeMain.IsDarkTheme, handler);
+  });
+
+  it('no-ops when event type was never registered', () => {
+    const mgr = new EventManager();
+    expect(() => mgr.unregisterSyncEventHandler(EventTypeMain.IsDarkTheme, vi.fn())).not.toThrow();
+    expect(mockIpcMain.removeListener).not.toHaveBeenCalled();
+  });
+});
+
+describe('EventManager.unregisterAllEventHandlers', () => {
+  it('removes all async handlers and calls ipcMain.removeListener for each', () => {
+    const mgr = new EventManager();
+    const h1 = vi.fn();
+    const h2 = vi.fn();
+    mgr.registerEventHandler(EventTypeMain.OpenFile, h1);
+    mgr.registerEventHandler(EventTypeMain.OpenFolder, h2);
+    vi.clearAllMocks();
+    mgr.unregisterAllEventHandlers();
+    expect(mockIpcMain.removeListener).toHaveBeenCalledWith(EventTypeMain.OpenFile, h1);
+    expect(mockIpcMain.removeListener).toHaveBeenCalledWith(EventTypeMain.OpenFolder, h2);
+  });
+
+  it('no-ops when no handlers registered', () => {
+    const mgr = new EventManager();
+    expect(() => mgr.unregisterAllEventHandlers()).not.toThrow();
+    expect(mockIpcMain.removeListener).not.toHaveBeenCalled();
+  });
+});
+
+describe('EventManager.unregisterAllSyncEventHandlers', () => {
+  it('removes all sync handlers', () => {
+    const mgr = new EventManager();
+    const h1 = vi.fn();
+    const h2 = vi.fn();
+    mgr.registerSyncEventHandler(EventTypeMain.IsDarkTheme, h1);
+    mgr.registerSyncEventHandler(EventTypeMain.IsDarkTheme, h2);
+    vi.clearAllMocks();
+    mgr.unregisterAllSyncEventHandlers();
+    expect(mockIpcMain.removeListener).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('EventManager.dispose', () => {
+  it('removes all async and sync handlers and returns a resolved Promise', async () => {
+    const mgr = new EventManager();
+    const async1 = vi.fn();
+    const sync1 = vi.fn();
+    mgr.registerEventHandler(EventTypeMain.OpenFile, async1);
+    mgr.registerSyncEventHandler(EventTypeMain.IsDarkTheme, sync1);
+    vi.clearAllMocks();
+    await expect(mgr.dispose()).resolves.toBeUndefined();
+    expect(mockIpcMain.removeListener).toHaveBeenCalledWith(EventTypeMain.OpenFile, async1);
+    expect(mockIpcMain.removeListener).toHaveBeenCalledWith(EventTypeMain.IsDarkTheme, sync1);
+  });
+
+  it('is safe to call dispose twice', async () => {
+    const mgr = new EventManager();
+    mgr.registerEventHandler(EventTypeMain.OpenFile, vi.fn());
+    await mgr.dispose();
+    vi.clearAllMocks();
+    await expect(mgr.dispose()).resolves.toBeUndefined();
+    expect(mockIpcMain.removeListener).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/eventtypes.test.ts
+++ b/test/unit/eventtypes.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { EventTypeMain, EventTypeRenderer } from '../../src/main/eventtypes';
+
+// Spot-check critical IPC event strings — a typo here silently breaks the IPC channel
+
+describe('EventTypeMain — window controls', () => {
+  it('MinimizeWindow', () => expect(EventTypeMain.MinimizeWindow).toBe('minimize-window'));
+  it('MaximizeWindow', () => expect(EventTypeMain.MaximizeWindow).toBe('maximize-window'));
+  it('RestoreWindow', () => expect(EventTypeMain.RestoreWindow).toBe('restore-window'));
+  it('CloseWindow', () => expect(EventTypeMain.CloseWindow).toBe('close-window'));
+});
+
+describe('EventTypeMain — session management', () => {
+  it('CreateNewSession', () => expect(EventTypeMain.CreateNewSession).toBe('create-new-session'));
+  it('CreateNewRemoteSession', () => expect(EventTypeMain.CreateNewRemoteSession).toBe('create-new-remote-session'));
+  it('OpenRecentSession', () => expect(EventTypeMain.OpenRecentSession).toBe('open-recent-session'));
+  it('DeleteRecentSession', () => expect(EventTypeMain.DeleteRecentSession).toBe('delete-recent-session'));
+  it('OpenDroppedFiles', () => expect(EventTypeMain.OpenDroppedFiles).toBe('open-dropped-files'));
+  it('RestartSession', () => expect(EventTypeMain.RestartSession).toBe('restart-session'));
+  it('LabUIReady', () => expect(EventTypeMain.LabUIReady).toBe('lab-ui-ready'));
+});
+
+describe('EventTypeMain — python environment', () => {
+  it('ValidatePythonPath', () => expect(EventTypeMain.ValidatePythonPath).toBe('validate-python-path'));
+  it('SetDefaultPythonPath', () => expect(EventTypeMain.SetDefaultPythonPath).toBe('set-default-python-path'));
+  it('InstallBundledPythonEnv', () => expect(EventTypeMain.InstallBundledPythonEnv).toBe('install-bundled-python-env'));
+  it('UpdateBundledPythonEnv', () => expect(EventTypeMain.UpdateBundledPythonEnv).toBe('update-bundled-python-env'));
+  it('GetPythonEnvironmentList', () => expect(EventTypeMain.GetPythonEnvironmentList).toBe('get-python-environment-list'));
+  it('DeletePythonEnvironment', () => expect(EventTypeMain.DeletePythonEnvironment).toBe('delete-python-environment'));
+  it('CreateNewPythonEnvironment', () => expect(EventTypeMain.CreateNewPythonEnvironment).toBe('create-new-python-environment'));
+  it('ValidateNewPythonEnvironmentName', () => expect(EventTypeMain.ValidateNewPythonEnvironmentName).toBe('validate-new-env-name'));
+  it('ValidateCondaChannels', () => expect(EventTypeMain.ValidateCondaChannels).toBe('validate-conda-channels'));
+});
+
+describe('EventTypeMain — settings', () => {
+  it('SetTheme', () => expect(EventTypeMain.SetTheme).toBe('set-theme'));
+  it('SetLogLevel', () => expect(EventTypeMain.SetLogLevel).toBe('set-log-level'));
+  it('SetStartupMode', () => expect(EventTypeMain.SetStartupMode).toBe('set-startup-mode'));
+  it('SetCtrlWBehavior', () => expect(EventTypeMain.SetCtrlWBehavior).toBe('set-ctrl-w-behavior'));
+  it('SetSettings', () => expect(EventTypeMain.SetSettings).toBe('set-settings'));
+  it('ClearHistory', () => expect(EventTypeMain.ClearHistory).toBe('clear-history'));
+  it('CheckForUpdates', () => expect(EventTypeMain.CheckForUpdates).toBe('check-for-updates'));
+});
+
+describe('EventTypeMain — all values are non-empty strings', () => {
+  it('every event has a non-empty string value', () => {
+    for (const [key, val] of Object.entries(EventTypeMain)) {
+      expect(typeof val, `EventTypeMain.${key}`).toBe('string');
+      expect((val as string).length, `EventTypeMain.${key} is empty`).toBeGreaterThan(0);
+    }
+  });
+
+  it('no duplicate event values', () => {
+    const values = Object.values(EventTypeMain);
+    const unique = new Set(values);
+    expect(unique.size).toBe(values.length);
+  });
+});
+
+describe('EventTypeRenderer', () => {
+  it('WorkingDirectorySelected', () => expect(EventTypeRenderer.WorkingDirectorySelected).toBe('working-directory-selected'));
+  it('InstallPythonEnvStatus', () => expect(EventTypeRenderer.InstallPythonEnvStatus).toBe('install-python-env-status'));
+  it('ShowProgress', () => expect(EventTypeRenderer.ShowProgress).toBe('show-progress'));
+  it('SetCurrentPythonPath', () => expect(EventTypeRenderer.SetCurrentPythonPath).toBe('set-current-python-path'));
+  it('SetRunningServerList', () => expect(EventTypeRenderer.SetRunningServerList).toBe('set-running-server-list'));
+  it('SetTitle', () => expect(EventTypeRenderer.SetTitle).toBe('set-title'));
+  it('SetRecentSessionList', () => expect(EventTypeRenderer.SetRecentSessionList).toBe('set-recent-session-list'));
+  it('SetPythonEnvironmentList', () => expect(EventTypeRenderer.SetPythonEnvironmentList).toBe('set-python-environment-list'));
+
+  it('all values are non-empty strings', () => {
+    for (const [key, val] of Object.entries(EventTypeRenderer)) {
+      expect(typeof val, `EventTypeRenderer.${key}`).toBe('string');
+      expect((val as string).length, `EventTypeRenderer.${key} is empty`).toBeGreaterThan(0);
+    }
+  });
+
+  it('no duplicate event values', () => {
+    const values = Object.values(EventTypeRenderer);
+    const unique = new Set(values);
+    expect(unique.size).toBe(values.length);
+  });
+});

--- a/test/unit/sessionconfig.test.ts
+++ b/test/unit/sessionconfig.test.ts
@@ -1,0 +1,427 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as fs from 'fs';
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return { ...actual, existsSync: vi.fn(), lstatSync: vi.fn() };
+});
+vi.mock('../../../src/main/config/settings', () => ({
+  userSettings: {
+    getValue: vi.fn(() => ''),
+    resolvedWorkingDirectory: '/home/user'
+  },
+  SettingType: {
+    defaultWorkingDirectory: 'defaultWorkingDirectory',
+    pythonPath: 'pythonPath'
+  },
+  DEFAULT_WIN_WIDTH: 1024,
+  DEFAULT_WIN_HEIGHT: 768,
+  resolveWorkingDirectory: vi.fn((dir: string) => dir || '/home/user')
+}));
+vi.mock('../../../src/main/config/appdata', () => ({
+  appData: { recentSessions: [] }
+}));
+
+import { SessionConfig } from '../../../src/main/config/sessionconfig';
+
+const mockFs = vi.mocked(fs);
+
+describe('SessionConfig defaults', () => {
+  it('x and y default to 0', () => {
+    const s = new SessionConfig();
+    expect(s.x).toBe(0);
+    expect(s.y).toBe(0);
+  });
+
+  it('width and height default to 1024x768', () => {
+    const s = new SessionConfig();
+    expect(s.width).toBe(1024);
+    expect(s.height).toBe(768);
+  });
+
+  it('persistSessionData defaults to true', () => {
+    expect(new SessionConfig().persistSessionData).toBe(true);
+  });
+
+  it('filesToOpen defaults to empty array', () => {
+    expect(new SessionConfig().filesToOpen).toEqual([]);
+  });
+
+  it('remoteURL defaults to empty string', () => {
+    expect(new SessionConfig().remoteURL).toBe('');
+  });
+});
+
+describe('SessionConfig.isRemote', () => {
+  it('false when remoteURL is empty', () => {
+    expect(new SessionConfig().isRemote).toBe(false);
+  });
+
+  it('true when remoteURL is set', () => {
+    const s = new SessionConfig();
+    s.remoteURL = 'http://localhost:8888/lab';
+    expect(s.isRemote).toBe(true);
+  });
+});
+
+describe('SessionConfig.createLocal', () => {
+  it('returns a SessionConfig', () => {
+    expect(SessionConfig.createLocal()).toBeInstanceOf(SessionConfig);
+  });
+
+  it('sets workingDirectory from argument', () => {
+    const s = SessionConfig.createLocal('/data/notebooks');
+    expect(s.workingDirectory).toBe('/data/notebooks');
+  });
+
+  it('sets filesToOpen when files exist', () => {
+    mockFs.lstatSync = vi.fn(() => ({ isFile: () => true } as fs.Stats));
+    const s = SessionConfig.createLocal('/data', ['a.ipynb', 'b.ipynb']);
+    expect(s.filesToOpen).toEqual(['a.ipynb', 'b.ipynb']);
+  });
+
+  it('skips files that do not exist', () => {
+    mockFs.lstatSync = vi.fn(() => { throw new Error('ENOENT'); });
+    const s = SessionConfig.createLocal('/data', ['missing.ipynb']);
+    expect(s.filesToOpen).toEqual([]);
+  });
+
+  it('skips paths that are not files', () => {
+    mockFs.lstatSync = vi.fn(() => ({ isFile: () => false } as fs.Stats));
+    const s = SessionConfig.createLocal('/data', ['subdir']);
+    expect(s.filesToOpen).toEqual([]);
+  });
+
+  it('sets pythonPath when provided', () => {
+    const s = SessionConfig.createLocal('/data', undefined, '/usr/bin/python3');
+    expect(s.pythonPath).toBe('/usr/bin/python3');
+  });
+});
+
+describe('SessionConfig.createRemote', () => {
+  it('sets remoteURL', () => {
+    const s = SessionConfig.createRemote('http://localhost:8888/lab?token=abc', true, '');
+    expect(s.remoteURL).toBe('http://localhost:8888/lab?token=abc');
+    expect(s.isRemote).toBe(true);
+  });
+
+  it('extracts token from URL', () => {
+    const s = SessionConfig.createRemote('http://localhost:8888/lab?token=mysecret', true, '');
+    expect(s.token).toBe('mysecret');
+  });
+
+  it('persist partition when persistSessionData is true', () => {
+    const s = SessionConfig.createRemote('http://localhost:8888/lab?token=x', true, '');
+    expect(s.partition).toMatch(/^persist:/);
+  });
+
+  it('non-persist partition when persistSessionData is false', () => {
+    const s = SessionConfig.createRemote('http://localhost:8888/lab?token=x', false, '');
+    expect(s.partition).toMatch(/^partition:/);
+  });
+
+  it('uses provided partition instead of generating one', () => {
+    const s = SessionConfig.createRemote('http://localhost:8888/lab?token=x', true, 'persist:my-custom-id');
+    expect(s.partition).toBe('persist:my-custom-id');
+  });
+
+  it('sets persistSessionData to false correctly', () => {
+    const s = SessionConfig.createRemote('http://localhost:8888/lab?token=x', false, '');
+    expect(s.persistSessionData).toBe(false);
+  });
+
+  it('persistSessionData defaults to true when not false', () => {
+    const s = SessionConfig.createRemote('http://localhost:8888/lab?token=x', true, '');
+    expect(s.persistSessionData).toBe(true);
+  });
+});
+
+describe('SessionConfig.createLocalForFilesOrFolders', () => {
+  it('creates session in parent dir of first file', () => {
+    mockFs.lstatSync = vi.fn(() => ({ isFile: () => true, isDirectory: () => false } as fs.Stats));
+    const s = SessionConfig.createLocalForFilesOrFolders(['/data/nb/test.ipynb']);
+    expect(s.workingDirectory).toBe('/data/nb');
+  });
+
+  it('creates session at directory path', () => {
+    mockFs.lstatSync = vi.fn(() => ({ isFile: () => false, isDirectory: () => true } as fs.Stats));
+    const s = SessionConfig.createLocalForFilesOrFolders(['/data/notebooks']);
+    expect(s.workingDirectory).toBe('/data/notebooks');
+  });
+
+  it('returns undefined for empty array', () => {
+    const s = SessionConfig.createLocalForFilesOrFolders([]);
+    expect(s).toBeUndefined();
+  });
+
+  it('skips paths where lstatSync throws', () => {
+    mockFs.lstatSync = vi.fn(() => { throw new Error('ENOENT'); });
+    const s = SessionConfig.createLocalForFilesOrFolders(['/missing/path.ipynb']);
+    expect(s).toBeUndefined();
+  });
+
+  it('prefers files over folders when both given', () => {
+    let call = 0;
+    mockFs.lstatSync = vi.fn(() => {
+      call++;
+      if (call === 1) return { isFile: () => false, isDirectory: () => true } as fs.Stats; // folder first
+      return { isFile: () => true, isDirectory: () => false } as fs.Stats; // then file
+    });
+    const s = SessionConfig.createLocalForFilesOrFolders(['/some/folder', '/some/folder/note.ipynb']);
+    // files take precedence: working dir should be parent of the file
+    expect(s.workingDirectory).toBe('/some/folder');
+  });
+});
+
+describe('SessionConfig.createFromArgs', () => {
+  beforeEach(() => {
+    mockFs.existsSync = vi.fn(() => false);
+    mockFs.lstatSync = vi.fn(() => { throw new Error('ENOENT'); });
+  });
+
+  it('returns undefined when no args', () => {
+    const result = SessionConfig.createFromArgs({ _: [], $0: '', cwd: '/cwd', pythonPath: '', workingDir: '' });
+    expect(result).toBeUndefined();
+  });
+
+  it('creates remote session for https URL', () => {
+    const result = SessionConfig.createFromArgs({
+      _: ['https://example.com/lab?token=tok'],
+      $0: '', cwd: '/cwd', pythonPath: '', workingDir: ''
+    });
+    expect(result).toBeDefined();
+    expect(result.isRemote).toBe(true);
+    expect(result.remoteURL).toBe('https://example.com/lab?token=tok');
+  });
+
+  it('creates remote session for http URL', () => {
+    const result = SessionConfig.createFromArgs({
+      _: ['http://localhost:8888/lab?token=abc'],
+      $0: '', cwd: '/cwd', pythonPath: '', workingDir: ''
+    });
+    expect(result.isRemote).toBe(true);
+  });
+
+  it('creates local session when workingDir exists', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    const result = SessionConfig.createFromArgs({
+      _: [], $0: '', cwd: '/cwd', pythonPath: '', workingDir: '/valid/dir'
+    });
+    expect(result).toBeDefined();
+    expect(result.isRemote).toBe(false);
+    expect(result.workingDirectory).toContain('valid');
+  });
+
+  it('returns undefined when workingDir does not exist and no files', () => {
+    mockFs.existsSync = vi.fn(() => false);
+    const result = SessionConfig.createFromArgs({
+      _: [], $0: '', cwd: '/cwd', pythonPath: '', workingDir: '/nonexistent'
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it('includes file paths resolved from cwd', () => {
+    mockFs.existsSync = vi.fn(() => false);
+    mockFs.lstatSync = vi.fn(() => ({ isFile: () => true, isDirectory: () => false } as fs.Stats));
+    const result = SessionConfig.createFromArgs({
+      _: ['test.ipynb'], $0: '', cwd: '/cwd', pythonPath: '', workingDir: ''
+    });
+    expect(result).toBeDefined();
+  });
+
+  it('includes pythonPath when it exists', () => {
+    mockFs.existsSync = vi.fn((p: fs.PathLike) => {
+      const pathStr = p.toString();
+      return pathStr.includes('python3') || pathStr.includes('valid/dir');
+    });
+    const result = SessionConfig.createFromArgs({
+      _: [], $0: '', cwd: '/cwd', pythonPath: '/usr/bin/python3', workingDir: '/valid/dir'
+    });
+    expect(result).toBeDefined();
+    expect(result.pythonPath).toContain('python3');
+  });
+
+  it('excludes pythonPath when it does not exist', () => {
+    mockFs.existsSync = vi.fn((p: fs.PathLike) => {
+      return p.toString().includes('valid/dir');
+    });
+    const result = SessionConfig.createFromArgs({
+      _: [], $0: '', cwd: '/cwd', pythonPath: '/nonexistent/python', workingDir: '/valid/dir'
+    });
+    expect(result).toBeDefined();
+    expect(result.pythonPath).toBe('');
+  });
+});
+
+describe('SessionConfig.serialize', () => {
+  it('always includes x, y, width, height, lastOpened', () => {
+    const s = new SessionConfig();
+    const json = s.serialize();
+    expect(json).toHaveProperty('x');
+    expect(json).toHaveProperty('y');
+    expect(json).toHaveProperty('width');
+    expect(json).toHaveProperty('height');
+    expect(json).toHaveProperty('lastOpened');
+  });
+
+  it('omits remoteURL when empty', () => {
+    const json = new SessionConfig().serialize();
+    expect(json).not.toHaveProperty('remoteURL');
+  });
+
+  it('includes remoteURL when set', () => {
+    const s = new SessionConfig();
+    s.remoteURL = 'http://localhost:8888/lab';
+    expect(s.serialize()).toHaveProperty('remoteURL', 'http://localhost:8888/lab');
+  });
+
+  it('omits persistSessionData when true (default)', () => {
+    expect(new SessionConfig().serialize()).not.toHaveProperty('persistSessionData');
+  });
+
+  it('includes persistSessionData when false', () => {
+    const s = new SessionConfig();
+    s.persistSessionData = false;
+    expect(s.serialize()).toHaveProperty('persistSessionData', false);
+  });
+
+  it('omits partition when persistSessionData is false', () => {
+    const s = new SessionConfig();
+    s.persistSessionData = false;
+    s.partition = 'partition:123';
+    expect(s.serialize()).not.toHaveProperty('partition');
+  });
+
+  it('includes partition when persistSessionData is true', () => {
+    const s = new SessionConfig();
+    s.partition = 'persist:abc';
+    expect(s.serialize()).toHaveProperty('partition', 'persist:abc');
+  });
+
+  it('omits workingDirectory when empty', () => {
+    expect(new SessionConfig().serialize()).not.toHaveProperty('workingDirectory');
+  });
+
+  it('includes workingDirectory when set', () => {
+    const s = new SessionConfig();
+    s.workingDirectory = '/data/notebooks';
+    expect(s.serialize()).toHaveProperty('workingDirectory', '/data/notebooks');
+  });
+
+  it('omits filesToOpen when empty', () => {
+    expect(new SessionConfig().serialize()).not.toHaveProperty('filesToOpen');
+  });
+
+  it('includes filesToOpen when non-empty', () => {
+    const s = new SessionConfig();
+    s.filesToOpen = ['test.ipynb'];
+    expect(s.serialize()).toHaveProperty('filesToOpen', ['test.ipynb']);
+  });
+
+  it('lastOpened is ISO string', () => {
+    const s = new SessionConfig();
+    const json = s.serialize();
+    expect(() => new Date(json.lastOpened)).not.toThrow();
+    expect(new Date(json.lastOpened).getFullYear()).toBeGreaterThanOrEqual(2020);
+  });
+});
+
+describe('SessionConfig.deserialize', () => {
+  it('sets x, y, width, height', () => {
+    const s = new SessionConfig();
+    s.deserialize({ x: 10, y: 20, width: 800, height: 600 });
+    expect(s.x).toBe(10);
+    expect(s.y).toBe(20);
+    expect(s.width).toBe(800);
+    expect(s.height).toBe(600);
+  });
+
+  it('sets remoteURL', () => {
+    const s = new SessionConfig();
+    s.deserialize({ remoteURL: 'http://remote:8888/lab' });
+    expect(s.remoteURL).toBe('http://remote:8888/lab');
+  });
+
+  it('sets persistSessionData', () => {
+    const s = new SessionConfig();
+    s.deserialize({ persistSessionData: false });
+    expect(s.persistSessionData).toBe(false);
+  });
+
+  it('sets partition only when persistSessionData is true', () => {
+    const s = new SessionConfig();
+    s.deserialize({ persistSessionData: true, partition: 'persist:xyz' });
+    expect(s.partition).toBe('persist:xyz');
+  });
+
+  it('ignores partition when persistSessionData is false', () => {
+    const s = new SessionConfig();
+    s.deserialize({ persistSessionData: false, partition: 'persist:xyz' });
+    expect(s.partition).toBe('');
+  });
+
+  it('sets workingDirectory', () => {
+    const s = new SessionConfig();
+    s.deserialize({ workingDirectory: '/data/nb' });
+    expect(s.workingDirectory).toBe('/data/nb');
+  });
+
+  it('sets filesToOpen', () => {
+    const s = new SessionConfig();
+    s.deserialize({ filesToOpen: ['a.ipynb', 'b.ipynb'] });
+    expect(s.filesToOpen).toEqual(['a.ipynb', 'b.ipynb']);
+  });
+
+  it('parses lastOpened as Date', () => {
+    const s = new SessionConfig();
+    const iso = '2024-01-15T10:30:00.000Z';
+    s.deserialize({ lastOpened: iso });
+    expect(s.lastOpened).toBeInstanceOf(Date);
+    expect(s.lastOpened.getFullYear()).toBe(2024);
+  });
+
+  it('ignores unknown keys', () => {
+    const s = new SessionConfig();
+    expect(() => s.deserialize({ unknownKey: 'value' })).not.toThrow();
+  });
+});
+
+describe('SessionConfig serialize/deserialize round-trip', () => {
+  it('round-trips a local session', () => {
+    const original = new SessionConfig();
+    original.workingDirectory = '/data/notebooks';
+    original.filesToOpen = ['test.ipynb'];
+    original.x = 50;
+    original.y = 100;
+    original.width = 1200;
+    original.height = 900;
+
+    const copy = new SessionConfig();
+    copy.deserialize(original.serialize());
+
+    expect(copy.workingDirectory).toBe('/data/notebooks');
+    expect(copy.filesToOpen).toEqual(['test.ipynb']);
+    expect(copy.x).toBe(50);
+    expect(copy.width).toBe(1200);
+  });
+
+  it('round-trips a remote session', () => {
+    const original = SessionConfig.createRemote('http://remote:8888/lab?token=tok', true, 'persist:id123');
+    const copy = new SessionConfig();
+    copy.deserialize(original.serialize());
+
+    expect(copy.remoteURL).toBe('http://remote:8888/lab?token=tok');
+    expect(copy.persistSessionData).toBe(true);
+    expect(copy.partition).toBe('persist:id123');
+    expect(copy.isRemote).toBe(true);
+  });
+
+  it('round-trips a non-persistent remote session', () => {
+    const original = SessionConfig.createRemote('http://remote:8888/lab?token=tok', false, '');
+    const copy = new SessionConfig();
+    copy.deserialize(original.serialize());
+
+    expect(copy.persistSessionData).toBe(false);
+    expect(copy.partition).toBe('');
+  });
+});

--- a/test/unit/settings.test.ts
+++ b/test/unit/settings.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi } from 'vitest';
+import * as fs from 'fs';
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return { ...actual, existsSync: vi.fn(), lstatSync: vi.fn(), mkdirSync: vi.fn() };
+});
+
+import {
+  ThemeType,
+  StartupMode,
+  LogLevel,
+  CtrlWBehavior,
+  UIMode,
+  SettingType,
+  serverLaunchArgsFixed,
+  serverLaunchArgsDefault,
+  DEFAULT_WIN_WIDTH,
+  DEFAULT_WIN_HEIGHT,
+  resolveWorkingDirectory
+} from '../../../src/main/config/settings';
+
+const mockFs = vi.mocked(fs);
+
+describe('constants', () => {
+  it('DEFAULT_WIN_WIDTH is 1024', () => expect(DEFAULT_WIN_WIDTH).toBe(1024));
+  it('DEFAULT_WIN_HEIGHT is 768', () => expect(DEFAULT_WIN_HEIGHT).toBe(768));
+});
+
+describe('enums', () => {
+  it('ThemeType has system/light/dark', () => {
+    expect(ThemeType.System).toBe('system');
+    expect(ThemeType.Light).toBe('light');
+    expect(ThemeType.Dark).toBe('dark');
+  });
+
+  it('StartupMode values are correct', () => {
+    expect(StartupMode.WelcomePage).toBe('welcome-page');
+    expect(StartupMode.LastSessions).toBe('restore-sessions');
+  });
+
+  it('LogLevel values are correct', () => {
+    expect(LogLevel.Error).toBe('error');
+    expect(LogLevel.Debug).toBe('debug');
+  });
+
+  it('CtrlWBehavior values are correct', () => {
+    expect(CtrlWBehavior.CloseWindow).toBe('close');
+    expect(CtrlWBehavior.Warn).toBe('warn');
+  });
+
+  it('UIMode values are correct', () => {
+    expect(UIMode.MultiDocument).toBe('multi-document');
+    expect(UIMode.Zen).toBe('zen');
+  });
+});
+
+describe('serverLaunchArgsFixed', () => {
+  it('contains --no-browser', () => {
+    expect(serverLaunchArgsFixed).toContain('--no-browser');
+  });
+
+  it('contains port placeholder', () => {
+    expect(serverLaunchArgsFixed.some(a => a.includes('{port}'))).toBe(true);
+  });
+
+  it('contains token placeholder', () => {
+    expect(serverLaunchArgsFixed.some(a => a.includes('{token}'))).toBe(true);
+  });
+
+  it('disables browser', () => {
+    expect(serverLaunchArgsFixed).toContain('--no-browser');
+  });
+
+  it('disables quit button', () => {
+    expect(serverLaunchArgsFixed).toContain('--LabApp.quit_button=False');
+  });
+});
+
+describe('serverLaunchArgsDefault', () => {
+  it('allows hidden files', () => {
+    expect(serverLaunchArgsDefault.some(a => a.includes('allow_hidden=True'))).toBe(true);
+  });
+});
+
+describe('resolveWorkingDirectory', () => {
+  it('returns home when no directory given', () => {
+    // app.getPath mock returns /tmp/jlab-test-userdata/home
+    const result = resolveWorkingDirectory('');
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it('returns given path when it is a valid directory', () => {
+    mockFs.lstatSync = vi.fn(() => ({ isDirectory: () => true } as fs.Stats));
+    const result = resolveWorkingDirectory('/valid/dir');
+    expect(result).toBe('/valid/dir');
+  });
+
+  it('resets to home when path is a file not a directory', () => {
+    mockFs.lstatSync = vi.fn(() => ({ isDirectory: () => false } as fs.Stats));
+    const result = resolveWorkingDirectory('/some/file.txt');
+    expect(result).not.toBe('/some/file.txt');
+  });
+
+  it('resets to home when path does not exist', () => {
+    mockFs.lstatSync = vi.fn(() => { throw new Error('ENOENT'); });
+    const result = resolveWorkingDirectory('/nonexistent/path');
+    expect(result).not.toBe('/nonexistent/path');
+  });
+
+  it('keeps invalid path when resetIfInvalid is false', () => {
+    mockFs.lstatSync = vi.fn(() => { throw new Error('ENOENT'); });
+    const result = resolveWorkingDirectory('/bad/path', false);
+    expect(result).toBe('/bad/path');
+  });
+});

--- a/test/unit/tokens.test.ts
+++ b/test/unit/tokens.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import {
+  IEnvironmentType,
+  EnvironmentTypeName,
+  PythonEnvResolveErrorType
+} from '../../src/main/tokens';
+
+describe('IEnvironmentType', () => {
+  it('Path is "path"', () => expect(IEnvironmentType.Path).toBe('path'));
+  it('CondaRoot is "conda-root"', () => expect(IEnvironmentType.CondaRoot).toBe('conda-root'));
+  it('CondaEnv is "conda-env"', () => expect(IEnvironmentType.CondaEnv).toBe('conda-env'));
+  it('WindowsReg is "windows-reg"', () => expect(IEnvironmentType.WindowsReg).toBe('windows-reg'));
+  it('VirtualEnv is "venv"', () => expect(IEnvironmentType.VirtualEnv).toBe('venv'));
+});
+
+describe('EnvironmentTypeName', () => {
+  it('Path maps to "system"', () => expect(EnvironmentTypeName[IEnvironmentType.Path]).toBe('system'));
+  it('CondaRoot maps to "conda"', () => expect(EnvironmentTypeName[IEnvironmentType.CondaRoot]).toBe('conda'));
+  it('CondaEnv maps to "conda"', () => expect(EnvironmentTypeName[IEnvironmentType.CondaEnv]).toBe('conda'));
+  it('WindowsReg maps to "win"', () => expect(EnvironmentTypeName[IEnvironmentType.WindowsReg]).toBe('win'));
+  it('VirtualEnv maps to "venv"', () => expect(EnvironmentTypeName[IEnvironmentType.VirtualEnv]).toBe('venv'));
+
+  it('all IEnvironmentType values have a display name', () => {
+    for (const key of Object.values(IEnvironmentType)) {
+      expect(EnvironmentTypeName[key]).toBeDefined();
+      expect(typeof EnvironmentTypeName[key]).toBe('string');
+    }
+  });
+});
+
+describe('PythonEnvResolveErrorType', () => {
+  it('PathNotFound is "path-not-found"', () => {
+    expect(PythonEnvResolveErrorType.PathNotFound).toBe('path-not-found');
+  });
+  it('InvalidPythonBinary is "invalid-python-binary"', () => {
+    expect(PythonEnvResolveErrorType.InvalidPythonBinary).toBe('invalid-python-binary');
+  });
+  it('ResolveError is "resolve-error"', () => {
+    expect(PythonEnvResolveErrorType.ResolveError).toBe('resolve-error');
+  });
+  it('RequirementsNotSatisfied is "requirements-not-satisfied"', () => {
+    expect(PythonEnvResolveErrorType.RequirementsNotSatisfied).toBe('requirements-not-satisfied');
+  });
+});

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 
@@ -13,12 +13,25 @@ vi.mock('fs', async () => {
     readlinkSync: vi.fn(),
     mkdtempSync: vi.fn(),
     writeFileSync: vi.fn(),
-    mkdirSync: vi.fn()
+    mkdirSync: vi.fn(),
+    rmSync: vi.fn()
   };
 });
+vi.mock('net', async () => {
+  const actual = await vi.importActual<typeof import('net')>('net');
+  return { ...actual, Socket: vi.fn(), createServer: vi.fn() };
+});
 vi.mock('child_process', async () => {
-  const actual = await vi.importActual<typeof import('child_process')>('child_process');
-  return { ...actual, exec: vi.fn(), execFile: vi.fn(), execFileSync: vi.fn(), execSync: vi.fn() };
+  const actual = await vi.importActual<typeof import('child_process')>(
+    'child_process'
+  );
+  return {
+    ...actual,
+    exec: vi.fn(),
+    execFile: vi.fn(),
+    execFileSync: vi.fn(),
+    execSync: vi.fn()
+  };
 });
 vi.mock('os', async () => {
   const actual = await vi.importActual<typeof import('os')>('os');
@@ -26,30 +39,37 @@ vi.mock('os', async () => {
 });
 
 import {
-  isDarkTheme,
-  versionWithoutSuffix,
-  pythonPathForEnvPath,
-  envPathForPythonPath,
   activatePathForEnvPath,
-  condaSourcePathForEnvPath,
-  jupyterEnvInstallInfoPathForEnvPath,
-  isCondaEnv,
-  isBaseCondaEnv,
-  isEnvInstalledByDesktopApp,
-  getRelativePathToUserHome,
   bundledEnvironmentIsInstalled,
-  getLogFilePath,
+  condaSourcePathForEnvPath,
+  createCommandScriptInEnv,
+  createTempFile,
+  DarkThemeBGColor,
+  deletePythonEnvironment,
+  EnvironmentDeleteStatus,
+  envPathForPythonPath,
+  getFreePort,
   getJlabCLICommandSymlinkPath,
   getJlabCLICommandTargetPath,
+  getLogFilePath,
+  getRelativePathToUserHome,
+  isBaseCondaEnv,
+  isCondaEnv,
+  isDarkTheme,
+  isEnvInstalledByDesktopApp,
+  isPortInUse,
   jlabCLICommandIsSetup,
-  createCommandScriptInEnv,
+  jupyterEnvInstallInfoPathForEnvPath,
+  LightThemeBGColor,
+  markEnvironmentAsJupyterInstalled,
   openDirectoryInExplorer,
+  pythonPathForEnvPath,
+  versionWithoutSuffix,
   waitForDuration,
-  waitForFunction,
-  DarkThemeBGColor,
-  LightThemeBGColor
+  waitForFunction
 } from '../../../src/main/utils';
 import * as childProcess from 'child_process';
+import * as net from 'net';
 
 const mockFs = vi.mocked(fs);
 
@@ -155,7 +175,9 @@ describe('condaSourcePathForEnvPath', () => {
 
   it('returns conda.sh path on posix', () => {
     Object.defineProperty(process, 'platform', { value: 'darwin' });
-    expect(condaSourcePathForEnvPath('/env')).toBe('/env/etc/profile.d/conda.sh');
+    expect(condaSourcePathForEnvPath('/env')).toBe(
+      '/env/etc/profile.d/conda.sh'
+    );
   });
 
   it('returns undefined on windows', () => {
@@ -219,7 +241,9 @@ describe('waitForFunction', () => {
   });
 
   it('rejects on timeout when fn never returns true', async () => {
-    await expect(waitForFunction(() => false, 100)).rejects.toThrow('Timed out');
+    await expect(waitForFunction(() => false, 100)).rejects.toThrow(
+      'Timed out'
+    );
   });
 
   it('resolves after fn eventually returns true', async () => {
@@ -445,7 +469,9 @@ describe('createCommandScriptInEnv', () => {
   it('returns empty string when envPath lstatSync throws and no activate exists', () => {
     // when lstatSync throws, the try-catch swallows it and execution continues;
     // if there's also no activate script, the function returns ''
-    mockFs.lstatSync = vi.fn(() => { throw new Error('ENOENT'); });
+    mockFs.lstatSync = vi.fn(() => {
+      throw new Error('ENOENT');
+    });
     mockFs.existsSync = vi.fn(() => false);
     expect(createCommandScriptInEnv('/missing', '/base', {})).toBe('');
   });
@@ -459,9 +485,15 @@ describe('createCommandScriptInEnv', () => {
 
   it('includes source activate for venv on posix', () => {
     Object.defineProperty(process, 'platform', { value: 'darwin' });
-    mockFs.lstatSync = vi.fn(() => ({ isDirectory: () => true, isFile: () => false } as fs.Stats));
-    mockFs.existsSync = vi.fn((p: fs.PathLike) => p.toString().includes('activate')); // has activate, not conda
-    const script = createCommandScriptInEnv('/env', '/base', { command: 'pip install numpy' });
+    mockFs.lstatSync = vi.fn(
+      () => ({ isDirectory: () => true, isFile: () => false } as fs.Stats)
+    );
+    mockFs.existsSync = vi.fn((p: fs.PathLike) =>
+      p.toString().includes('activate')
+    ); // has activate, not conda
+    const script = createCommandScriptInEnv('/env', '/base', {
+      command: 'pip install numpy'
+    });
     expect(script).toContain('source');
     expect(script).toContain('activate');
     expect(script).toContain('pip install numpy');
@@ -469,9 +501,15 @@ describe('createCommandScriptInEnv', () => {
 
   it('includes CALL activate on windows venv', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
-    mockFs.lstatSync = vi.fn(() => ({ isDirectory: () => true, isFile: () => false } as fs.Stats));
-    mockFs.existsSync = vi.fn((p: fs.PathLike) => p.toString().includes('activate'));
-    const script = createCommandScriptInEnv('/env', '/base', { command: 'pip install numpy' });
+    mockFs.lstatSync = vi.fn(
+      () => ({ isDirectory: () => true, isFile: () => false } as fs.Stats)
+    );
+    mockFs.existsSync = vi.fn((p: fs.PathLike) =>
+      p.toString().includes('activate')
+    );
+    const script = createCommandScriptInEnv('/env', '/base', {
+      command: 'pip install numpy'
+    });
     expect(script).toContain('CALL');
     expect(script).toContain('activate');
   });
@@ -479,7 +517,9 @@ describe('createCommandScriptInEnv', () => {
   it('uses custom quoteChar and joinStr', () => {
     Object.defineProperty(process, 'platform', { value: 'linux' });
     mockFs.lstatSync = vi.fn(() => ({ isDirectory: () => true } as fs.Stats));
-    mockFs.existsSync = vi.fn((p: fs.PathLike) => p.toString().includes('activate'));
+    mockFs.existsSync = vi.fn((p: fs.PathLike) =>
+      p.toString().includes('activate')
+    );
     const script = createCommandScriptInEnv('/env', '/base', {
       command: 'echo hello',
       quoteChar: "'",
@@ -487,5 +527,199 @@ describe('createCommandScriptInEnv', () => {
     });
     expect(script).toContain("'");
     expect(script).toContain(' ; ');
+  });
+});
+
+describe('markEnvironmentAsJupyterInstalled', () => {
+  beforeEach(() => {
+    mockFs.existsSync = vi.fn(() => false);
+    mockFs.mkdirSync = vi.fn();
+    mockFs.writeFileSync = vi.fn();
+  });
+
+  it('creates .jupyter dir when missing and writes env.json', () => {
+    markEnvironmentAsJupyterInstalled('/env/myenv');
+    expect(mockFs.mkdirSync).toHaveBeenCalledWith(
+      expect.stringContaining('.jupyter'),
+      { recursive: true }
+    );
+    expect(mockFs.writeFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('env.json'),
+      expect.stringContaining('jupyterlab-desktop')
+    );
+  });
+
+  it('skips mkdirSync when .jupyter dir already exists', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    markEnvironmentAsJupyterInstalled('/env/myenv');
+    expect(mockFs.mkdirSync).not.toHaveBeenCalled();
+    expect(mockFs.writeFileSync).toHaveBeenCalled();
+  });
+
+  it('merges extraData into written JSON', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    markEnvironmentAsJupyterInstalled('/env/myenv', { version: '4.0.0' });
+    const content = (mockFs.writeFileSync as any).mock.calls[0][1] as string;
+    const json = JSON.parse(content);
+    expect(json.installer).toBe('jupyterlab-desktop');
+    expect(json.version).toBe('4.0.0');
+  });
+
+  it('does not throw when writeFileSync fails', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.writeFileSync = vi.fn(() => {
+      throw new Error('EACCES');
+    });
+    expect(() => markEnvironmentAsJupyterInstalled('/env/myenv')).not.toThrow();
+  });
+});
+
+describe('deletePythonEnvironment', () => {
+  beforeEach(() => {
+    mockFs.existsSync = vi.fn(() => false);
+    mockFs.rmSync = vi.fn();
+  });
+
+  it('rejects when env was not installed by Desktop (no env.json)', async () => {
+    // isEnvInstalledByDesktopApp → existsSync returns false
+    const listener = { onDeleteStatus: vi.fn() };
+    await expect(
+      deletePythonEnvironment('/env/foreign', listener)
+    ).rejects.toBeUndefined();
+    expect(listener.onDeleteStatus).toHaveBeenCalledWith(
+      EnvironmentDeleteStatus.Failure,
+      expect.any(String)
+    );
+  });
+
+  it('calls rmSync and resolves true when env.json exists', async () => {
+    // isEnvInstalledByDesktopApp → existsSync returns true
+    mockFs.existsSync = vi.fn(() => true);
+    const listener = { onDeleteStatus: vi.fn() };
+    const result = await deletePythonEnvironment('/env/myenv', listener);
+    expect(mockFs.rmSync).toHaveBeenCalledWith('/env/myenv', {
+      recursive: true,
+      force: true
+    });
+    expect(result).toBe(true);
+    expect(listener.onDeleteStatus).toHaveBeenCalledWith(
+      EnvironmentDeleteStatus.Success
+    );
+  });
+
+  it('rejects with Failure status when rmSync throws', async () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.rmSync = vi.fn(() => {
+      throw new Error('EPERM');
+    });
+    const listener = { onDeleteStatus: vi.fn() };
+    await expect(
+      deletePythonEnvironment('/env/myenv', listener)
+    ).rejects.toBeUndefined();
+    expect(listener.onDeleteStatus).toHaveBeenCalledWith(
+      EnvironmentDeleteStatus.Failure,
+      'EPERM'
+    );
+  });
+
+  it('works without a listener', async () => {
+    mockFs.existsSync = vi.fn(() => true);
+    await expect(deletePythonEnvironment('/env/myenv')).resolves.toBe(true);
+  });
+});
+
+describe('createTempFile', () => {
+  beforeEach(() => {
+    mockFs.mkdtempSync = vi.fn(() => '/tmp/jlab_desktop_abc');
+    mockFs.writeFileSync = vi.fn();
+  });
+
+  it('calls mkdtempSync with jlab_desktop prefix', () => {
+    createTempFile('test.sh', 'echo hi');
+    expect(mockFs.mkdtempSync).toHaveBeenCalledWith(
+      expect.stringContaining('jlab_desktop')
+    );
+  });
+
+  it('writes data to the temp file', () => {
+    createTempFile('test.sh', 'echo hi', 'utf8');
+    expect(mockFs.writeFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('test.sh'),
+      'echo hi',
+      { encoding: 'utf8' }
+    );
+  });
+
+  it('returns path inside the temp dir', () => {
+    const result = createTempFile('run.sh');
+    expect(result).toContain('run.sh');
+    expect(result).toContain('/tmp/jlab_desktop_abc');
+  });
+
+  it('uses defaults when called with no args', () => {
+    const result = createTempFile();
+    expect(result).toContain('temp');
+  });
+});
+
+describe('isPortInUse', () => {
+  it('resolves false on connection error (port not in use)', async () => {
+    const mockSocket = {
+      setTimeout: vi.fn(),
+      once: vi.fn((event: string, cb: () => void) => {
+        if (event === 'error') cb();
+      }),
+      on: vi.fn((event: string, cb: (v?: any) => void) => {
+        if (event === 'close') cb(false);
+      }),
+      connect: vi.fn(),
+      destroy: vi.fn()
+    };
+    vi.mocked(net.Socket).mockImplementation(function () {
+      return mockSocket;
+    } as any);
+    const result = await isPortInUse(9999);
+    expect(result).toBe(false);
+  });
+
+  it('resolves true on connect (port in use)', async () => {
+    let closeCallback: ((v?: any) => void) | null = null;
+    const mockSocket = {
+      setTimeout: vi.fn(),
+      once: vi.fn(),
+      on: vi.fn((event: string, cb: (v?: any) => void) => {
+        if (event === 'connect') {
+          cb();
+        }
+        if (event === 'close') {
+          closeCallback = cb;
+        }
+      }),
+      connect: vi.fn(() => {
+        if (closeCallback) closeCallback(false);
+      }),
+      destroy: vi.fn()
+    };
+    vi.mocked(net.Socket).mockImplementation(function () {
+      return mockSocket;
+    } as any);
+    const result = await isPortInUse(8080);
+    expect(result).toBe(true);
+  });
+});
+
+describe('getFreePort', () => {
+  it('resolves a numeric port from server address', async () => {
+    const mockServer = {
+      on: vi.fn((event: string, cb: (e?: any) => void) => {
+        if (event === 'listening') cb({});
+      }),
+      listen: vi.fn(),
+      close: vi.fn(),
+      address: vi.fn(() => ({ port: 54321 }))
+    };
+    vi.mocked(net.createServer).mockReturnValue(mockServer as any);
+    const port = await getFreePort();
+    expect(port).toBe(54321);
   });
 });

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -4,7 +4,17 @@ import * as os from 'os';
 
 vi.mock('fs', async () => {
   const actual = await vi.importActual<typeof import('fs')>('fs');
-  return { ...actual, existsSync: vi.fn(), lstatSync: vi.fn(), mkdtempSync: vi.fn(), writeFileSync: vi.fn(), mkdirSync: vi.fn() };
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    lstatSync: vi.fn(),
+    statSync: vi.fn(),
+    accessSync: vi.fn(),
+    readlinkSync: vi.fn(),
+    mkdtempSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    mkdirSync: vi.fn()
+  };
 });
 vi.mock('os', async () => {
   const actual = await vi.importActual<typeof import('os')>('os');
@@ -20,8 +30,14 @@ import {
   condaSourcePathForEnvPath,
   jupyterEnvInstallInfoPathForEnvPath,
   isCondaEnv,
+  isBaseCondaEnv,
   isEnvInstalledByDesktopApp,
   getRelativePathToUserHome,
+  bundledEnvironmentIsInstalled,
+  getLogFilePath,
+  getJlabCLICommandSymlinkPath,
+  getJlabCLICommandTargetPath,
+  jlabCLICommandIsSetup,
   waitForDuration,
   waitForFunction,
   DarkThemeBGColor,
@@ -213,5 +229,145 @@ describe('theme constants', () => {
 
   it('LightThemeBGColor is valid hex', () => {
     expect(LightThemeBGColor).toMatch(/^#[0-9a-f]{6}$/i);
+  });
+});
+
+describe('isBaseCondaEnv', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('returns true when condabin/conda exists and is a file on posix', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.lstatSync = vi.fn(() => ({ isFile: () => true } as fs.Stats));
+    expect(isBaseCondaEnv('/env')).toBe(true);
+  });
+
+  it('returns false when condabin/conda does not exist', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    mockFs.existsSync = vi.fn(() => false);
+    expect(isBaseCondaEnv('/env')).toBe(false);
+  });
+
+  it('returns false when path exists but is not a file', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.lstatSync = vi.fn(() => ({ isFile: () => false } as fs.Stats));
+    expect(isBaseCondaEnv('/env')).toBe(false);
+  });
+
+  it('checks condabin/conda.bat on windows', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    let checkedPath = '';
+    mockFs.existsSync = vi.fn((p: fs.PathLike) => {
+      checkedPath = p.toString();
+      return true;
+    });
+    mockFs.lstatSync = vi.fn(() => ({ isFile: () => true } as fs.Stats));
+    isBaseCondaEnv('/env');
+    expect(checkedPath).toContain('conda.bat');
+  });
+});
+
+describe('bundledEnvironmentIsInstalled', () => {
+  it('returns true when bundled env path exists and is directory', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.statSync = vi.fn(() => ({ isDirectory: () => true } as fs.Stats));
+    expect(bundledEnvironmentIsInstalled()).toBe(true);
+  });
+
+  it('returns false when bundled env path does not exist', () => {
+    mockFs.existsSync = vi.fn(() => false);
+    expect(bundledEnvironmentIsInstalled()).toBe(false);
+  });
+
+  it('returns false when path is a file not directory', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.statSync = vi.fn(() => ({ isDirectory: () => false } as fs.Stats));
+    expect(bundledEnvironmentIsInstalled()).toBe(false);
+  });
+});
+
+describe('getLogFilePath', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('returns path containing main.log by default', () => {
+    expect(getLogFilePath()).toContain('main.log');
+  });
+
+  it('returns path containing renderer.log for renderer process', () => {
+    expect(getLogFilePath('renderer')).toContain('renderer.log');
+  });
+
+  it('returns path under Library/Logs on darwin', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    expect(getLogFilePath()).toContain('Library/Logs');
+  });
+
+  it('returns path under .config on linux', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    expect(getLogFilePath()).toContain('.config');
+  });
+
+  it('returns path under userData on windows', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    expect(getLogFilePath()).toContain('logs');
+  });
+});
+
+describe('getJlabCLICommandSymlinkPath', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('returns /usr/local/bin/jlab on darwin', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    expect(getJlabCLICommandSymlinkPath()).toBe('/usr/local/bin/jlab');
+  });
+
+  it('returns undefined on non-darwin', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    expect(getJlabCLICommandSymlinkPath()).toBeUndefined();
+  });
+});
+
+describe('getJlabCLICommandTargetPath', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  // darwin path requires require.main via isDevMode() — only test the non-darwin case here
+  it('returns undefined on non-darwin', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    expect(getJlabCLICommandTargetPath()).toBeUndefined();
+  });
+});
+
+describe('jlabCLICommandIsSetup', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('returns true on non-darwin platforms (linux)', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    expect(jlabCLICommandIsSetup()).toBe(true);
+  });
+
+  it('returns true on non-darwin platforms (win32)', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    expect(jlabCLICommandIsSetup()).toBe(true);
   });
 });

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return { ...actual, existsSync: vi.fn(), lstatSync: vi.fn(), mkdtempSync: vi.fn(), writeFileSync: vi.fn(), mkdirSync: vi.fn() };
+});
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os');
+  return { ...actual, tmpdir: vi.fn(() => '/tmp') };
+});
+
+import {
+  isDarkTheme,
+  versionWithoutSuffix,
+  pythonPathForEnvPath,
+  envPathForPythonPath,
+  activatePathForEnvPath,
+  condaSourcePathForEnvPath,
+  jupyterEnvInstallInfoPathForEnvPath,
+  isCondaEnv,
+  isEnvInstalledByDesktopApp,
+  getRelativePathToUserHome,
+  waitForDuration,
+  waitForFunction,
+  DarkThemeBGColor,
+  LightThemeBGColor
+} from '../../../src/main/utils';
+
+const mockFs = vi.mocked(fs);
+
+describe('isDarkTheme', () => {
+  it.each([
+    ['light', false],
+    ['dark', true]
+  ])('"%s" → %s', (theme, expected) => {
+    expect(isDarkTheme(theme)).toBe(expected);
+  });
+
+  it('falls back to nativeTheme.shouldUseDarkColors for unknown value', () => {
+    // nativeTheme mock returns false
+    expect(isDarkTheme('system')).toBe(false);
+  });
+});
+
+describe('versionWithoutSuffix', () => {
+  it.each([
+    ['3.6.0a1', '3.6.0'],
+    ['4.0.0b2', '4.0.0'],
+    ['4.4.7', '4.4.7'],
+    ['1.0.0rc1', '1.0.0']
+  ])('"%s" → "%s"', (input, expected) => {
+    expect(versionWithoutSuffix(input)).toBe(expected);
+  });
+});
+
+describe('pythonPathForEnvPath', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('returns bin/python on posix', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    mockFs.existsSync = vi.fn(() => false);
+    expect(pythonPathForEnvPath('/env')).toBe('/env/bin/python');
+  });
+
+  it('returns python.exe in root for conda on windows', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    mockFs.existsSync = vi.fn(() => true);
+    expect(pythonPathForEnvPath('/env', true)).toContain('python.exe');
+    expect(pythonPathForEnvPath('/env', true)).not.toContain('Scripts');
+  });
+
+  it('returns Scripts/python.exe for venv on windows', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    mockFs.existsSync = vi.fn(() => false);
+    expect(pythonPathForEnvPath('/env', false)).toContain('Scripts');
+    expect(pythonPathForEnvPath('/env', false)).toContain('python.exe');
+  });
+});
+
+describe('envPathForPythonPath', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('returns parent of bin/ on posix', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    const result = envPathForPythonPath('/env/bin/python');
+    expect(result).toContain('/env');
+  });
+
+  it('returns parent of Scripts/ on windows', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    // path.join uses host OS separator — just verify it doesn't include Scripts
+    const result = envPathForPythonPath('C:/env/Scripts/python.exe');
+    expect(result).not.toContain('Scripts');
+    expect(result).not.toContain('python.exe');
+  });
+});
+
+describe('activatePathForEnvPath', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('returns activate.bat on windows', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    expect(activatePathForEnvPath('/env')).toContain('activate.bat');
+  });
+
+  it('returns bin/activate on posix', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    expect(activatePathForEnvPath('/env')).toBe('/env/bin/activate');
+  });
+});
+
+describe('condaSourcePathForEnvPath', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('returns conda.sh path on posix', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    expect(condaSourcePathForEnvPath('/env')).toBe('/env/etc/profile.d/conda.sh');
+  });
+
+  it('returns undefined on windows', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    expect(condaSourcePathForEnvPath('/env')).toBeUndefined();
+  });
+});
+
+describe('jupyterEnvInstallInfoPathForEnvPath', () => {
+  it('returns .jupyter/env.json path', () => {
+    expect(jupyterEnvInstallInfoPathForEnvPath('/env')).toBe(
+      '/env/.jupyter/env.json'
+    );
+  });
+});
+
+describe('isCondaEnv', () => {
+  it('returns true when conda-meta exists', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    expect(isCondaEnv('/env')).toBe(true);
+  });
+
+  it('returns false when conda-meta missing', () => {
+    mockFs.existsSync = vi.fn(() => false);
+    expect(isCondaEnv('/env')).toBe(false);
+  });
+});
+
+describe('isEnvInstalledByDesktopApp', () => {
+  it('returns true when env.json marker exists', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    expect(isEnvInstalledByDesktopApp('/env')).toBe(true);
+  });
+
+  it('returns false when marker missing', () => {
+    mockFs.existsSync = vi.fn(() => false);
+    expect(isEnvInstalledByDesktopApp('/env')).toBe(false);
+  });
+});
+
+describe('getRelativePathToUserHome', () => {
+  it('replaces home prefix with ~', () => {
+    const home = '/Users/test';
+    const abs = '/Users/test/notebooks/file.ipynb';
+    // app.getPath('home') is mocked to /tmp/jlab-test-userdata/home
+    // but we can test the logic by checking the function exists
+    expect(typeof getRelativePathToUserHome).toBe('function');
+  });
+});
+
+describe('waitForDuration', () => {
+  it('resolves false after duration', async () => {
+    const result = await waitForDuration(10);
+    expect(result).toBe(false);
+  });
+});
+
+describe('waitForFunction', () => {
+  it('resolves immediately when fn returns true', async () => {
+    await expect(waitForFunction(() => true)).resolves.toBeUndefined();
+  });
+
+  it('rejects on timeout when fn never returns true', async () => {
+    await expect(waitForFunction(() => false, 100)).rejects.toThrow('Timed out');
+  });
+
+  it('resolves after fn eventually returns true', async () => {
+    let count = 0;
+    await expect(waitForFunction(() => ++count >= 3)).resolves.toBeUndefined();
+    expect(count).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe('theme constants', () => {
+  it('DarkThemeBGColor is valid hex', () => {
+    expect(DarkThemeBGColor).toMatch(/^#[0-9a-f]{6}$/i);
+  });
+
+  it('LightThemeBGColor is valid hex', () => {
+    expect(LightThemeBGColor).toMatch(/^#[0-9a-f]{6}$/i);
+  });
+});

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -16,6 +16,10 @@ vi.mock('fs', async () => {
     mkdirSync: vi.fn()
   };
 });
+vi.mock('child_process', async () => {
+  const actual = await vi.importActual<typeof import('child_process')>('child_process');
+  return { ...actual, exec: vi.fn(), execFile: vi.fn(), execFileSync: vi.fn(), execSync: vi.fn() };
+});
 vi.mock('os', async () => {
   const actual = await vi.importActual<typeof import('os')>('os');
   return { ...actual, tmpdir: vi.fn(() => '/tmp') };
@@ -38,11 +42,14 @@ import {
   getJlabCLICommandSymlinkPath,
   getJlabCLICommandTargetPath,
   jlabCLICommandIsSetup,
+  createCommandScriptInEnv,
+  openDirectoryInExplorer,
   waitForDuration,
   waitForFunction,
   DarkThemeBGColor,
   LightThemeBGColor
 } from '../../../src/main/utils';
+import * as childProcess from 'child_process';
 
 const mockFs = vi.mocked(fs);
 
@@ -369,5 +376,116 @@ describe('jlabCLICommandIsSetup', () => {
   it('returns true on non-darwin platforms (win32)', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
     expect(jlabCLICommandIsSetup()).toBe(true);
+  });
+});
+
+describe('openDirectoryInExplorer', () => {
+  const originalPlatform = process.platform;
+  const mockExec = vi.mocked(childProcess.exec);
+
+  beforeEach(() => {
+    mockExec.mockReset();
+  });
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('returns false when path does not exist', () => {
+    mockFs.existsSync = vi.fn(() => false);
+    expect(openDirectoryInExplorer('/nonexistent')).toBe(false);
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it('returns false when path is a file not a directory', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.statSync = vi.fn(() => ({ isDirectory: () => false } as fs.Stats));
+    expect(openDirectoryInExplorer('/some/file.txt')).toBe(false);
+  });
+
+  it('returns true and calls exec on darwin', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.statSync = vi.fn(() => ({ isDirectory: () => true } as fs.Stats));
+    const result = openDirectoryInExplorer('/data/notebooks');
+    expect(result).toBe(true);
+    expect(mockExec).toHaveBeenCalledWith(expect.stringContaining('open'));
+  });
+
+  it('returns true and calls exec on windows', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.statSync = vi.fn(() => ({ isDirectory: () => true } as fs.Stats));
+    const result = openDirectoryInExplorer('/data/notebooks');
+    expect(result).toBe(true);
+    expect(mockExec).toHaveBeenCalledWith(expect.stringContaining('explorer'));
+  });
+
+  it('returns true and calls exec on linux', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.statSync = vi.fn(() => ({ isDirectory: () => true } as fs.Stats));
+    const result = openDirectoryInExplorer('/data/notebooks');
+    expect(result).toBe(true);
+    expect(mockExec).toHaveBeenCalledWith(expect.stringContaining('xdg-open'));
+  });
+});
+
+describe('createCommandScriptInEnv', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('returns empty string when envPath is not a directory', () => {
+    mockFs.lstatSync = vi.fn(() => ({ isDirectory: () => false } as fs.Stats));
+    expect(createCommandScriptInEnv('/notadir', '/base', {})).toBe('');
+  });
+
+  it('returns empty string when envPath lstatSync throws and no activate exists', () => {
+    // when lstatSync throws, the try-catch swallows it and execution continues;
+    // if there's also no activate script, the function returns ''
+    mockFs.lstatSync = vi.fn(() => { throw new Error('ENOENT'); });
+    mockFs.existsSync = vi.fn(() => false);
+    expect(createCommandScriptInEnv('/missing', '/base', {})).toBe('');
+  });
+
+  it('returns empty string when no activate script exists', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    mockFs.lstatSync = vi.fn(() => ({ isDirectory: () => true } as fs.Stats));
+    mockFs.existsSync = vi.fn(() => false); // no activate, no conda-meta
+    expect(createCommandScriptInEnv('/env', '/base', {})).toBe('');
+  });
+
+  it('includes source activate for venv on posix', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    mockFs.lstatSync = vi.fn(() => ({ isDirectory: () => true, isFile: () => false } as fs.Stats));
+    mockFs.existsSync = vi.fn((p: fs.PathLike) => p.toString().includes('activate')); // has activate, not conda
+    const script = createCommandScriptInEnv('/env', '/base', { command: 'pip install numpy' });
+    expect(script).toContain('source');
+    expect(script).toContain('activate');
+    expect(script).toContain('pip install numpy');
+  });
+
+  it('includes CALL activate on windows venv', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    mockFs.lstatSync = vi.fn(() => ({ isDirectory: () => true, isFile: () => false } as fs.Stats));
+    mockFs.existsSync = vi.fn((p: fs.PathLike) => p.toString().includes('activate'));
+    const script = createCommandScriptInEnv('/env', '/base', { command: 'pip install numpy' });
+    expect(script).toContain('CALL');
+    expect(script).toContain('activate');
+  });
+
+  it('uses custom quoteChar and joinStr', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    mockFs.lstatSync = vi.fn(() => ({ isDirectory: () => true } as fs.Stats));
+    mockFs.existsSync = vi.fn((p: fs.PathLike) => p.toString().includes('activate'));
+    const script = createCommandScriptInEnv('/env', '/base', {
+      command: 'echo hello',
+      quoteChar: "'",
+      joinStr: ' ; '
+    });
+    expect(script).toContain("'");
+    expect(script).toContain(' ; ');
   });
 });

--- a/test/unit/workspacesettings.test.ts
+++ b/test/unit/workspacesettings.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    lstatSync: vi.fn(),
+    readFileSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    mkdirSync: vi.fn()
+  };
+});
+
+import {
+  WorkspaceSettings,
+  SettingType,
+  ThemeType,
+  UIMode,
+  resolveWorkingDirectory
+} from '../../../src/main/config/settings';
+
+const mockFs = vi.mocked(fs);
+
+describe('WorkspaceSettings.getWorkspaceSettingsPath', () => {
+  it('returns .jupyter/desktop-settings.json inside working dir', () => {
+    const result = WorkspaceSettings.getWorkspaceSettingsPath('/data/notebooks');
+    expect(result).toBe(path.join('/data/notebooks', '.jupyter', 'desktop-settings.json'));
+  });
+});
+
+describe('WorkspaceSettings — no workspace file', () => {
+  beforeEach(() => {
+    // user settings file does not exist, workspace settings file does not exist
+    mockFs.existsSync = vi.fn(() => false);
+    mockFs.readFileSync = vi.fn(() => { throw new Error('ENOENT'); });
+  });
+
+  it('constructs without throwing', () => {
+    expect(() => new WorkspaceSettings('/data/nb')).not.toThrow();
+  });
+
+  it('hasValue returns false for any setting when no workspace file', () => {
+    const ws = new WorkspaceSettings('/data/nb');
+    expect(ws.hasValue(SettingType.theme)).toBe(false);
+  });
+
+  it('getValue falls through to user default when no workspace override', () => {
+    const ws = new WorkspaceSettings('/data/nb');
+    // theme default is 'system'
+    const val = ws.getValue(SettingType.theme);
+    expect(typeof val).toBe('string');
+  });
+});
+
+describe('WorkspaceSettings — with workspace file', () => {
+  beforeEach(() => {
+    mockFs.existsSync = vi.fn((p: fs.PathLike) => {
+      return p.toString().includes('desktop-settings.json');
+    });
+    mockFs.readFileSync = vi.fn((p: fs.PathLike | fs.promises.FileHandle) => {
+      if (p.toString().includes('desktop-settings.json')) {
+        // serverArgs and uiMode are wsOverridable
+        return Buffer.from(JSON.stringify({ serverArgs: '--no-browser', uiMode: 'zen' }));
+      }
+      throw new Error('ENOENT');
+    });
+  });
+
+  it('reads workspace-overridden serverArgs', () => {
+    const ws = new WorkspaceSettings('/data/nb');
+    expect(ws.getValue(SettingType.serverArgs)).toBe('--no-browser');
+  });
+
+  it('reads workspace-overridden uiMode', () => {
+    const ws = new WorkspaceSettings('/data/nb');
+    expect(ws.getValue(SettingType.uiMode)).toBe(UIMode.Zen);
+  });
+
+  it('hasValue returns true for overridden setting', () => {
+    const ws = new WorkspaceSettings('/data/nb');
+    expect(ws.hasValue(SettingType.serverArgs)).toBe(true);
+  });
+
+  it('hasValue returns false for non-overridden setting', () => {
+    const ws = new WorkspaceSettings('/data/nb');
+    expect(ws.hasValue(SettingType.theme)).toBe(false);
+  });
+
+  it('non-overridden settings still return global default', () => {
+    const ws = new WorkspaceSettings('/data/nb');
+    // theme is not wsOverridable, should still have default
+    expect(typeof ws.getValue(SettingType.theme)).toBe('string');
+  });
+});
+
+describe('WorkspaceSettings setValue / unsetValue', () => {
+  beforeEach(() => {
+    mockFs.existsSync = vi.fn(() => false);
+    mockFs.readFileSync = vi.fn(() => { throw new Error('ENOENT'); });
+  });
+
+  it('setValue sets workspace-level value', () => {
+    const ws = new WorkspaceSettings('/data/nb');
+    ws.setValue(SettingType.theme, ThemeType.Dark);
+    expect(ws.getValue(SettingType.theme)).toBe(ThemeType.Dark);
+    expect(ws.hasValue(SettingType.theme)).toBe(true);
+  });
+
+  it('setValue overrides default', () => {
+    const ws = new WorkspaceSettings('/data/nb');
+    const before = ws.getValue(SettingType.theme);
+    ws.setValue(SettingType.theme, ThemeType.Light);
+    expect(ws.getValue(SettingType.theme)).toBe(ThemeType.Light);
+  });
+
+  it('unsetValue removes workspace override', () => {
+    const ws = new WorkspaceSettings('/data/nb');
+    ws.setValue(SettingType.theme, ThemeType.Dark);
+    ws.unsetValue(SettingType.theme);
+    expect(ws.hasValue(SettingType.theme)).toBe(false);
+  });
+});
+
+describe('WorkspaceSettings save', () => {
+  beforeEach(() => {
+    mockFs.existsSync = vi.fn(() => false);
+    mockFs.readFileSync = vi.fn(() => { throw new Error('ENOENT'); });
+    mockFs.writeFileSync = vi.fn();
+    mockFs.mkdirSync = vi.fn();
+  });
+
+  it('writes desktop-settings.json when workspace settings differ from user settings', () => {
+    const ws = new WorkspaceSettings('/data/nb');
+    // uiMode is wsOverridable and always saved when present
+    ws.setValue(SettingType.uiMode, UIMode.Zen);
+    ws.save();
+    expect(mockFs.writeFileSync).toHaveBeenCalled();
+    const [writePath, content] = (mockFs.writeFileSync as any).mock.calls[0];
+    expect(writePath).toContain('desktop-settings.json');
+    const parsed = JSON.parse(content as string);
+    expect(parsed.uiMode).toBe(UIMode.Zen);
+  });
+
+  it('creates parent directory when it does not exist', () => {
+    const ws = new WorkspaceSettings('/data/nb');
+    ws.setValue(SettingType.uiMode, UIMode.Zen);
+    ws.save();
+    expect(mockFs.mkdirSync).toHaveBeenCalled();
+  });
+
+  it('does not write when no workspace settings changed and file does not exist', () => {
+    const ws = new WorkspaceSettings('/data/nb');
+    ws.save();
+    expect(mockFs.writeFileSync).not.toHaveBeenCalled();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['test/unit/**/*.test.ts'],
+    setupFiles: ['test/setup/electron-mock.ts'],
+    coverage: {
+      provider: 'v8',
+      include: ['src/main/**/*.ts'],
+      exclude: ['src/main/**/*.d.ts', 'src/main/main.ts']
+    }
+  },
+  resolve: {
+    alias: {
+      electron: '/Users/notluquis/jupyterlab-desktop/test/setup/electron-mock.ts'
+    }
+  }
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,7 +14,12 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      // redirect electron to the in-process mock so unit tests run without a real Electron binary
       electron: '/Users/notluquis/jupyterlab-desktop/test/setup/electron-mock.ts'
     }
   }
+  // Import-path note: test files that call vi.mock() have their mocks hoisted by vitest,
+  // which resolves paths from the project root — so '../../../src/main/foo' works.
+  // Test files with NO vi.mock() use standard Node.js resolution from the file's directory;
+  // those must use '../../src/main/foo' (two levels up to reach the project root).
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,4 +22,8 @@ export default defineConfig({
   // which resolves paths from the project root — so '../../../src/main/foo' works.
   // Test files with NO vi.mock() use standard Node.js resolution from the file's directory;
   // those must use '../../src/main/foo' (two levels up to reach the project root).
+  //
+  // Preload scripts (src/main/*/preload.ts) use require('electron') which bypasses vitest's
+  // module interception. The alias only applies to ESM import statements. Preload tests
+  // must be done via Playwright E2E (electron-playwright-helpers) not unit tests.
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,10 +14,20 @@
   dependencies:
     "@babel/highlight" "^7.18.6"
 
+"@babel/helper-string-parser@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz#54da796097ab19ce67ed9f88b47bb2ec49367687"
+  integrity sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==
+
 "@babel/helper-validator-identifier@^7.18.6":
   version "7.19.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz#7eea834cf32901ffdc1a7ee555e2f9c27e249ca2"
   integrity sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==
+
+"@babel/helper-validator-identifier@^7.28.5":
+  version "7.28.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz#010b6938fab7cb7df74aa2bbc06aa503b8fe5fb4"
+  integrity sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==
 
 "@babel/highlight@^7.18.6":
   version "7.18.6"
@@ -27,6 +37,26 @@
     "@babel/helper-validator-identifier" "^7.18.6"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
+
+"@babel/parser@^7.29.0":
+  version "7.29.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.3.tgz#116f70a77958307fceac27747573032f8a62f88e"
+  integrity sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==
+  dependencies:
+    "@babel/types" "^7.29.0"
+
+"@babel/types@^7.29.0":
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.29.0.tgz#9f5b1e838c446e72cf3cd4b918152b8c605e37c7"
+  integrity sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==
+  dependencies:
+    "@babel/helper-string-parser" "^7.27.1"
+    "@babel/helper-validator-identifier" "^7.28.5"
+
+"@bcoe/v8-coverage@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz#bbe12dca5b4ef983a0d0af4b07b9bc90ea0ababa"
+  integrity sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==
 
 "@csstools/css-parser-algorithms@^2.3.0":
   version "2.3.0"
@@ -67,6 +97,15 @@
   integrity sha512-lykfY3TJRRWFeTxccEKdf1I6BLl2Plw81H0bbp4Fc5iEc67foDCa5pjJQULVgo0wF+Dli75f3xVcdb/67FFZ/g==
   dependencies:
     chromium-pickle-js "^0.2.0"
+    commander "^5.0.0"
+    glob "^7.1.6"
+    minimatch "^3.0.4"
+
+"@electron/asar@^3.2.4":
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@electron/asar/-/asar-3.4.1.tgz#4e9196a4b54fba18c56cd8d5cac67c5bdc588065"
+  integrity sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==
+  dependencies:
     commander "^5.0.0"
     glob "^7.1.6"
     minimatch "^3.0.4"
@@ -120,6 +159,28 @@
     minimatch "^3.0.4"
     plist "^3.0.4"
 
+"@emnapi/core@1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.10.0.tgz#380ccc8f2412ea22d1d972df7f8ee23a3b9c7467"
+  integrity sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==
+  dependencies:
+    "@emnapi/wasi-threads" "1.2.1"
+    tslib "^2.4.0"
+
+"@emnapi/runtime@1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.10.0.tgz#4b260c0d3534204e98c6110b8db1a987d26ec87c"
+  integrity sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==
+  dependencies:
+    tslib "^2.4.0"
+
+"@emnapi/wasi-threads@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz#28fed21a1ba1ce797c44a070abc94d42f3ae8548"
+  integrity sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==
+  dependencies:
+    tslib "^2.4.0"
+
 "@eslint/eslintrc@^1.3.0":
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.4.1.tgz#af58772019a2d271b7e2d4c23ff4ddcba3ccfb3e"
@@ -163,6 +224,11 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
   integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
 
+"@jridgewell/resolve-uri@^3.1.0":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
+  integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
+
 "@jridgewell/set-array@^1.0.1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
@@ -181,6 +247,11 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
 
+"@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.5.5":
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
+  integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
+
 "@jridgewell/trace-mapping@^0.3.14", "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.17"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz#793041277af9073b0951a7fe0f0d8c4c98c36985"
@@ -188,6 +259,14 @@
   dependencies:
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
+
+"@jridgewell/trace-mapping@^0.3.31":
+  version "0.3.31"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz#db15d6781c931f3a251a3dac39501c98a6082fd0"
+  integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
 
 "@jupyter-notebook/web-components@0.9.1":
   version "0.9.1"
@@ -278,6 +357,18 @@
   dependencies:
     exenv-es6 "^1.1.1"
 
+"@napi-rs/wasm-runtime@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz#a46bbfedc29751b7170c5d23bc1d8ee8c7e3c1e1"
+  integrity sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==
+  dependencies:
+    "@tybys/wasm-util" "^0.10.1"
+
+"@nodable/entities@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@nodable/entities/-/entities-2.1.0.tgz#f543e5c6446720d4cf9e498a83019dd159973bc2"
+  integrity sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -299,10 +390,111 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@oxc-project/types@=0.127.0":
+  version "0.127.0"
+  resolved "https://registry.yarnpkg.com/@oxc-project/types/-/types-0.127.0.tgz#8374fcdfb4a641861218daa5700c447c00b66663"
+  integrity sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==
+
+"@playwright/test@^1.59.1":
+  version "1.59.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.59.1.tgz#5c4d38eac84a61527af466602ae20277685a02d6"
+  integrity sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==
+  dependencies:
+    playwright "1.59.1"
+
+"@rolldown/binding-android-arm64@1.0.0-rc.17":
+  version "1.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz#0a502a88c39d0ffa81aa30b561dade6f6217dcc5"
+  integrity sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==
+
+"@rolldown/binding-darwin-arm64@1.0.0-rc.17":
+  version "1.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz#8b7f05ac9000ab19161a79a0346b1b64a1bc7ba3"
+  integrity sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==
+
+"@rolldown/binding-darwin-x64@1.0.0-rc.17":
+  version "1.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz#f8b465b3a4e992053890b162f1ae19e4f1719a6a"
+  integrity sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==
+
+"@rolldown/binding-freebsd-x64@1.0.0-rc.17":
+  version "1.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz#a8281e14fa9c243fe22dc2d0e54900e66b31935e"
+  integrity sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==
+
+"@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17":
+  version "1.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz#cd29cf869ddd4fac8d6929abf94b91ddb0494650"
+  integrity sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==
+
+"@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17":
+  version "1.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz#91c331236ec3728366218d61a62f0bd226546c6c"
+  integrity sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==
+
+"@rolldown/binding-linux-arm64-musl@1.0.0-rc.17":
+  version "1.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz#80108957db752e7826836e22240e56b8140e9684"
+  integrity sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==
+
+"@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17":
+  version "1.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz#1dce51148cbc6bab3c3f9157b5323d2a31aac924"
+  integrity sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==
+
+"@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17":
+  version "1.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz#d4a0d2e01d8d441e4ac3af3fa68eec17a7d0e9cd"
+  integrity sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==
+
+"@rolldown/binding-linux-x64-gnu@1.0.0-rc.17":
+  version "1.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz#0ac8b3139cefeea798ad147f30ea70572b133af1"
+  integrity sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==
+
+"@rolldown/binding-linux-x64-musl@1.0.0-rc.17":
+  version "1.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz#2af61bee087571728f58f1c47734bbbd41dd7050"
+  integrity sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==
+
+"@rolldown/binding-openharmony-arm64@1.0.0-rc.17":
+  version "1.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz#56c1afbf6c592819abf47b4a983987dc288b30c1"
+  integrity sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==
+
+"@rolldown/binding-wasm32-wasi@1.0.0-rc.17":
+  version "1.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz#5d112ff4dd0d268a60fb4e0eb3077e3ea2531f0d"
+  integrity sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==
+  dependencies:
+    "@emnapi/core" "1.10.0"
+    "@emnapi/runtime" "1.10.0"
+    "@napi-rs/wasm-runtime" "^1.1.4"
+
+"@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17":
+  version "1.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz#5125a85222d64a543201d28e16a395cc45bf4d17"
+  integrity sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==
+
+"@rolldown/binding-win32-x64-msvc@1.0.0-rc.17":
+  version "1.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz#fc6b78e759a0bb2054b5c0a3489da12b2cae54b4"
+  integrity sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==
+
+"@rolldown/pluginutils@1.0.0-rc.17":
+  version "1.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz#a89b30833fb628bc834fe2e89fea93a2da9fa69a"
+  integrity sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==
+
 "@sindresorhus/is@^4.0.0":
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f"
   integrity sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==
+
+"@standard-schema/spec@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.1.0.tgz#a79b55dbaf8604812f52d140b2c9ab41bc150bb8"
+  integrity sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==
 
 "@szmarczak/http-timer@^4.0.5":
   version "4.0.6"
@@ -316,6 +508,13 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
+"@tybys/wasm-util@^0.10.1":
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.2.tgz#12b3a1b33db1f9cad4ddff1f604ab7dd00bf464e"
+  integrity sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==
+  dependencies:
+    tslib "^2.4.0"
+
 "@types/cacheable-request@^6.0.1":
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/@types/cacheable-request/-/cacheable-request-6.0.3.tgz#a430b3260466ca7b5ca5bfd735693b36e7a9d183"
@@ -326,12 +525,25 @@
     "@types/node" "*"
     "@types/responselike" "^1.0.0"
 
+"@types/chai@^5.2.2":
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-5.2.3.tgz#8e9cd9e1c3581fa6b341a5aed5588eb285be0b4a"
+  integrity sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==
+  dependencies:
+    "@types/deep-eql" "*"
+    assertion-error "^2.0.1"
+
 "@types/debug@^4.1.6":
   version "4.1.7"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
   integrity sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==
   dependencies:
     "@types/ms" "*"
+
+"@types/deep-eql@*":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/deep-eql/-/deep-eql-4.0.2.tgz#334311971d3a07121e7eb91b684a605e7eea9cbd"
+  integrity sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==
 
 "@types/ejs@^3.1.0":
   version "3.1.1"
@@ -363,6 +575,11 @@
   version "0.0.51"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.51.tgz#cfd70924a25a3fd32b218e5e420e6897e1ac4f40"
   integrity sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==
+
+"@types/estree@^1.0.0":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
+  integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
 
 "@types/fs-extra@9.0.13", "@types/fs-extra@^9.0.11":
   version "9.0.13"
@@ -583,6 +800,82 @@
   dependencies:
     "@typescript-eslint/types" "5.28.0"
     eslint-visitor-keys "^3.3.0"
+
+"@vitest/coverage-v8@^4.1.5":
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz#26bbdbebecd66be77fa1b63a9ed985dd86a3ba85"
+  integrity sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==
+  dependencies:
+    "@bcoe/v8-coverage" "^1.0.2"
+    "@vitest/utils" "4.1.5"
+    ast-v8-to-istanbul "^1.0.0"
+    istanbul-lib-coverage "^3.2.2"
+    istanbul-lib-report "^3.0.1"
+    istanbul-reports "^3.2.0"
+    magicast "^0.5.2"
+    obug "^2.1.1"
+    std-env "^4.0.0-rc.1"
+    tinyrainbow "^3.1.0"
+
+"@vitest/expect@4.1.5":
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-4.1.5.tgz#5caab19535cfb04fbc37087c5608d46e74dc9292"
+  integrity sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==
+  dependencies:
+    "@standard-schema/spec" "^1.1.0"
+    "@types/chai" "^5.2.2"
+    "@vitest/spy" "4.1.5"
+    "@vitest/utils" "4.1.5"
+    chai "^6.2.2"
+    tinyrainbow "^3.1.0"
+
+"@vitest/mocker@4.1.5":
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-4.1.5.tgz#9d5791733e4866cfb8af2d48ca371b127e7d2e93"
+  integrity sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==
+  dependencies:
+    "@vitest/spy" "4.1.5"
+    estree-walker "^3.0.3"
+    magic-string "^0.30.21"
+
+"@vitest/pretty-format@4.1.5":
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-4.1.5.tgz#4c13d77a77e2931e44db95522ed5700bcf0570d4"
+  integrity sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==
+  dependencies:
+    tinyrainbow "^3.1.0"
+
+"@vitest/runner@4.1.5":
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-4.1.5.tgz#a14dd2d2f48603f906dd52304a10c7fc623bb1de"
+  integrity sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==
+  dependencies:
+    "@vitest/utils" "4.1.5"
+    pathe "^2.0.3"
+
+"@vitest/snapshot@4.1.5":
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-4.1.5.tgz#d07970d1448190ee5a258db6ab79c65b8018c13b"
+  integrity sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==
+  dependencies:
+    "@vitest/pretty-format" "4.1.5"
+    "@vitest/utils" "4.1.5"
+    magic-string "^0.30.21"
+    pathe "^2.0.3"
+
+"@vitest/spy@4.1.5":
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-4.1.5.tgz#fa7858ffab746fa9ac29496e626f5a0caf9a5a7f"
+  integrity sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==
+
+"@vitest/utils@4.1.5":
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-4.1.5.tgz#20d6a6ae651a0dd33f945548921698d49701fa43"
+  integrity sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==
+  dependencies:
+    "@vitest/pretty-format" "4.1.5"
+    convert-source-map "^2.0.0"
+    tinyrainbow "^3.1.0"
 
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
@@ -904,6 +1197,20 @@ assert-plus@^1.0.0:
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==
 
+assertion-error@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
+  integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
+
+ast-v8-to-istanbul@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz#d1e8bfc79fa9c452972ff91897633bda4e5e7577"
+  integrity sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.31"
+    estree-walker "^3.0.3"
+    js-tokens "^10.0.0"
+
 astral-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
@@ -991,7 +1298,7 @@ brace-expansion@^2.0.1:
   dependencies:
     balanced-match "^1.0.0"
 
-braces@^3.0.2:
+braces@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
   integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
@@ -1125,6 +1432,11 @@ caniuse-lite@^1.0.30001449:
   version "1.0.30001450"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001450.tgz#022225b91200589196b814b51b1bbe45144cf74f"
   integrity sha512-qMBmvmQmFXaSxexkjjfMvD5rnDL0+m+dUMZKoDYsGG8iZN29RuYh9eRoMvKsT6uMAWlyUUGDEQGJJYjzCIO9ew==
+
+chai@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-6.2.2.tgz#ae41b52c9aca87734505362717f3255facda360e"
+  integrity sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==
 
 chalk@^2.0.0:
   version "2.4.2"
@@ -1270,6 +1582,11 @@ config-file-ts@^0.2.4:
     glob "^7.1.6"
     typescript "^4.0.2"
 
+convert-source-map@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
+  integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
+
 core-util-is@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -1397,6 +1714,11 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
+detect-libc@^2.0.3:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
+  integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
+
 detect-node@^2.0.4:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
@@ -1518,6 +1840,13 @@ electron-notarize@^1.2.2:
   dependencies:
     debug "^4.1.1"
     fs-extra "^9.0.1"
+
+electron-playwright-helpers@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/electron-playwright-helpers/-/electron-playwright-helpers-2.1.0.tgz#bafda622b236a53cdcfb7e8d62f3d62550fdbfce"
+  integrity sha512-aQOefS1irz/Ou6IYuTE34ZLmIKVHKoTGUwkVuwu2P5iguuMTLtsg6CFImsWu0cabRPVZ1NgEpcGPumFZNDdrqA==
+  dependencies:
+    "@electron/asar" "^3.2.4"
 
 electron-publish@24.8.1:
   version "24.8.1"
@@ -1641,6 +1970,11 @@ es-module-lexer@^0.9.0:
   version "0.9.3"
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.9.3.tgz#6f13db00cc38417137daf74366f535c8eb438f19"
   integrity sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==
+
+es-module-lexer@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-2.1.0.tgz#1dfcbb5ea3bbfb63f28e1fc3676c3676d1c9624c"
+  integrity sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==
 
 es-set-tostringtag@^2.0.1:
   version "2.0.1"
@@ -1826,6 +2160,13 @@ estraverse@^5.1.0, estraverse@^5.2.0, estraverse@^5.3.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
 
+estree-walker@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.3.tgz#67c3e549ec402a487b4fc193d1953a524752340d"
+  integrity sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==
+  dependencies:
+    "@types/estree" "^1.0.0"
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -1853,6 +2194,11 @@ exenv-es6@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/exenv-es6/-/exenv-es6-1.1.1.tgz#80b7a8c5af24d53331f755bac07e84abb1f6de67"
   integrity sha512-vlVu3N8d6yEMpMsEm+7sUBAI81aqYYuEvfK0jNqmdb/OPXzzH7QWDDnVjMvDSY47JdHEqx/dfC/q8WkfoTmpGQ==
+
+expect-type@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.3.0.tgz#0d58ed361877a31bbc4dd6cf71bbfef7faf6bd68"
+  integrity sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==
 
 extract-zip@^2.0.1:
   version "2.0.1"
@@ -1912,12 +2258,22 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
-fast-xml-parser@^4.2.5:
-  version "4.2.5"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz#a6747a09296a6cb34f2ae634019bf1738f3b421f"
-  integrity sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==
+fast-xml-builder@^1.1.7:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.1.8.tgz#7bbc0c3957587f3c44d13c10fa1fdf8d4bcc328b"
+  integrity sha512-sDVBc2gg8pSKvcbE8rBmOyjSGQf0AdsbqvHeIOv3D/uYNoV4eCReQXyDF8Pdv8+m1FHazACypSz2hR7O2S1LLw==
   dependencies:
-    strnum "^1.0.5"
+    path-expression-matcher "^1.1.3"
+
+fast-xml-parser@^5.7.0:
+  version "5.7.3"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz#309b04b08d835defc62ab657a0bb340c0e0fbe6a"
+  integrity sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==
+  dependencies:
+    "@nodable/entities" "^2.1.0"
+    fast-xml-builder "^1.1.7"
+    path-expression-matcher "^1.5.0"
+    strnum "^2.2.3"
 
 fastest-levenshtein@^1.0.12, fastest-levenshtein@^1.0.16:
   version "1.0.16"
@@ -1937,6 +2293,11 @@ fd-slicer@~1.1.0:
   integrity sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==
   dependencies:
     pend "~1.2.0"
+
+fdir@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
+  integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
@@ -2059,6 +2420,16 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
+fsevents@~2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -2322,6 +2693,11 @@ hosted-git-info@^4.0.1, hosted-git-info@^4.1.0:
   integrity sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==
   dependencies:
     lru-cache "^6.0.0"
+
+html-escaper@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
+  integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
 html-tags@^3.3.1:
   version "3.3.1"
@@ -2646,6 +3022,28 @@ isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==
 
+istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz#2d166c4b0644d43a39f04bf6c2edd1e585f31756"
+  integrity sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==
+
+istanbul-lib-report@^3.0.0, istanbul-lib-report@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz#908305bac9a5bd175ac6a74489eafd0fc2445a7d"
+  integrity sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==
+  dependencies:
+    istanbul-lib-coverage "^3.0.0"
+    make-dir "^4.0.0"
+    supports-color "^7.1.0"
+
+istanbul-reports@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.2.0.tgz#cb4535162b5784aa623cee21a7252cf2c807ac93"
+  integrity sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==
+  dependencies:
+    html-escaper "^2.0.0"
+    istanbul-lib-report "^3.0.0"
+
 istextorbinary@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/istextorbinary/-/istextorbinary-6.0.0.tgz#bc6e7541006bc203feffe16628d0a72893b2ad54"
@@ -2672,6 +3070,11 @@ jest-worker@^27.4.5:
     "@types/node" "*"
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
+
+js-tokens@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-10.0.0.tgz#dffe7599b4a8bb7fe30aff8d0235234dffb79831"
+  integrity sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -2774,6 +3177,80 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
+lightningcss-android-arm64@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz#f033885116dfefd9c6f54787523e3514b61e1968"
+  integrity sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==
+
+lightningcss-darwin-arm64@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz#50b71871b01c8199584b649e292547faea7af9b5"
+  integrity sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==
+
+lightningcss-darwin-x64@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz#35f3e97332d130b9ca181e11b568ded6aebc6d5e"
+  integrity sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==
+
+lightningcss-freebsd-x64@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz#9777a76472b64ed6ff94342ad64c7bafd794a575"
+  integrity sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==
+
+lightningcss-linux-arm-gnueabihf@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz#13ae652e1ab73b9135d7b7da172f666c410ad53d"
+  integrity sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==
+
+lightningcss-linux-arm64-gnu@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz#417858795a94592f680123a1b1f9da8a0e1ef335"
+  integrity sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==
+
+lightningcss-linux-arm64-musl@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz#6be36692e810b718040802fd809623cffe732133"
+  integrity sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==
+
+lightningcss-linux-x64-gnu@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz#0b7803af4eb21cfd38dd39fe2abbb53c7dd091f6"
+  integrity sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==
+
+lightningcss-linux-x64-musl@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz#88dc8ba865ddddb1ac5ef04b0f161804418c163b"
+  integrity sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==
+
+lightningcss-win32-arm64-msvc@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz#4f30ba3fa5e925f5b79f945e8cc0d176c3b1ab38"
+  integrity sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==
+
+lightningcss-win32-x64-msvc@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz#141aa5605645064928902bb4af045fa7d9f4220a"
+  integrity sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==
+
+lightningcss@^1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/lightningcss/-/lightningcss-1.32.0.tgz#b85aae96486dcb1bf49a7c8571221273f4f1e4a9"
+  integrity sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==
+  dependencies:
+    detect-libc "^2.0.3"
+  optionalDependencies:
+    lightningcss-android-arm64 "1.32.0"
+    lightningcss-darwin-arm64 "1.32.0"
+    lightningcss-darwin-x64 "1.32.0"
+    lightningcss-freebsd-x64 "1.32.0"
+    lightningcss-linux-arm-gnueabihf "1.32.0"
+    lightningcss-linux-arm64-gnu "1.32.0"
+    lightningcss-linux-arm64-musl "1.32.0"
+    lightningcss-linux-x64-gnu "1.32.0"
+    lightningcss-linux-x64-musl "1.32.0"
+    lightningcss-win32-arm64-msvc "1.32.0"
+    lightningcss-win32-x64-msvc "1.32.0"
+
 lines-and-columns@^1.1.6:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
@@ -2849,6 +3326,29 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+magic-string@^0.30.21:
+  version "0.30.21"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
+  integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.5"
+
+magicast@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/magicast/-/magicast-0.5.2.tgz#70cea9df729c164485049ea5df85a390281dfb9d"
+  integrity sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==
+  dependencies:
+    "@babel/parser" "^7.29.0"
+    "@babel/types" "^7.29.0"
+    source-map-js "^1.2.1"
+
+make-dir@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-4.0.0.tgz#c3c2307a771277cd9638305f915c29ae741b614e"
+  integrity sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==
+  dependencies:
+    semver "^7.5.3"
+
 map-obj@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
@@ -2921,12 +3421,12 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-micromatch@^4.0.4, micromatch@^4.0.5:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
-  integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
+micromatch@^4.0.4, micromatch@^4.0.5, micromatch@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
+  integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
   dependencies:
-    braces "^3.0.2"
+    braces "^3.0.3"
     picomatch "^2.3.1"
 
 mime-db@1.52.0:
@@ -3037,6 +3537,11 @@ ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+nanoid@^3.3.11:
+  version "3.3.12"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.12.tgz#ab3d912e217a6d0a514f00a72a16543a28982c05"
+  integrity sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==
 
 nanoid@^3.3.6:
   version "3.3.6"
@@ -3187,6 +3692,11 @@ object.values@^1.1.5:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
 
+obug@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/obug/-/obug-2.1.1.tgz#2cba74ff241beb77d63055ddf4cd1e9f90b538be"
+  integrity sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==
+
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -3271,6 +3781,11 @@ path-exists@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
+path-expression-matcher@^1.1.3, path-expression-matcher@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz#3b98545dc88ffebb593e2d8458d0929da9275f4a"
+  integrity sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==
+
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
@@ -3296,6 +3811,11 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+pathe@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
+  integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
+
 pend@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
@@ -3306,10 +3826,20 @@ picocolors@^1.0.0:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
+picocolors@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
+  integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
+
 picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+picomatch@^4.0.3, picomatch@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
+  integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
 
 pinkie-promise@^2.0.0:
   version "2.0.1"
@@ -3329,6 +3859,20 @@ pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+playwright-core@1.59.1:
+  version "1.59.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.59.1.tgz#d8a2b28bcb8f2bd08ef3df93b02ae83c813244b2"
+  integrity sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==
+
+playwright@1.59.1:
+  version "1.59.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.59.1.tgz#f7b0ca61637ae25264cec370df671bbe1f368a4a"
+  integrity sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==
+  dependencies:
+    playwright-core "1.59.1"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 plist@^3.0.4:
   version "3.0.6"
@@ -3378,6 +3922,15 @@ postcss@^8.4.24:
     nanoid "^3.3.6"
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
+
+postcss@^8.5.10:
+  version "8.5.14"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.14.tgz#a66c2d7808fadf69ebb5b84a03f8bafd76c4919c"
+  integrity sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==
+  dependencies:
+    nanoid "^3.3.11"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -3681,6 +4234,30 @@ roarr@^2.15.3:
     semver-compare "^1.0.0"
     sprintf-js "^1.1.2"
 
+rolldown@1.0.0-rc.17:
+  version "1.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/rolldown/-/rolldown-1.0.0-rc.17.tgz#c524fc22f6bb37b5588aec862ab1ee11382610f3"
+  integrity sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==
+  dependencies:
+    "@oxc-project/types" "=0.127.0"
+    "@rolldown/pluginutils" "1.0.0-rc.17"
+  optionalDependencies:
+    "@rolldown/binding-android-arm64" "1.0.0-rc.17"
+    "@rolldown/binding-darwin-arm64" "1.0.0-rc.17"
+    "@rolldown/binding-darwin-x64" "1.0.0-rc.17"
+    "@rolldown/binding-freebsd-x64" "1.0.0-rc.17"
+    "@rolldown/binding-linux-arm-gnueabihf" "1.0.0-rc.17"
+    "@rolldown/binding-linux-arm64-gnu" "1.0.0-rc.17"
+    "@rolldown/binding-linux-arm64-musl" "1.0.0-rc.17"
+    "@rolldown/binding-linux-ppc64-gnu" "1.0.0-rc.17"
+    "@rolldown/binding-linux-s390x-gnu" "1.0.0-rc.17"
+    "@rolldown/binding-linux-x64-gnu" "1.0.0-rc.17"
+    "@rolldown/binding-linux-x64-musl" "1.0.0-rc.17"
+    "@rolldown/binding-openharmony-arm64" "1.0.0-rc.17"
+    "@rolldown/binding-wasm32-wasi" "1.0.0-rc.17"
+    "@rolldown/binding-win32-arm64-msvc" "1.0.0-rc.17"
+    "@rolldown/binding-win32-x64-msvc" "1.0.0-rc.17"
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -3757,10 +4334,10 @@ serialize-error@^7.0.1:
   dependencies:
     type-fest "^0.13.1"
 
-serialize-javascript@^6.0.0:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.1.tgz#b206efb27c3da0b0ab6b52f48d170b7996458e5c"
-  integrity sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==
+serialize-javascript@^6.0.0, serialize-javascript@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
+  integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==
   dependencies:
     randombytes "^2.1.0"
 
@@ -3825,6 +4402,11 @@ side-channel@^1.0.4:
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
 
+siginfo@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
+  integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
+
 signal-exit@^3.0.0:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
@@ -3880,6 +4462,11 @@ source-map-js@^1.0.1, source-map-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
+source-map-js@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
+  integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
+
 source-map-support@^0.5.19, source-map-support@~0.5.20:
   version "0.5.21"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
@@ -3924,10 +4511,20 @@ sprintf-js@^1.1.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.2.tgz#da1765262bf8c0f571749f2ad6c26300207ae673"
   integrity sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==
 
+stackback@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
+  integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
+
 stat-mode@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stat-mode/-/stat-mode-1.0.0.tgz#68b55cb61ea639ff57136f36b216a291800d1465"
   integrity sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==
+
+std-env@^4.0.0-rc.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-4.1.0.tgz#45899abc590d86d682e87f0acd1033a75084cd3f"
+  integrity sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==
 
 string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
@@ -4008,10 +4605,10 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-strnum@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.0.5.tgz#5c4e829fe15ad4ff0d20c3db5ac97b73c9b072db"
-  integrity sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==
+strnum@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.2.3.tgz#0119fce02749a11bb126a4d686ac5dbdf6e57586"
+  integrity sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==
 
 style-search@^0.1.0:
   version "0.1.0"
@@ -4206,6 +4803,29 @@ textextensions@^5.14.0:
   resolved "https://registry.yarnpkg.com/textextensions/-/textextensions-5.16.0.tgz#57dd60c305019bba321e848b1fdf0f99bfa59ec1"
   integrity sha512-7D/r3s6uPZyU//MCYrX6I14nzauDwJ5CxazouuRGNuvSCihW87ufN6VLoROLCrHg6FblLuJrT6N2BVaPVzqElw==
 
+tinybench@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
+  integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
+
+tinyexec@^1.0.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-1.1.2.tgz#11feef204b706d4668ca4013db29f3bd64f5c4dc"
+  integrity sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==
+
+tinyglobby@^0.2.15, tinyglobby@^0.2.16:
+  version "0.2.16"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.16.tgz#1c3b7eb953fce42b226bc5a1ee06428281aff3d6"
+  integrity sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==
+  dependencies:
+    fdir "^6.5.0"
+    picomatch "^4.0.4"
+
+tinyrainbow@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-3.1.0.tgz#1d8a623893f95cf0a2ddb9e5d11150e191409421"
+  integrity sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==
+
 tmp-promise@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-3.0.3.tgz#60a1a1cc98c988674fcbfd23b6e3367bdeac4ce7"
@@ -4253,6 +4873,11 @@ tslib@^1.13.0, tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.4.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tsutils@^3.21.0:
   version "3.21.0"
@@ -4396,6 +5021,45 @@ verror@^1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+"vite@^6.0.0 || ^7.0.0 || ^8.0.0":
+  version "8.0.10"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-8.0.10.tgz#fb31868526ec874101fac084172a2cdc6776319b"
+  integrity sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==
+  dependencies:
+    lightningcss "^1.32.0"
+    picomatch "^4.0.4"
+    postcss "^8.5.10"
+    rolldown "1.0.0-rc.17"
+    tinyglobby "^0.2.16"
+  optionalDependencies:
+    fsevents "~2.3.3"
+
+vitest@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-4.1.5.tgz#cda189c0cd9dd1c920be477c0f371b64ec14782a"
+  integrity sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==
+  dependencies:
+    "@vitest/expect" "4.1.5"
+    "@vitest/mocker" "4.1.5"
+    "@vitest/pretty-format" "4.1.5"
+    "@vitest/runner" "4.1.5"
+    "@vitest/snapshot" "4.1.5"
+    "@vitest/spy" "4.1.5"
+    "@vitest/utils" "4.1.5"
+    es-module-lexer "^2.0.0"
+    expect-type "^1.3.0"
+    magic-string "^0.30.21"
+    obug "^2.1.1"
+    pathe "^2.0.3"
+    picomatch "^4.0.3"
+    std-env "^4.0.0-rc.1"
+    tinybench "^2.9.0"
+    tinyexec "^1.0.2"
+    tinyglobby "^0.2.15"
+    tinyrainbow "^3.1.0"
+    vite "^6.0.0 || ^7.0.0 || ^8.0.0"
+    why-is-node-running "^2.3.0"
+
 watchpack@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.4.0.tgz#fa33032374962c78113f93c7f2fb4c54c9862a5d"
@@ -4522,6 +5186,14 @@ which@^2.0.1, which@^2.0.2:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+why-is-node-running@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz#a3f69a97107f494b3cdc3bdddd883a7d65cebf04"
+  integrity sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==
+  dependencies:
+    siginfo "^2.0.0"
+    stackback "0.0.2"
 
 wildcard@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -110,6 +110,11 @@
     glob "^7.1.6"
     minimatch "^3.0.4"
 
+"@electron/fuses@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@electron/fuses/-/fuses-2.1.1.tgz#8b15eb91dcde51e20a2b3cefb5fb11adb43d237a"
+  integrity sha512-38ho27/mtUV/LpsZ1LCDJUomKBBSUZDk/qBH4FNNtoN5fmnkmWDcIp5pm1Kv3InqhRjKZKs7Jzx+wWZNMArHrA==
+
 "@electron/get@^2.0.0":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@electron/get/-/get-2.0.2.tgz#ae2a967b22075e9c25aaf00d5941cd79c21efd7e"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1077,6 +1077,13 @@ ajv@^8.0.1:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
+ansi-escapes@^7.0.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-7.3.0.tgz#5395bb74b2150a4a1d6e3c2565f4aeca78d28627"
+  integrity sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==
+  dependencies:
+    environment "^1.0.0"
+
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
@@ -1086,6 +1093,11 @@ ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
+ansi-regex@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.2.2.tgz#60216eea464d864597ce2832000738a0589650c1"
+  integrity sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==
 
 ansi-styles@^3.2.1:
   version "3.2.1"
@@ -1100,6 +1112,11 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
+
+ansi-styles@^6.2.1, ansi-styles@^6.2.3:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.3.tgz#c044d5dcc521a076413472597a1acb1f103c4041"
+  integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
 
 app-builder-bin@4.0.0:
   version "4.0.0"
@@ -1475,6 +1492,13 @@ ci-info@^3.2.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.7.1.tgz#708a6cdae38915d597afdf3b145f2f8e1ff55f3f"
   integrity sha512-4jYS4MOAaCIStSRwiuxc4B8MYhIe676yO1sYGzARnjXkWpmzZMMYxY6zu8WYWDhSuth5zhrQ1rhNSibyyvv4/w==
 
+cli-cursor@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-5.0.0.tgz#24a4831ecf5a6b01ddeb32fb71a4b2088b0dce38"
+  integrity sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==
+  dependencies:
+    restore-cursor "^5.0.0"
+
 cli-truncate@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-2.1.0.tgz#c39e28bf05edcde5be3b98992a22deed5a2b93c7"
@@ -1482,6 +1506,14 @@ cli-truncate@^2.1.0:
   dependencies:
     slice-ansi "^3.0.0"
     string-width "^4.2.0"
+
+cli-truncate@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-5.2.0.tgz#c8e72aaca8339c773d128c36e0a17c6315b694eb"
+  integrity sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==
+  dependencies:
+    slice-ansi "^8.0.0"
+    string-width "^8.2.0"
 
 cliui@^8.0.1:
   version "8.0.1"
@@ -1542,12 +1574,22 @@ colorette@^2.0.14:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.19.tgz#cdf044f47ad41a0f4b56b3a0d5b4e6e1a2d5a798"
   integrity sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==
 
+colorette@^2.0.20:
+  version "2.0.20"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
+  integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
+
 combined-stream@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+commander@^14.0.3:
+  version "14.0.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-14.0.3.tgz#425d79b48f9af82fcd9e4fc1ea8af6c5ec07bbc2"
+  integrity sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==
 
 commander@^2.20.0:
   version "2.20.3"
@@ -1655,6 +1697,13 @@ debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
+
+debug@^2.2.0:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
 
 debuglog@^1.0.1:
   version "1.0.1"
@@ -1875,6 +1924,11 @@ electron@^27.0.2:
     "@types/node" "^18.11.18"
     extract-zip "^2.0.1"
 
+emoji-regex@^10.3.0:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.6.0.tgz#bf3d6e8f7f8fd22a65d9703475bc0147357a6b0d"
+  integrity sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==
+
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
@@ -1909,6 +1963,11 @@ envinfo@^7.7.3:
   version "7.8.1"
   resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.8.1.tgz#06377e3e5f4d379fea7ac592d5ad8927e0c4d475"
   integrity sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==
+
+environment@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/environment/-/environment-1.1.0.tgz#8e86c66b180f363c7ab311787e0259665f45a9f1"
+  integrity sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==
 
 err-code@^2.0.2:
   version "2.0.3"
@@ -2171,6 +2230,11 @@ esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
+
+eventemitter3@^5.0.1:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.4.tgz#a86d66170433712dde814707ac52b5271ceb1feb"
+  integrity sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==
 
 events@^3.2.0:
   version "3.3.0"
@@ -2466,6 +2530,11 @@ get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
+get-east-asian-width@^1.0.0, get-east-asian-width@^1.3.1, get-east-asian-width@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz#ce7008fe345edcf5497a6f557cfa54bc318a9ce7"
+  integrity sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==
+
 get-intrinsic@^1.0.2, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.0.tgz#7ad1dc0535f3a2904bba075772763e5051f6d05f"
@@ -2734,6 +2803,11 @@ https-proxy-agent@^5.0.1:
     agent-base "6"
     debug "4"
 
+husky@^9.1.7:
+  version "9.1.7"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-9.1.7.tgz#d46a38035d101b46a70456a850ff4201344c0b2d"
+  integrity sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==
+
 iconv-corefoundation@^1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/iconv-corefoundation/-/iconv-corefoundation-1.1.7.tgz#31065e6ab2c9272154c8b0821151e2c88f1b002a"
@@ -2903,6 +2977,13 @@ is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
+
+is-fullwidth-code-point@^5.0.0, is-fullwidth-code-point@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz#046b2a6d4f6b156b2233d3207d4b5a9783999b98"
+  integrity sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==
+  dependencies:
+    get-east-asian-width "^1.3.1"
 
 is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
   version "4.0.3"
@@ -3256,6 +3337,30 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
+lint-staged@^16.4.0:
+  version "16.4.0"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-16.4.0.tgz#a00b0e3abff59239cef6d7d9341e8f8473308e23"
+  integrity sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==
+  dependencies:
+    commander "^14.0.3"
+    listr2 "^9.0.5"
+    picomatch "^4.0.3"
+    string-argv "^0.3.2"
+    tinyexec "^1.0.4"
+    yaml "^2.8.2"
+
+listr2@^9.0.5:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/listr2/-/listr2-9.0.5.tgz#92df7c4416a6da630eb9ef46da469b70de97b316"
+  integrity sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==
+  dependencies:
+    cli-truncate "^5.0.0"
+    colorette "^2.0.20"
+    eventemitter3 "^5.0.1"
+    log-update "^6.1.0"
+    rfdc "^1.4.1"
+    wrap-ansi "^9.0.0"
+
 loader-runner@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.3.0.tgz#c1b4a163b99f614830353b16755e7149ac2314e1"
@@ -3298,6 +3403,17 @@ lodash@^4.17.15:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+log-update@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-6.1.0.tgz#1a04ff38166f94647ae1af562f4bd6a15b1b7cd4"
+  integrity sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==
+  dependencies:
+    ansi-escapes "^7.0.0"
+    cli-cursor "^5.0.0"
+    slice-ansi "^7.1.0"
+    strip-ansi "^7.1.0"
+    wrap-ansi "^9.0.0"
 
 loose-envify@^1.4.0:
   version "1.4.0"
@@ -3446,6 +3562,11 @@ mime@^2.5.2:
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
   integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
 
+mimic-function@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/mimic-function/-/mimic-function-5.0.1.tgz#acbe2b3349f99b9deaca7fb70e48b83e94e67076"
+  integrity sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==
+
 mimic-response@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
@@ -3527,6 +3648,11 @@ mkdirp@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+  integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
 
 ms@2.1.2:
   version "2.1.2"
@@ -3703,6 +3829,13 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
   dependencies:
     wrappy "1"
+
+onetime@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-7.0.0.tgz#9f16c92d8c9ef5120e3acd9dd9957cceecc1ab60"
+  integrity sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==
+  dependencies:
+    mimic-function "^5.0.0"
 
 optionator@^0.9.1:
   version "0.9.1"
@@ -4205,6 +4338,14 @@ responselike@^2.0.0:
   dependencies:
     lowercase-keys "^2.0.0"
 
+restore-cursor@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-5.1.0.tgz#0766d95699efacb14150993f55baf0953ea1ebe7"
+  integrity sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==
+  dependencies:
+    onetime "^7.0.0"
+    signal-exit "^4.1.0"
+
 retry@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
@@ -4214,6 +4355,11 @@ reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
+rfdc@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.4.1.tgz#778f76c4fb731d93414e8f925fbecf64cce7f6ca"
+  integrity sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==
 
 rimraf@^3.0.0, rimraf@^3.0.2, rimraf@~3.0.0:
   version "3.0.2"
@@ -4417,6 +4563,11 @@ signal-exit@^4.0.1:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.0.2.tgz#ff55bb1d9ff2114c13b400688fa544ac63c36967"
   integrity sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==
 
+signal-exit@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
+  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
+
 simple-update-notifier@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz#d70b92bdab7d6d90dfd73931195a30b6e3d7cebb"
@@ -4446,6 +4597,22 @@ slice-ansi@^4.0.0:
     ansi-styles "^4.0.0"
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
+
+slice-ansi@^7.1.0:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-7.1.2.tgz#adf7be70aa6d72162d907cd0e6d5c11f507b5403"
+  integrity sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==
+  dependencies:
+    ansi-styles "^6.2.1"
+    is-fullwidth-code-point "^5.0.0"
+
+slice-ansi@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-8.0.0.tgz#22d0b66d18bc5c57f488bfcf36cbde3bef731537"
+  integrity sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==
+  dependencies:
+    ansi-styles "^6.2.3"
+    is-fullwidth-code-point "^5.1.0"
 
 smart-buffer@^4.0.2:
   version "4.2.0"
@@ -4526,6 +4693,11 @@ std-env@^4.0.0-rc.1:
   resolved "https://registry.yarnpkg.com/std-env/-/std-env-4.1.0.tgz#45899abc590d86d682e87f0acd1033a75084cd3f"
   integrity sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==
 
+string-argv@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
+  integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
+
 string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
@@ -4534,6 +4706,23 @@ string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
+
+string-width@^7.0.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-7.2.0.tgz#b5bb8e2165ce275d4d43476dd2700ad9091db6dc"
+  integrity sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==
+  dependencies:
+    emoji-regex "^10.3.0"
+    get-east-asian-width "^1.0.0"
+    strip-ansi "^7.1.0"
+
+string-width@^8.2.0:
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-8.2.1.tgz#165089cfa527cc88fbc23dd73313f5e334af1ea1"
+  integrity sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==
+  dependencies:
+    get-east-asian-width "^1.5.0"
+    strip-ansi "^7.1.2"
 
 string.prototype.matchall@^4.0.6:
   version "4.0.8"
@@ -4580,6 +4769,13 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
     ansi-regex "^5.0.1"
+
+strip-ansi@^7.1.0, strip-ansi@^7.1.2:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.2.0.tgz#d22a269522836a627af8d04b5c3fd2c7fa3e32e3"
+  integrity sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==
+  dependencies:
+    ansi-regex "^6.2.2"
 
 strip-eof@^1.0.0:
   version "1.0.0"
@@ -4808,7 +5004,7 @@ tinybench@^2.9.0:
   resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
   integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
 
-tinyexec@^1.0.2:
+tinyexec@^1.0.2, tinyexec@^1.0.4:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-1.1.2.tgz#11feef204b706d4668ca4013db29f3bd64f5c4dc"
   integrity sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==
@@ -5173,7 +5369,7 @@ which-typed-array@^1.1.9:
     has-tostringtag "^1.0.0"
     is-typed-array "^1.1.10"
 
-which@^1.2.9, which@^1.3.1:
+which@^1.2.4, which@^1.2.9, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
@@ -5219,6 +5415,15 @@ wrap-ansi@^7.0.0:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
+wrap-ansi@^9.0.0:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-9.0.2.tgz#956832dea9494306e6d209eb871643bb873d7c98"
+  integrity sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==
+  dependencies:
+    ansi-styles "^6.2.1"
+    string-width "^7.0.0"
+    strip-ansi "^7.1.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -5237,6 +5442,14 @@ xmlbuilder@>=11.0.1, xmlbuilder@^15.1.1:
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-15.1.1.tgz#9dcdce49eea66d8d10b42cae94a79c3c8d0c2ec5"
   integrity sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==
 
+xvfb-maybe@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/xvfb-maybe/-/xvfb-maybe-0.2.1.tgz#ed8cb132957b7848b439984c66f010ea7f24361b"
+  integrity sha512-9IyRz3l6Qyhl6LvnGRF5jMPB4oBEepQnuzvVAFTynP6ACLLSevqigICJ9d/+ofl29m2daeaVBChnPYUnaeJ7yA==
+  dependencies:
+    debug "^2.2.0"
+    which "^1.2.4"
+
 y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
@@ -5251,6 +5464,11 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
+yaml@^2.8.2:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.4.tgz#4b5f411dd25f9544914d8673d4da7f29248e5e2e"
+  integrity sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==
 
 yargs-parser@^18.1.3:
   version "18.1.3"


### PR DESCRIPTION
Fixes #953.

`node-fetch` uses Node.js TLS which fails on incomplete certificate chains. `blog.jupyter.org` has served a broken chain since Jan 27 2026 — the leaf cert's issuer doesn't match the intermediate being sent. Node.js rejects it; Chromium handles it fine (AIA fetching / cached intermediates).

Replacing both `node-fetch` usages in the main process with `net.fetch` from Electron's `net` module, which uses the Chromium network stack. This also inherits system proxy settings.

**Changes:**
- `welcomeview.ts`: `net.fetch` for news feed; also adds `isArray` option to `XMLParser` for fast-xml-parser v5 compatibility (single `<item>` collapsed to object without it)
- `app.ts`: `net.fetch` for update check
- removes `node-fetch` and `@types/node-fetch` (no remaining usages)

**Testing:**
1. Cleared `newsList` in `app-data.json` to remove cache
2. Ran dev build with `node-fetch` — `FetchError: unable to verify the first certificate`, news section empty
3. Ran dev build with `net.fetch` — 10 articles loaded, no error
4. Build clean, 341 unit tests pass

Note: AI-assisted (Claude Code). Manually verified: reproduced bug and confirmed fix by running the dev build both ways and checking app-data.json cache state.