### PR TITLE
ci: cross-platform test matrix and CI hardening

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Build app
         run: yarn build
 
+      - name: Check preload bundle sizes
+        run: node scripts/check-bundle-size.js
+
       # --with-deps installs Linux apt packages; macOS/Windows handle deps natively
       - name: Install Playwright Chromium (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     name: 'E2E smoke (${{ matrix.os }})'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,6 +7,10 @@ on:
     branches: [ master ]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   e2e:
     name: 'E2E smoke (${{ matrix.os }})'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Type check
+        run: npx tsc --noEmit
+
       - name: Build app
         run: yarn build
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,8 +9,12 @@ on:
 
 jobs:
   e2e:
-    name: 'E2E smoke tests'
-    runs-on: ubuntu-latest
+    name: 'E2E smoke (${{ matrix.os }})'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 20
 
     steps:
@@ -27,10 +31,16 @@ jobs:
       - name: Build app
         run: yarn build
 
-      - name: Install Playwright Chromium + system deps
+      # --with-deps installs Linux apt packages; macOS/Windows handle deps natively
+      - name: Install Playwright Chromium (Linux)
+        if: runner.os == 'Linux'
         run: npx playwright install --with-deps chromium
 
-      # xvfb-maybe auto-detects headless Linux and wraps with xvfb-run
+      - name: Install Playwright Chromium (macOS/Windows)
+        if: runner.os != 'Linux'
+        run: npx playwright install chromium
+
+      # xvfb-maybe auto-detects headless Linux and wraps with xvfb-run; passes through on macOS/Windows
       - name: Run E2E tests
         run: yarn test:e2e
         env:
@@ -40,6 +50,6 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-test-results
+          name: e2e-test-results-${{ matrix.os }}
           path: test-results/
           retention-days: 7

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,9 +15,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# Default workflow-level permissions are minimal. The `publish` job that
+# uploads release assets overrides this at the job level.
+permissions:
+  contents: read
+
 jobs:
   test:
     name: 'Unit tests (${{ matrix.os }})'
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -44,6 +51,9 @@ jobs:
 
   publish:
     needs: test
+    # Needs write access to upload release assets and read draft/prerelease metadata.
+    permissions:
+      contents: write
     strategy:
       matrix:
         cfg:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,8 +11,12 @@ on:
 
 jobs:
   test:
-    name: 'Unit tests'
-    runs-on: ubuntu-latest
+    name: 'Unit tests (${{ matrix.os }})'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -23,6 +27,7 @@ jobs:
       - name: Run unit tests with coverage
         run: yarn test:unit:coverage
       - name: Upload coverage report
+        if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v4
         with:
           name: unit-coverage

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,8 @@ jobs:
           node-version: '20.x'
           cache: 'yarn'
       - run: yarn install --frozen-lockfile
+      - name: Type check
+        run: npx tsc --noEmit
       - name: Run unit tests with coverage
         run: yarn test:unit:coverage
       - name: Upload coverage report

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,12 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+# Cancel previous in-flight runs on the same PR; pushes to master queue
+# so a release-tag push is never aborted by a follow-up commit.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     name: 'Unit tests (${{ matrix.os }})'

--- a/dev.md
+++ b/dev.md
@@ -85,6 +85,18 @@ JupyterLab Desktop bundles JupyterLab front-end and a conda environment as Jupyt
 
   Application Installer will be created in `dist/JupyterLab.dmg` (macOS), `dist/JupyterLab.deb` (Debian, Ubuntu), `dist/JupyterLab.rpm` (Red Hat, Fedora) and `dist/JupyterLab-Setup.exe` (Windows) based on the platform
 
+## Automated test coverage
+
+CI runs the following on every push and PR to `master`:
+
+- **Unit tests** (`yarn test:unit:coverage`, Vitest): runs on Linux, macOS, and Windows in parallel via the matrix in `.github/workflows/publish.yml`. Coverage report is uploaded only from the Linux job to avoid duplicate artifacts.
+- **E2E smoke tests** (`yarn test:e2e`, Playwright + Electron): same 3-OS matrix in `.github/workflows/e2e.yml`. Linux uses `xvfb-maybe` for headless display; macOS and Windows run natively.
+- **Type check** (`npx tsc --noEmit`): explicit step before build in both workflows so type errors surface independent of the bundle/copy pipeline.
+- **Bundle size budget** (`scripts/check-bundle-size.js`): verifies each preload bundle stays under 30 KB after `yarn build`.
+- **Lint** (`yarn lint:check`): Prettier + ESLint, runs in the publish workflow.
+
+Failing one OS in the matrix does not cancel the others (`fail-fast: false`), so a platform-specific regression does not mask others.
+
 ## Review guidance
 
 Expected manual testing coverage depends on the PR, when pulling:

--- a/scripts/check-bundle-size.js
+++ b/scripts/check-bundle-size.js
@@ -1,0 +1,45 @@
+// Verify each bundled preload script stays under the size budget.
+// Cross-platform: Node-only, no shell utilities.
+
+const fs = require('fs');
+const path = require('path');
+
+const PRELOAD_DIR = path.join(__dirname, '..', 'build', 'out', 'main');
+const BUDGET_BYTES = 30 * 1024; // 30 KB per preload bundle
+
+function findPreloads(dir) {
+  const results = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...findPreloads(full));
+    } else if (entry.isFile() && entry.name === 'preload.js') {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+const preloads = findPreloads(PRELOAD_DIR);
+if (preloads.length === 0) {
+  console.error(
+    `No preload bundles found under ${PRELOAD_DIR}. Did you run yarn build?`
+  );
+  process.exit(1);
+}
+
+let failed = false;
+for (const file of preloads) {
+  const size = fs.statSync(file).size;
+  const rel = path.relative(process.cwd(), file);
+  const status = size > BUDGET_BYTES ? 'FAIL' : 'OK';
+  console.log(`${status}  ${size.toString().padStart(7)} bytes  ${rel}`);
+  if (size > BUDGET_BYTES) failed = true;
+}
+
+if (failed) {
+  console.error(
+    `\nBudget exceeded. Limit: ${BUDGET_BYTES} bytes per preload bundle.`
+  );
+  process.exit(1);
+}

--- a/test/e2e/smoke.test.ts
+++ b/test/e2e/smoke.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, _electron as electron } from '@playwright/test';
+import { _electron as electron, expect, test } from '@playwright/test';
 import { ElectronApplication } from '@playwright/test';
 import { stubAllDialogs } from 'electron-playwright-helpers';
 import { mkdtempSync, rmSync } from 'fs';

--- a/test/setup/electron-mock.ts
+++ b/test/setup/electron-mock.ts
@@ -51,7 +51,11 @@ vi.mock('electron', () => ({
   })),
   shell: { openExternal: vi.fn(), openPath: vi.fn() },
   nativeTheme: { shouldUseDarkColors: false },
-  screen: { getPrimaryDisplay: vi.fn(() => ({ workAreaSize: { width: 1920, height: 1080 } })) }
+  screen: {
+    getPrimaryDisplay: vi.fn(() => ({
+      workAreaSize: { width: 1920, height: 1080 }
+    }))
+  }
 }));
 
 vi.mock('electron-log', () => ({

--- a/test/unit/appdata.test.ts
+++ b/test/unit/appdata.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'fs';
 
 vi.mock('fs', async () => {
@@ -6,7 +6,9 @@ vi.mock('fs', async () => {
   return {
     ...actual,
     existsSync: vi.fn(() => false),
-    readFileSync: vi.fn(() => { throw new Error('ENOENT'); }),
+    readFileSync: vi.fn(() => {
+      throw new Error('ENOENT');
+    }),
     writeFileSync: vi.fn(),
     mkdirSync: vi.fn()
   };
@@ -15,8 +17,8 @@ vi.mock('fs', async () => {
 import {
   appData,
   ApplicationData,
-  IRecentSession,
-  IRecentRemoteURL
+  IRecentRemoteURL,
+  IRecentSession
 } from '../../../src/main/config/appdata';
 
 const mockFs = vi.mocked(fs);
@@ -166,7 +168,9 @@ describe('ApplicationData.addRemoteURLToRecents', () => {
   it('new entry gets a date close to now', () => {
     const before = Date.now();
     appData.addRemoteURLToRecents('https://example.com');
-    expect(appData.recentRemoteURLs[0].date.valueOf()).toBeGreaterThanOrEqual(before);
+    expect(appData.recentRemoteURLs[0].date.valueOf()).toBeGreaterThanOrEqual(
+      before
+    );
   });
 
   it('updates date of existing URL without duplicating', () => {
@@ -249,13 +253,21 @@ describe('ApplicationData.addSessionToRecents', () => {
   });
 
   it('re-adding existing session updates date without duplicating', async () => {
-    await appData.addSessionToRecents({ workingDirectory: '/a', filesToOpen: [] });
+    await appData.addSessionToRecents({
+      workingDirectory: '/a',
+      filesToOpen: []
+    });
     const before = appData.recentSessions[0].date.valueOf();
     // small delay so new Date() advances
     await new Promise(r => setTimeout(r, 5));
-    await appData.addSessionToRecents({ workingDirectory: '/a', filesToOpen: [] });
+    await appData.addSessionToRecents({
+      workingDirectory: '/a',
+      filesToOpen: []
+    });
     expect(appData.recentSessions).toHaveLength(1);
-    expect(appData.recentSessions[0].date.valueOf()).toBeGreaterThanOrEqual(before);
+    expect(appData.recentSessions[0].date.valueOf()).toBeGreaterThanOrEqual(
+      before
+    );
   });
 });
 

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../../../src/main/config/settings', () => ({
   userSettings: { getValue: vi.fn(() => null), setValue: vi.fn() },
@@ -30,7 +30,9 @@ import { parseCLIArgs } from '../../../src/main/cli';
 let exitSpy: ReturnType<typeof vi.spyOn>;
 
 beforeAll(() => {
-  exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+  exitSpy = vi
+    .spyOn(process, 'exit')
+    .mockImplementation(() => undefined as never);
 });
 afterAll(() => {
   exitSpy.mockRestore();

--- a/test/unit/eventmanager.test.ts
+++ b/test/unit/eventmanager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ipcMain } from 'electron';
 import { EventManager } from '../../src/main/eventmanager';
 import { EventTypeMain } from '../../src/main/eventtypes';
@@ -14,7 +14,10 @@ describe('EventManager.registerEventHandler', () => {
     const mgr = new EventManager();
     const handler = vi.fn();
     mgr.registerEventHandler(EventTypeMain.OpenFile, handler);
-    expect(mockIpcMain.on).toHaveBeenCalledWith(EventTypeMain.OpenFile, handler);
+    expect(mockIpcMain.on).toHaveBeenCalledWith(
+      EventTypeMain.OpenFile,
+      handler
+    );
   });
 
   it('registers multiple handlers for same event type', () => {
@@ -44,7 +47,10 @@ describe('EventManager.registerSyncEventHandler', () => {
     const mgr = new EventManager();
     const handler = vi.fn();
     mgr.registerSyncEventHandler(EventTypeMain.IsDarkTheme, handler);
-    expect(mockIpcMain.handle).toHaveBeenCalledWith(EventTypeMain.IsDarkTheme, handler);
+    expect(mockIpcMain.handle).toHaveBeenCalledWith(
+      EventTypeMain.IsDarkTheme,
+      handler
+    );
   });
 
   it('registers multiple sync handlers for same event', () => {
@@ -64,13 +70,18 @@ describe('EventManager.unregisterEventHandler', () => {
     mgr.registerEventHandler(EventTypeMain.OpenFile, handler);
     vi.clearAllMocks();
     mgr.unregisterEventHandler(EventTypeMain.OpenFile, handler);
-    expect(mockIpcMain.removeListener).toHaveBeenCalledWith(EventTypeMain.OpenFile, handler);
+    expect(mockIpcMain.removeListener).toHaveBeenCalledWith(
+      EventTypeMain.OpenFile,
+      handler
+    );
   });
 
   it('no-ops when event type was never registered', () => {
     const mgr = new EventManager();
     const handler = vi.fn();
-    expect(() => mgr.unregisterEventHandler(EventTypeMain.OpenFile, handler)).not.toThrow();
+    expect(() =>
+      mgr.unregisterEventHandler(EventTypeMain.OpenFile, handler)
+    ).not.toThrow();
     expect(mockIpcMain.removeListener).not.toHaveBeenCalled();
   });
 
@@ -93,7 +104,10 @@ describe('EventManager.unregisterEventHandler', () => {
     vi.clearAllMocks();
     mgr.unregisterEventHandler(EventTypeMain.OpenFile, h1);
     expect(mockIpcMain.removeListener).toHaveBeenCalledTimes(1);
-    expect(mockIpcMain.removeListener).toHaveBeenCalledWith(EventTypeMain.OpenFile, h1);
+    expect(mockIpcMain.removeListener).toHaveBeenCalledWith(
+      EventTypeMain.OpenFile,
+      h1
+    );
   });
 });
 
@@ -104,12 +118,17 @@ describe('EventManager.unregisterSyncEventHandler', () => {
     mgr.registerSyncEventHandler(EventTypeMain.IsDarkTheme, handler);
     vi.clearAllMocks();
     mgr.unregisterSyncEventHandler(EventTypeMain.IsDarkTheme, handler);
-    expect(mockIpcMain.removeListener).toHaveBeenCalledWith(EventTypeMain.IsDarkTheme, handler);
+    expect(mockIpcMain.removeListener).toHaveBeenCalledWith(
+      EventTypeMain.IsDarkTheme,
+      handler
+    );
   });
 
   it('no-ops when event type was never registered', () => {
     const mgr = new EventManager();
-    expect(() => mgr.unregisterSyncEventHandler(EventTypeMain.IsDarkTheme, vi.fn())).not.toThrow();
+    expect(() =>
+      mgr.unregisterSyncEventHandler(EventTypeMain.IsDarkTheme, vi.fn())
+    ).not.toThrow();
     expect(mockIpcMain.removeListener).not.toHaveBeenCalled();
   });
 });
@@ -123,8 +142,14 @@ describe('EventManager.unregisterAllEventHandlers', () => {
     mgr.registerEventHandler(EventTypeMain.OpenFolder, h2);
     vi.clearAllMocks();
     mgr.unregisterAllEventHandlers();
-    expect(mockIpcMain.removeListener).toHaveBeenCalledWith(EventTypeMain.OpenFile, h1);
-    expect(mockIpcMain.removeListener).toHaveBeenCalledWith(EventTypeMain.OpenFolder, h2);
+    expect(mockIpcMain.removeListener).toHaveBeenCalledWith(
+      EventTypeMain.OpenFile,
+      h1
+    );
+    expect(mockIpcMain.removeListener).toHaveBeenCalledWith(
+      EventTypeMain.OpenFolder,
+      h2
+    );
   });
 
   it('no-ops when no handlers registered', () => {
@@ -156,8 +181,14 @@ describe('EventManager.dispose', () => {
     mgr.registerSyncEventHandler(EventTypeMain.IsDarkTheme, sync1);
     vi.clearAllMocks();
     await expect(mgr.dispose()).resolves.toBeUndefined();
-    expect(mockIpcMain.removeListener).toHaveBeenCalledWith(EventTypeMain.OpenFile, async1);
-    expect(mockIpcMain.removeListener).toHaveBeenCalledWith(EventTypeMain.IsDarkTheme, sync1);
+    expect(mockIpcMain.removeListener).toHaveBeenCalledWith(
+      EventTypeMain.OpenFile,
+      async1
+    );
+    expect(mockIpcMain.removeListener).toHaveBeenCalledWith(
+      EventTypeMain.IsDarkTheme,
+      sync1
+    );
   });
 
   it('is safe to call dispose twice', async () => {

--- a/test/unit/eventtypes.test.ts
+++ b/test/unit/eventtypes.test.ts
@@ -1,52 +1,96 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { EventTypeMain, EventTypeRenderer } from '../../src/main/eventtypes';
 
 // Spot-check critical IPC event strings — a typo here silently breaks the IPC channel
 
 describe('EventTypeMain — window controls', () => {
-  it('MinimizeWindow', () => expect(EventTypeMain.MinimizeWindow).toBe('minimize-window'));
-  it('MaximizeWindow', () => expect(EventTypeMain.MaximizeWindow).toBe('maximize-window'));
-  it('RestoreWindow', () => expect(EventTypeMain.RestoreWindow).toBe('restore-window'));
-  it('CloseWindow', () => expect(EventTypeMain.CloseWindow).toBe('close-window'));
+  it('MinimizeWindow', () =>
+    expect(EventTypeMain.MinimizeWindow).toBe('minimize-window'));
+  it('MaximizeWindow', () =>
+    expect(EventTypeMain.MaximizeWindow).toBe('maximize-window'));
+  it('RestoreWindow', () =>
+    expect(EventTypeMain.RestoreWindow).toBe('restore-window'));
+  it('CloseWindow', () =>
+    expect(EventTypeMain.CloseWindow).toBe('close-window'));
 });
 
 describe('EventTypeMain — session management', () => {
-  it('CreateNewSession', () => expect(EventTypeMain.CreateNewSession).toBe('create-new-session'));
-  it('CreateNewRemoteSession', () => expect(EventTypeMain.CreateNewRemoteSession).toBe('create-new-remote-session'));
-  it('OpenRecentSession', () => expect(EventTypeMain.OpenRecentSession).toBe('open-recent-session'));
-  it('DeleteRecentSession', () => expect(EventTypeMain.DeleteRecentSession).toBe('delete-recent-session'));
-  it('OpenDroppedFiles', () => expect(EventTypeMain.OpenDroppedFiles).toBe('open-dropped-files'));
-  it('RestartSession', () => expect(EventTypeMain.RestartSession).toBe('restart-session'));
+  it('CreateNewSession', () =>
+    expect(EventTypeMain.CreateNewSession).toBe('create-new-session'));
+  it('CreateNewRemoteSession', () =>
+    expect(EventTypeMain.CreateNewRemoteSession).toBe(
+      'create-new-remote-session'
+    ));
+  it('OpenRecentSession', () =>
+    expect(EventTypeMain.OpenRecentSession).toBe('open-recent-session'));
+  it('DeleteRecentSession', () =>
+    expect(EventTypeMain.DeleteRecentSession).toBe('delete-recent-session'));
+  it('OpenDroppedFiles', () =>
+    expect(EventTypeMain.OpenDroppedFiles).toBe('open-dropped-files'));
+  it('RestartSession', () =>
+    expect(EventTypeMain.RestartSession).toBe('restart-session'));
   it('LabUIReady', () => expect(EventTypeMain.LabUIReady).toBe('lab-ui-ready'));
 });
 
 describe('EventTypeMain — python environment', () => {
-  it('ValidatePythonPath', () => expect(EventTypeMain.ValidatePythonPath).toBe('validate-python-path'));
-  it('SetDefaultPythonPath', () => expect(EventTypeMain.SetDefaultPythonPath).toBe('set-default-python-path'));
-  it('InstallBundledPythonEnv', () => expect(EventTypeMain.InstallBundledPythonEnv).toBe('install-bundled-python-env'));
-  it('UpdateBundledPythonEnv', () => expect(EventTypeMain.UpdateBundledPythonEnv).toBe('update-bundled-python-env'));
-  it('GetPythonEnvironmentList', () => expect(EventTypeMain.GetPythonEnvironmentList).toBe('get-python-environment-list'));
-  it('DeletePythonEnvironment', () => expect(EventTypeMain.DeletePythonEnvironment).toBe('delete-python-environment'));
-  it('CreateNewPythonEnvironment', () => expect(EventTypeMain.CreateNewPythonEnvironment).toBe('create-new-python-environment'));
-  it('ValidateNewPythonEnvironmentName', () => expect(EventTypeMain.ValidateNewPythonEnvironmentName).toBe('validate-new-env-name'));
-  it('ValidateCondaChannels', () => expect(EventTypeMain.ValidateCondaChannels).toBe('validate-conda-channels'));
+  it('ValidatePythonPath', () =>
+    expect(EventTypeMain.ValidatePythonPath).toBe('validate-python-path'));
+  it('SetDefaultPythonPath', () =>
+    expect(EventTypeMain.SetDefaultPythonPath).toBe('set-default-python-path'));
+  it('InstallBundledPythonEnv', () =>
+    expect(EventTypeMain.InstallBundledPythonEnv).toBe(
+      'install-bundled-python-env'
+    ));
+  it('UpdateBundledPythonEnv', () =>
+    expect(EventTypeMain.UpdateBundledPythonEnv).toBe(
+      'update-bundled-python-env'
+    ));
+  it('GetPythonEnvironmentList', () =>
+    expect(EventTypeMain.GetPythonEnvironmentList).toBe(
+      'get-python-environment-list'
+    ));
+  it('DeletePythonEnvironment', () =>
+    expect(EventTypeMain.DeletePythonEnvironment).toBe(
+      'delete-python-environment'
+    ));
+  it('CreateNewPythonEnvironment', () =>
+    expect(EventTypeMain.CreateNewPythonEnvironment).toBe(
+      'create-new-python-environment'
+    ));
+  it('ValidateNewPythonEnvironmentName', () =>
+    expect(EventTypeMain.ValidateNewPythonEnvironmentName).toBe(
+      'validate-new-env-name'
+    ));
+  it('ValidateCondaChannels', () =>
+    expect(EventTypeMain.ValidateCondaChannels).toBe(
+      'validate-conda-channels'
+    ));
 });
 
 describe('EventTypeMain — settings', () => {
   it('SetTheme', () => expect(EventTypeMain.SetTheme).toBe('set-theme'));
-  it('SetLogLevel', () => expect(EventTypeMain.SetLogLevel).toBe('set-log-level'));
-  it('SetStartupMode', () => expect(EventTypeMain.SetStartupMode).toBe('set-startup-mode'));
-  it('SetCtrlWBehavior', () => expect(EventTypeMain.SetCtrlWBehavior).toBe('set-ctrl-w-behavior'));
-  it('SetSettings', () => expect(EventTypeMain.SetSettings).toBe('set-settings'));
-  it('ClearHistory', () => expect(EventTypeMain.ClearHistory).toBe('clear-history'));
-  it('CheckForUpdates', () => expect(EventTypeMain.CheckForUpdates).toBe('check-for-updates'));
+  it('SetLogLevel', () =>
+    expect(EventTypeMain.SetLogLevel).toBe('set-log-level'));
+  it('SetStartupMode', () =>
+    expect(EventTypeMain.SetStartupMode).toBe('set-startup-mode'));
+  it('SetCtrlWBehavior', () =>
+    expect(EventTypeMain.SetCtrlWBehavior).toBe('set-ctrl-w-behavior'));
+  it('SetSettings', () =>
+    expect(EventTypeMain.SetSettings).toBe('set-settings'));
+  it('ClearHistory', () =>
+    expect(EventTypeMain.ClearHistory).toBe('clear-history'));
+  it('CheckForUpdates', () =>
+    expect(EventTypeMain.CheckForUpdates).toBe('check-for-updates'));
 });
 
 describe('EventTypeMain — all values are non-empty strings', () => {
   it('every event has a non-empty string value', () => {
     for (const [key, val] of Object.entries(EventTypeMain)) {
       expect(typeof val, `EventTypeMain.${key}`).toBe('string');
-      expect((val as string).length, `EventTypeMain.${key} is empty`).toBeGreaterThan(0);
+      expect(
+        (val as string).length,
+        `EventTypeMain.${key} is empty`
+      ).toBeGreaterThan(0);
     }
   });
 
@@ -58,19 +102,41 @@ describe('EventTypeMain — all values are non-empty strings', () => {
 });
 
 describe('EventTypeRenderer', () => {
-  it('WorkingDirectorySelected', () => expect(EventTypeRenderer.WorkingDirectorySelected).toBe('working-directory-selected'));
-  it('InstallPythonEnvStatus', () => expect(EventTypeRenderer.InstallPythonEnvStatus).toBe('install-python-env-status'));
-  it('ShowProgress', () => expect(EventTypeRenderer.ShowProgress).toBe('show-progress'));
-  it('SetCurrentPythonPath', () => expect(EventTypeRenderer.SetCurrentPythonPath).toBe('set-current-python-path'));
-  it('SetRunningServerList', () => expect(EventTypeRenderer.SetRunningServerList).toBe('set-running-server-list'));
+  it('WorkingDirectorySelected', () =>
+    expect(EventTypeRenderer.WorkingDirectorySelected).toBe(
+      'working-directory-selected'
+    ));
+  it('InstallPythonEnvStatus', () =>
+    expect(EventTypeRenderer.InstallPythonEnvStatus).toBe(
+      'install-python-env-status'
+    ));
+  it('ShowProgress', () =>
+    expect(EventTypeRenderer.ShowProgress).toBe('show-progress'));
+  it('SetCurrentPythonPath', () =>
+    expect(EventTypeRenderer.SetCurrentPythonPath).toBe(
+      'set-current-python-path'
+    ));
+  it('SetRunningServerList', () =>
+    expect(EventTypeRenderer.SetRunningServerList).toBe(
+      'set-running-server-list'
+    ));
   it('SetTitle', () => expect(EventTypeRenderer.SetTitle).toBe('set-title'));
-  it('SetRecentSessionList', () => expect(EventTypeRenderer.SetRecentSessionList).toBe('set-recent-session-list'));
-  it('SetPythonEnvironmentList', () => expect(EventTypeRenderer.SetPythonEnvironmentList).toBe('set-python-environment-list'));
+  it('SetRecentSessionList', () =>
+    expect(EventTypeRenderer.SetRecentSessionList).toBe(
+      'set-recent-session-list'
+    ));
+  it('SetPythonEnvironmentList', () =>
+    expect(EventTypeRenderer.SetPythonEnvironmentList).toBe(
+      'set-python-environment-list'
+    ));
 
   it('all values are non-empty strings', () => {
     for (const [key, val] of Object.entries(EventTypeRenderer)) {
       expect(typeof val, `EventTypeRenderer.${key}`).toBe('string');
-      expect((val as string).length, `EventTypeRenderer.${key} is empty`).toBeGreaterThan(0);
+      expect(
+        (val as string).length,
+        `EventTypeRenderer.${key} is empty`
+      ).toBeGreaterThan(0);
     }
   });
 

--- a/test/unit/sessionconfig.test.ts
+++ b/test/unit/sessionconfig.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'fs';
 
 vi.mock('fs', async () => {
@@ -81,7 +81,9 @@ describe('SessionConfig.createLocal', () => {
   });
 
   it('skips files that do not exist', () => {
-    mockFs.lstatSync = vi.fn(() => { throw new Error('ENOENT'); });
+    mockFs.lstatSync = vi.fn(() => {
+      throw new Error('ENOENT');
+    });
     const s = SessionConfig.createLocal('/data', ['missing.ipynb']);
     expect(s.filesToOpen).toEqual([]);
   });
@@ -100,51 +102,85 @@ describe('SessionConfig.createLocal', () => {
 
 describe('SessionConfig.createRemote', () => {
   it('sets remoteURL', () => {
-    const s = SessionConfig.createRemote('http://localhost:8888/lab?token=abc', true, '');
+    const s = SessionConfig.createRemote(
+      'http://localhost:8888/lab?token=abc',
+      true,
+      ''
+    );
     expect(s.remoteURL).toBe('http://localhost:8888/lab?token=abc');
     expect(s.isRemote).toBe(true);
   });
 
   it('extracts token from URL', () => {
-    const s = SessionConfig.createRemote('http://localhost:8888/lab?token=mysecret', true, '');
+    const s = SessionConfig.createRemote(
+      'http://localhost:8888/lab?token=mysecret',
+      true,
+      ''
+    );
     expect(s.token).toBe('mysecret');
   });
 
   it('persist partition when persistSessionData is true', () => {
-    const s = SessionConfig.createRemote('http://localhost:8888/lab?token=x', true, '');
+    const s = SessionConfig.createRemote(
+      'http://localhost:8888/lab?token=x',
+      true,
+      ''
+    );
     expect(s.partition).toMatch(/^persist:/);
   });
 
   it('non-persist partition when persistSessionData is false', () => {
-    const s = SessionConfig.createRemote('http://localhost:8888/lab?token=x', false, '');
+    const s = SessionConfig.createRemote(
+      'http://localhost:8888/lab?token=x',
+      false,
+      ''
+    );
     expect(s.partition).toMatch(/^partition:/);
   });
 
   it('uses provided partition instead of generating one', () => {
-    const s = SessionConfig.createRemote('http://localhost:8888/lab?token=x', true, 'persist:my-custom-id');
+    const s = SessionConfig.createRemote(
+      'http://localhost:8888/lab?token=x',
+      true,
+      'persist:my-custom-id'
+    );
     expect(s.partition).toBe('persist:my-custom-id');
   });
 
   it('sets persistSessionData to false correctly', () => {
-    const s = SessionConfig.createRemote('http://localhost:8888/lab?token=x', false, '');
+    const s = SessionConfig.createRemote(
+      'http://localhost:8888/lab?token=x',
+      false,
+      ''
+    );
     expect(s.persistSessionData).toBe(false);
   });
 
   it('persistSessionData defaults to true when not false', () => {
-    const s = SessionConfig.createRemote('http://localhost:8888/lab?token=x', true, '');
+    const s = SessionConfig.createRemote(
+      'http://localhost:8888/lab?token=x',
+      true,
+      ''
+    );
     expect(s.persistSessionData).toBe(true);
   });
 });
 
 describe('SessionConfig.createLocalForFilesOrFolders', () => {
   it('creates session in parent dir of first file', () => {
-    mockFs.lstatSync = vi.fn(() => ({ isFile: () => true, isDirectory: () => false } as fs.Stats));
-    const s = SessionConfig.createLocalForFilesOrFolders(['/data/nb/test.ipynb']);
+    mockFs.lstatSync = vi.fn(
+      () => ({ isFile: () => true, isDirectory: () => false } as fs.Stats)
+    );
+    const s = SessionConfig.createLocalForFilesOrFolders([
+      '/data/nb/test.ipynb'
+    ]);
     expect(s.workingDirectory).toBe('/data/nb');
   });
 
   it('creates session at directory path', () => {
-    mockFs.lstatSync = vi.fn(() => ({ isFile: () => false, isDirectory: () => true } as fs.Stats));
+    mockFs.lstatSync = vi.fn(
+      () => ({ isFile: () => false, isDirectory: () => true } as fs.Stats)
+    );
     const s = SessionConfig.createLocalForFilesOrFolders(['/data/notebooks']);
     expect(s.workingDirectory).toBe('/data/notebooks');
   });
@@ -155,8 +191,12 @@ describe('SessionConfig.createLocalForFilesOrFolders', () => {
   });
 
   it('skips paths where lstatSync throws', () => {
-    mockFs.lstatSync = vi.fn(() => { throw new Error('ENOENT'); });
-    const s = SessionConfig.createLocalForFilesOrFolders(['/missing/path.ipynb']);
+    mockFs.lstatSync = vi.fn(() => {
+      throw new Error('ENOENT');
+    });
+    const s = SessionConfig.createLocalForFilesOrFolders([
+      '/missing/path.ipynb'
+    ]);
     expect(s).toBeUndefined();
   });
 
@@ -164,10 +204,14 @@ describe('SessionConfig.createLocalForFilesOrFolders', () => {
     let call = 0;
     mockFs.lstatSync = vi.fn(() => {
       call++;
-      if (call === 1) return { isFile: () => false, isDirectory: () => true } as fs.Stats; // folder first
+      if (call === 1)
+        return { isFile: () => false, isDirectory: () => true } as fs.Stats; // folder first
       return { isFile: () => true, isDirectory: () => false } as fs.Stats; // then file
     });
-    const s = SessionConfig.createLocalForFilesOrFolders(['/some/folder', '/some/folder/note.ipynb']);
+    const s = SessionConfig.createLocalForFilesOrFolders([
+      '/some/folder',
+      '/some/folder/note.ipynb'
+    ]);
     // files take precedence: working dir should be parent of the file
     expect(s.workingDirectory).toBe('/some/folder');
   });
@@ -176,18 +220,29 @@ describe('SessionConfig.createLocalForFilesOrFolders', () => {
 describe('SessionConfig.createFromArgs', () => {
   beforeEach(() => {
     mockFs.existsSync = vi.fn(() => false);
-    mockFs.lstatSync = vi.fn(() => { throw new Error('ENOENT'); });
+    mockFs.lstatSync = vi.fn(() => {
+      throw new Error('ENOENT');
+    });
   });
 
   it('returns undefined when no args', () => {
-    const result = SessionConfig.createFromArgs({ _: [], $0: '', cwd: '/cwd', pythonPath: '', workingDir: '' });
+    const result = SessionConfig.createFromArgs({
+      _: [],
+      $0: '',
+      cwd: '/cwd',
+      pythonPath: '',
+      workingDir: ''
+    });
     expect(result).toBeUndefined();
   });
 
   it('creates remote session for https URL', () => {
     const result = SessionConfig.createFromArgs({
       _: ['https://example.com/lab?token=tok'],
-      $0: '', cwd: '/cwd', pythonPath: '', workingDir: ''
+      $0: '',
+      cwd: '/cwd',
+      pythonPath: '',
+      workingDir: ''
     });
     expect(result).toBeDefined();
     expect(result.isRemote).toBe(true);
@@ -197,7 +252,10 @@ describe('SessionConfig.createFromArgs', () => {
   it('creates remote session for http URL', () => {
     const result = SessionConfig.createFromArgs({
       _: ['http://localhost:8888/lab?token=abc'],
-      $0: '', cwd: '/cwd', pythonPath: '', workingDir: ''
+      $0: '',
+      cwd: '/cwd',
+      pythonPath: '',
+      workingDir: ''
     });
     expect(result.isRemote).toBe(true);
   });
@@ -205,7 +263,11 @@ describe('SessionConfig.createFromArgs', () => {
   it('creates local session when workingDir exists', () => {
     mockFs.existsSync = vi.fn(() => true);
     const result = SessionConfig.createFromArgs({
-      _: [], $0: '', cwd: '/cwd', pythonPath: '', workingDir: '/valid/dir'
+      _: [],
+      $0: '',
+      cwd: '/cwd',
+      pythonPath: '',
+      workingDir: '/valid/dir'
     });
     expect(result).toBeDefined();
     expect(result.isRemote).toBe(false);
@@ -215,16 +277,26 @@ describe('SessionConfig.createFromArgs', () => {
   it('returns undefined when workingDir does not exist and no files', () => {
     mockFs.existsSync = vi.fn(() => false);
     const result = SessionConfig.createFromArgs({
-      _: [], $0: '', cwd: '/cwd', pythonPath: '', workingDir: '/nonexistent'
+      _: [],
+      $0: '',
+      cwd: '/cwd',
+      pythonPath: '',
+      workingDir: '/nonexistent'
     });
     expect(result).toBeUndefined();
   });
 
   it('includes file paths resolved from cwd', () => {
     mockFs.existsSync = vi.fn(() => false);
-    mockFs.lstatSync = vi.fn(() => ({ isFile: () => true, isDirectory: () => false } as fs.Stats));
+    mockFs.lstatSync = vi.fn(
+      () => ({ isFile: () => true, isDirectory: () => false } as fs.Stats)
+    );
     const result = SessionConfig.createFromArgs({
-      _: ['test.ipynb'], $0: '', cwd: '/cwd', pythonPath: '', workingDir: ''
+      _: ['test.ipynb'],
+      $0: '',
+      cwd: '/cwd',
+      pythonPath: '',
+      workingDir: ''
     });
     expect(result).toBeDefined();
   });
@@ -235,7 +307,11 @@ describe('SessionConfig.createFromArgs', () => {
       return pathStr.includes('python3') || pathStr.includes('valid/dir');
     });
     const result = SessionConfig.createFromArgs({
-      _: [], $0: '', cwd: '/cwd', pythonPath: '/usr/bin/python3', workingDir: '/valid/dir'
+      _: [],
+      $0: '',
+      cwd: '/cwd',
+      pythonPath: '/usr/bin/python3',
+      workingDir: '/valid/dir'
     });
     expect(result).toBeDefined();
     expect(result.pythonPath).toContain('python3');
@@ -246,7 +322,11 @@ describe('SessionConfig.createFromArgs', () => {
       return p.toString().includes('valid/dir');
     });
     const result = SessionConfig.createFromArgs({
-      _: [], $0: '', cwd: '/cwd', pythonPath: '/nonexistent/python', workingDir: '/valid/dir'
+      _: [],
+      $0: '',
+      cwd: '/cwd',
+      pythonPath: '/nonexistent/python',
+      workingDir: '/valid/dir'
     });
     expect(result).toBeDefined();
     expect(result.pythonPath).toBe('');
@@ -272,11 +352,16 @@ describe('SessionConfig.serialize', () => {
   it('includes remoteURL when set', () => {
     const s = new SessionConfig();
     s.remoteURL = 'http://localhost:8888/lab';
-    expect(s.serialize()).toHaveProperty('remoteURL', 'http://localhost:8888/lab');
+    expect(s.serialize()).toHaveProperty(
+      'remoteURL',
+      'http://localhost:8888/lab'
+    );
   });
 
   it('omits persistSessionData when true (default)', () => {
-    expect(new SessionConfig().serialize()).not.toHaveProperty('persistSessionData');
+    expect(new SessionConfig().serialize()).not.toHaveProperty(
+      'persistSessionData'
+    );
   });
 
   it('includes persistSessionData when false', () => {
@@ -299,7 +384,9 @@ describe('SessionConfig.serialize', () => {
   });
 
   it('omits workingDirectory when empty', () => {
-    expect(new SessionConfig().serialize()).not.toHaveProperty('workingDirectory');
+    expect(new SessionConfig().serialize()).not.toHaveProperty(
+      'workingDirectory'
+    );
   });
 
   it('includes workingDirectory when set', () => {
@@ -322,7 +409,9 @@ describe('SessionConfig.serialize', () => {
     const s = new SessionConfig();
     const json = s.serialize();
     expect(() => new Date(json.lastOpened)).not.toThrow();
-    expect(new Date(json.lastOpened).getFullYear()).toBeGreaterThanOrEqual(2020);
+    expect(new Date(json.lastOpened).getFullYear()).toBeGreaterThanOrEqual(
+      2020
+    );
   });
 });
 
@@ -406,7 +495,11 @@ describe('SessionConfig serialize/deserialize round-trip', () => {
   });
 
   it('round-trips a remote session', () => {
-    const original = SessionConfig.createRemote('http://remote:8888/lab?token=tok', true, 'persist:id123');
+    const original = SessionConfig.createRemote(
+      'http://remote:8888/lab?token=tok',
+      true,
+      'persist:id123'
+    );
     const copy = new SessionConfig();
     copy.deserialize(original.serialize());
 
@@ -417,7 +510,11 @@ describe('SessionConfig serialize/deserialize round-trip', () => {
   });
 
   it('round-trips a non-persistent remote session', () => {
-    const original = SessionConfig.createRemote('http://remote:8888/lab?token=tok', false, '');
+    const original = SessionConfig.createRemote(
+      'http://remote:8888/lab?token=tok',
+      false,
+      ''
+    );
     const copy = new SessionConfig();
     copy.deserialize(original.serialize());
 

--- a/test/unit/settings.test.ts
+++ b/test/unit/settings.test.ts
@@ -1,23 +1,28 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import * as fs from 'fs';
 
 vi.mock('fs', async () => {
   const actual = await vi.importActual<typeof import('fs')>('fs');
-  return { ...actual, existsSync: vi.fn(), lstatSync: vi.fn(), mkdirSync: vi.fn() };
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    lstatSync: vi.fn(),
+    mkdirSync: vi.fn()
+  };
 });
 
 import {
-  ThemeType,
-  StartupMode,
-  LogLevel,
   CtrlWBehavior,
-  UIMode,
-  SettingType,
-  serverLaunchArgsFixed,
-  serverLaunchArgsDefault,
-  DEFAULT_WIN_WIDTH,
   DEFAULT_WIN_HEIGHT,
-  resolveWorkingDirectory
+  DEFAULT_WIN_WIDTH,
+  LogLevel,
+  resolveWorkingDirectory,
+  serverLaunchArgsDefault,
+  serverLaunchArgsFixed,
+  SettingType,
+  StartupMode,
+  ThemeType,
+  UIMode
 } from '../../../src/main/config/settings';
 
 const mockFs = vi.mocked(fs);
@@ -79,7 +84,9 @@ describe('serverLaunchArgsFixed', () => {
 
 describe('serverLaunchArgsDefault', () => {
   it('allows hidden files', () => {
-    expect(serverLaunchArgsDefault.some(a => a.includes('allow_hidden=True'))).toBe(true);
+    expect(
+      serverLaunchArgsDefault.some(a => a.includes('allow_hidden=True'))
+    ).toBe(true);
   });
 });
 
@@ -104,13 +111,17 @@ describe('resolveWorkingDirectory', () => {
   });
 
   it('resets to home when path does not exist', () => {
-    mockFs.lstatSync = vi.fn(() => { throw new Error('ENOENT'); });
+    mockFs.lstatSync = vi.fn(() => {
+      throw new Error('ENOENT');
+    });
     const result = resolveWorkingDirectory('/nonexistent/path');
     expect(result).not.toBe('/nonexistent/path');
   });
 
   it('keeps invalid path when resetIfInvalid is false', () => {
-    mockFs.lstatSync = vi.fn(() => { throw new Error('ENOENT'); });
+    mockFs.lstatSync = vi.fn(() => {
+      throw new Error('ENOENT');
+    });
     const result = resolveWorkingDirectory('/bad/path', false);
     expect(result).toBe('/bad/path');
   });

--- a/test/unit/tokens.test.ts
+++ b/test/unit/tokens.test.ts
@@ -1,24 +1,33 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
-  IEnvironmentType,
   EnvironmentTypeName,
+  IEnvironmentType,
   PythonEnvResolveErrorType
 } from '../../src/main/tokens';
 
 describe('IEnvironmentType', () => {
   it('Path is "path"', () => expect(IEnvironmentType.Path).toBe('path'));
-  it('CondaRoot is "conda-root"', () => expect(IEnvironmentType.CondaRoot).toBe('conda-root'));
-  it('CondaEnv is "conda-env"', () => expect(IEnvironmentType.CondaEnv).toBe('conda-env'));
-  it('WindowsReg is "windows-reg"', () => expect(IEnvironmentType.WindowsReg).toBe('windows-reg'));
-  it('VirtualEnv is "venv"', () => expect(IEnvironmentType.VirtualEnv).toBe('venv'));
+  it('CondaRoot is "conda-root"', () =>
+    expect(IEnvironmentType.CondaRoot).toBe('conda-root'));
+  it('CondaEnv is "conda-env"', () =>
+    expect(IEnvironmentType.CondaEnv).toBe('conda-env'));
+  it('WindowsReg is "windows-reg"', () =>
+    expect(IEnvironmentType.WindowsReg).toBe('windows-reg'));
+  it('VirtualEnv is "venv"', () =>
+    expect(IEnvironmentType.VirtualEnv).toBe('venv'));
 });
 
 describe('EnvironmentTypeName', () => {
-  it('Path maps to "system"', () => expect(EnvironmentTypeName[IEnvironmentType.Path]).toBe('system'));
-  it('CondaRoot maps to "conda"', () => expect(EnvironmentTypeName[IEnvironmentType.CondaRoot]).toBe('conda'));
-  it('CondaEnv maps to "conda"', () => expect(EnvironmentTypeName[IEnvironmentType.CondaEnv]).toBe('conda'));
-  it('WindowsReg maps to "win"', () => expect(EnvironmentTypeName[IEnvironmentType.WindowsReg]).toBe('win'));
-  it('VirtualEnv maps to "venv"', () => expect(EnvironmentTypeName[IEnvironmentType.VirtualEnv]).toBe('venv'));
+  it('Path maps to "system"', () =>
+    expect(EnvironmentTypeName[IEnvironmentType.Path]).toBe('system'));
+  it('CondaRoot maps to "conda"', () =>
+    expect(EnvironmentTypeName[IEnvironmentType.CondaRoot]).toBe('conda'));
+  it('CondaEnv maps to "conda"', () =>
+    expect(EnvironmentTypeName[IEnvironmentType.CondaEnv]).toBe('conda'));
+  it('WindowsReg maps to "win"', () =>
+    expect(EnvironmentTypeName[IEnvironmentType.WindowsReg]).toBe('win'));
+  it('VirtualEnv maps to "venv"', () =>
+    expect(EnvironmentTypeName[IEnvironmentType.VirtualEnv]).toBe('venv'));
 
   it('all IEnvironmentType values have a display name', () => {
     for (const key of Object.values(IEnvironmentType)) {
@@ -33,12 +42,16 @@ describe('PythonEnvResolveErrorType', () => {
     expect(PythonEnvResolveErrorType.PathNotFound).toBe('path-not-found');
   });
   it('InvalidPythonBinary is "invalid-python-binary"', () => {
-    expect(PythonEnvResolveErrorType.InvalidPythonBinary).toBe('invalid-python-binary');
+    expect(PythonEnvResolveErrorType.InvalidPythonBinary).toBe(
+      'invalid-python-binary'
+    );
   });
   it('ResolveError is "resolve-error"', () => {
     expect(PythonEnvResolveErrorType.ResolveError).toBe('resolve-error');
   });
   it('RequirementsNotSatisfied is "requirements-not-satisfied"', () => {
-    expect(PythonEnvResolveErrorType.RequirementsNotSatisfied).toBe('requirements-not-satisfied');
+    expect(PythonEnvResolveErrorType.RequirementsNotSatisfied).toBe(
+      'requirements-not-satisfied'
+    );
   });
 });

--- a/test/unit/workspacesettings.test.ts
+++ b/test/unit/workspacesettings.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -15,19 +15,23 @@ vi.mock('fs', async () => {
 });
 
 import {
-  WorkspaceSettings,
+  resolveWorkingDirectory,
   SettingType,
   ThemeType,
   UIMode,
-  resolveWorkingDirectory
+  WorkspaceSettings
 } from '../../../src/main/config/settings';
 
 const mockFs = vi.mocked(fs);
 
 describe('WorkspaceSettings.getWorkspaceSettingsPath', () => {
   it('returns .jupyter/desktop-settings.json inside working dir', () => {
-    const result = WorkspaceSettings.getWorkspaceSettingsPath('/data/notebooks');
-    expect(result).toBe(path.join('/data/notebooks', '.jupyter', 'desktop-settings.json'));
+    const result = WorkspaceSettings.getWorkspaceSettingsPath(
+      '/data/notebooks'
+    );
+    expect(result).toBe(
+      path.join('/data/notebooks', '.jupyter', 'desktop-settings.json')
+    );
   });
 });
 
@@ -35,7 +39,9 @@ describe('WorkspaceSettings — no workspace file', () => {
   beforeEach(() => {
     // user settings file does not exist, workspace settings file does not exist
     mockFs.existsSync = vi.fn(() => false);
-    mockFs.readFileSync = vi.fn(() => { throw new Error('ENOENT'); });
+    mockFs.readFileSync = vi.fn(() => {
+      throw new Error('ENOENT');
+    });
   });
 
   it('constructs without throwing', () => {
@@ -63,7 +69,9 @@ describe('WorkspaceSettings — with workspace file', () => {
     mockFs.readFileSync = vi.fn((p: fs.PathLike | fs.promises.FileHandle) => {
       if (p.toString().includes('desktop-settings.json')) {
         // serverArgs and uiMode are wsOverridable
-        return Buffer.from(JSON.stringify({ serverArgs: '--no-browser', uiMode: 'zen' }));
+        return Buffer.from(
+          JSON.stringify({ serverArgs: '--no-browser', uiMode: 'zen' })
+        );
       }
       throw new Error('ENOENT');
     });
@@ -99,7 +107,9 @@ describe('WorkspaceSettings — with workspace file', () => {
 describe('WorkspaceSettings setValue / unsetValue', () => {
   beforeEach(() => {
     mockFs.existsSync = vi.fn(() => false);
-    mockFs.readFileSync = vi.fn(() => { throw new Error('ENOENT'); });
+    mockFs.readFileSync = vi.fn(() => {
+      throw new Error('ENOENT');
+    });
   });
 
   it('setValue sets workspace-level value', () => {
@@ -127,7 +137,9 @@ describe('WorkspaceSettings setValue / unsetValue', () => {
 describe('WorkspaceSettings save', () => {
   beforeEach(() => {
     mockFs.existsSync = vi.fn(() => false);
-    mockFs.readFileSync = vi.fn(() => { throw new Error('ENOENT'); });
+    mockFs.readFileSync = vi.fn(() => {
+      throw new Error('ENOENT');
+    });
     mockFs.writeFileSync = vi.fn();
     mockFs.mkdirSync = vi.fn();
   });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,7 +15,8 @@ export default defineConfig({
   resolve: {
     alias: {
       // redirect electron to the in-process mock so unit tests run without a real Electron binary
-      electron: '/Users/notluquis/jupyterlab-desktop/test/setup/electron-mock.ts'
+      electron:
+        '/Users/notluquis/jupyterlab-desktop/test/setup/electron-mock.ts'
     }
   }
   // Import-path note: test files that call vi.mock() have their mocks hoisted by vitest,


### PR DESCRIPTION
First of a four-part split for the testing/CI work tracked in #951. This one is CI infrastructure only; it does not add test files (those land in follow-up PRs B/C/D).

## Why split

The full plan is roughly 26 new tests + 1 packaging-smoke workflow split across four PRs (this one + e2e/unit/security/visual). Doing it as one mega-PR would be unreviewable. This PR is the foundation: cross-platform CI + safety guards. PRs B/C/D depend on having the matrix and bundle-size budget already in place.

## What this PR changes

| Area | Change |
|---|---|
| Unit tests | Run on Linux + macOS + Windows in parallel (was Linux only) |
| E2E smoke | Same 3-OS matrix (was Linux only); Playwright `--with-deps` only on Linux |
| Type check | Explicit `npx tsc --noEmit` step before build in both workflows |
| Bundle budget | New `scripts/check-bundle-size.js`, fails if any preload bundle exceeds 30 KB (current sizes 9.5 to 14.4 KB) |
| Concurrency | Cancel outdated PR runs per workflow; pushes to `master` queue normally so a release-tag push is never aborted |
| Permissions | Workflow-level `contents: read`, with `contents: write` override on the publish job that actually uploads release assets |
| Timeout | 15 min cap on the unit-test job (e2e already had 20 min) |
| Coverage upload | Linux only, to avoid duplicate artifacts from the matrix |
| Artifact naming | E2E test-results suffixed by `${{ matrix.os }}` so the three jobs don't collide on `actions/upload-artifact@v4` |
| Lint unblock | Pre-existing prettier drift on `test/` and `vitest.config.ts` was masking eslint output through the `prettier:check && eslint:check` chain. This PR formats those files (no source under `src/` is touched) so `yarn lint:check` exits 0 and the rest of the matrix can run |
| Docs | New "Automated test coverage" section in `dev.md` describing what runs |

## Commit-by-commit (squash on merge if you prefer)

1. `ci: run unit tests on Linux, macOS, and Windows`
2. `ci: run e2e smoke tests on Linux, macOS, and Windows`
3. `ci: add explicit tsc --noEmit type check step`
4. `ci: add preload bundle size budget check`
5. `docs(ci): document automated test coverage and matrix`
6. `ci: cancel outdated PR runs via concurrency group`
7. `ci: declare least-privilege permissions on workflows`
8. `ci: cap unit test job at 15 minutes`
9. `style: prettier-format test files and vitest config`

## Verification I ran

Local on macOS, against the merged tip of `revival/electron-41`:

- `python -c "import yaml; yaml.safe_load(...)"` on both workflows: parses cleanly.
- `npx tsc --noEmit`: exits 0.
- `yarn build`: webpack 5.76.0 compiles all 12 preloads.
- `node scripts/check-bundle-size.js`: 12/12 OK, all under 30 KB.
- `yarn test:unit`: 11 files, 341 / 341 pass.
- `yarn lint:check`: exits 0 after the prettier-format commit (22 pre-existing eslint warnings remain, all about unused imports and missing vitest globals; out of scope to fix here).

What I could not verify locally and is left to CI on this PR:

- Multi-platform behavior on Windows (I am on macOS).
- E2E suite (`yarn test:e2e`): Chromium needs the platform-specific deps that the workflow itself installs.
- Concurrency cancellation: only observable by force-pushing twice to this PR; the matrix run on this push is the first opportunity to confirm behavior.

## Caveats and judgement calls

- Bundle budget set at 30 KB per preload (about 2x the current largest, `pythonenvdialog` at 14.4 KB). Generous on purpose; intent is to catch regressions, not police every byte. Easy to lower later if you'd rather a tighter budget.
- I did not pin actions to commit SHA. The repo currently uses tags everywhere (`actions/checkout@v4`, etc.) and Dependabot covers `github-actions` weekly. SHA pinning is a separate security concern.
- The publish job in `publish.yml` got `contents: write` because it uploads release assets via `svenstaro/upload-release-action`. If you'd rather scope that even tighter (e.g. only when the release-exists step returns true), happy to follow up.
- Concurrency keys are `${{ github.workflow }}-${{ github.ref }}` so `publish.yml` and `e2e.yml` do not cancel each other.

## Out of scope (deferred to PRs B/C/D)

- New tests (e2e expansion, unit coverage gaps, security tests, visual regression).
- Packaging smoke workflow (`dist:<os> --publish never` per OS in PR).
- Coverage threshold enforcement (better fixed once the unit gap tests in PR-C give a real coverage number).

> Note: AI-assisted (Claude Code). Manually verified the seven local checks listed above and the YAML syntax. Each commit body has its own AI disclosure with the specific verification per change.
