### PR TITLE
fix: resolve CodeQL high-severity findings and harden CI

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       
       - name: Get package info
         shell: bash
@@ -19,7 +19,7 @@ jobs:
         run: echo "version=$(python scripts/get_package_version.py)" >> $GITHUB_OUTPUT
 
       - name: 'Find Release with tag v${{ steps.package-info.outputs.version}}'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         id: release-exists
         env:
           APP_VERSION: ${{ steps.package-info.outputs.version}}
@@ -35,7 +35,7 @@ jobs:
           result-encoding: string
 
       - name: Create pre-release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         if: steps.release-exists.outputs.result == 'false'
         with:
           token: ${{ secrets.JLAB_APP_TOKEN }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -3,6 +3,9 @@ name: Create Pre-release
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   prerelease:
     runs-on: ubuntu-latest

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   prerelease:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,8 +19,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: '20.x'
           cache: 'yarn'
@@ -45,8 +45,8 @@ jobs:
         shell: bash -el {0}
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3
         with:
           auto-update-conda: true
           auto-activate-base: true
@@ -56,7 +56,7 @@ jobs:
       - run: conda install --file ./workflow_env/conda-${{ matrix.cfg.build_platform }}.lock -y
 
       - name: Install node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: '20.x'
           cache: 'yarn'
@@ -80,7 +80,7 @@ jobs:
         run: echo "version=$(python scripts/get_package_version.py)" >> $GITHUB_OUTPUT
 
       - name: 'Find Release with tag v${{ steps.package-info.outputs.version}}'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         id: release-exists
         env:
           APP_VERSION: ${{ steps.package-info.outputs.version}}
@@ -153,7 +153,7 @@ jobs:
 
       - name: Upload Debian x64 Installer
         if: matrix.cfg.platform == 'linux-64'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: debian-installer-x64
           path: |
@@ -161,7 +161,7 @@ jobs:
 
       - name: Upload Fedora x64 Installer
         if: matrix.cfg.platform == 'linux-64'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: fedora-installer-x64
           path: |
@@ -169,7 +169,7 @@ jobs:
       
       - name: Upload Snap Installer
         if: matrix.cfg.platform == 'linux-64'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         id: snap-artifact
         with:
           name: snap-installer
@@ -178,7 +178,7 @@ jobs:
 
       - name: Upload macOS x64 Installer
         if: matrix.cfg.platform == 'osx-64'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: mac-installer-x64
           path: |
@@ -186,7 +186,7 @@ jobs:
 
       - name: Upload macOS arm64 Installer
         if: matrix.cfg.platform == 'osx-arm64'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: mac-installer-arm64
           path: |
@@ -194,7 +194,7 @@ jobs:
 
       - name: Upload Windows x64 Installer
         if: matrix.cfg.platform == 'win-64'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: windows-installer-x64
           path: |
@@ -202,7 +202,7 @@ jobs:
 
       - name: Upload Debian x64 Installer as Release asset
         if: matrix.cfg.platform == 'linux-64' && steps.release-exists.outputs.result == 'true'
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # v2
         with:
           repo_token: ${{ secrets.JLAB_APP_TOKEN }}
           file: dist/JupyterLab.deb
@@ -212,7 +212,7 @@ jobs:
 
       - name: Upload Fedora x64 Installer as Release asset
         if: matrix.cfg.platform == 'linux-64' && steps.release-exists.outputs.result == 'true'
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # v2
         with:
           repo_token: ${{ secrets.JLAB_APP_TOKEN }}
           file: dist/JupyterLab.rpm
@@ -222,7 +222,7 @@ jobs:
 
       - name: Upload macOS x64 Installer as Release asset
         if: matrix.cfg.platform == 'osx-64' && steps.release-exists.outputs.result == 'true'
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # v2
         with:
           repo_token: ${{ secrets.JLAB_APP_TOKEN }}
           file: dist/JupyterLab-x64.dmg
@@ -232,7 +232,7 @@ jobs:
 
       - name: Upload macOS arm64 Installer as Release asset
         if: matrix.cfg.platform == 'osx-arm64' && steps.release-exists.outputs.result == 'true'
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # v2
         with:
           repo_token: ${{ secrets.JLAB_APP_TOKEN }}
           file: dist/JupyterLab-arm64.dmg
@@ -242,7 +242,7 @@ jobs:
 
       - name: Upload macOS x64 App as Release asset
         if: matrix.cfg.platform == 'osx-64' && steps.release-exists.outputs.result == 'true'
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # v2
         with:
           repo_token: ${{ secrets.JLAB_APP_TOKEN }}
           file: dist/JupyterLab-x64.zip
@@ -252,7 +252,7 @@ jobs:
       
       - name: Upload macOS arm64 App as Release asset
         if: matrix.cfg.platform == 'osx-arm64' && steps.release-exists.outputs.result == 'true'
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # v2
         with:
           repo_token: ${{ secrets.JLAB_APP_TOKEN }}
           file: dist/JupyterLab-arm64.zip
@@ -262,7 +262,7 @@ jobs:
 
       - name: Upload Windows x64 Installer as Release asset
         if: matrix.cfg.platform == 'win-64' && steps.release-exists.outputs.result == 'true'
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # v2
         with:
           repo_token: ${{ secrets.JLAB_APP_TOKEN }}
           file: dist/JupyterLab-Setup.exe
@@ -272,7 +272,7 @@ jobs:
 
       - name: Upload latest.yml Release asset
         if: matrix.cfg.platform == 'win-64' && steps.release-exists.outputs.result == 'true'
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # v2
         with:
           repo_token: ${{ secrets.JLAB_APP_TOKEN }}
           file: dist/latest.yml
@@ -282,7 +282,7 @@ jobs:
           
       - name: Upload snap installer as Release asset
         if: matrix.cfg.platform == 'linux-64' && steps.release-exists.outputs.result == 'true'
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # v2
         with:
           repo_token: ${{ secrets.JLAB_APP_TOKEN }}
           file: dist/JupyterLab.snap
@@ -292,7 +292,7 @@ jobs:
 
       - name: Publish snap to the latest/candidate channel in Snap Store
         if: matrix.cfg.platform == 'linux-64' && steps.release-exists.outputs.result == 'true'
-        uses: snapcore/action-publish@v1
+        uses: snapcore/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40 # v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: 'Unit tests'

--- a/.github/workflows/releasepr.yml
+++ b/.github/workflows/releasepr.yml
@@ -4,8 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   createPR:

--- a/.github/workflows/releasepr.yml
+++ b/.github/workflows/releasepr.yml
@@ -3,6 +3,10 @@ name: Create Release PR
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   createPR:
     runs-on: ubuntu-latest

--- a/.github/workflows/releasepr.yml
+++ b/.github/workflows/releasepr.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       
       - name: Get package info
         shell: bash
@@ -20,7 +20,7 @@ jobs:
         run: echo "version=$(python scripts/get_package_version.py)" >> $GITHUB_OUTPUT
 
       - name: 'Find pre-release with tag v${{ steps.package-info.outputs.version}}'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         id: pre-release-exists
         env:
           APP_VERSION: ${{ steps.package-info.outputs.version}}
@@ -41,7 +41,7 @@ jobs:
 
       - name: Create Release pull request
         if: steps.pre-release-exists.outputs.result == 'true'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           token: ${{ secrets.JLAB_APP_TOKEN }}
           commit-message: Update auto-release logs

--- a/.github/workflows/sync_lab_release.yml
+++ b/.github/workflows/sync_lab_release.yml
@@ -18,16 +18,16 @@ jobs:
       latest: ${{ steps.get-latest-jupyterlab-version.outputs.result }}
       update_available: ${{ steps.check-update.outputs.update_available }}
     steps:
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         id: app-token
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.9'
 
@@ -36,7 +36,7 @@ jobs:
 
       - name: Get latest JupyterLab version
         id: get-latest-jupyterlab-version
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -61,7 +61,7 @@ jobs:
           fi
 
       - name: Upload updated version spec files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: steps.check-update.outputs.update_available == 'true'
         with:
           name: updated-version-info
@@ -82,16 +82,16 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Download updated version info
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: updated-version-info
           path: .
 
       - name: Install Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: '20.x'
 
@@ -100,7 +100,7 @@ jobs:
           npm install --global yarn
           yarn install
 
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3
         with:
           auto-update-conda: true
           auto-activate-base: true
@@ -134,7 +134,7 @@ jobs:
           done
 
       - name: Upload updated repo as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: updated-repo
           path: changed-files/
@@ -149,18 +149,18 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         id: app-token
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Download updated lock files and sign lists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: updated-repo
           path: .

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -15,8 +15,8 @@ jobs:
     # Action can only be run on windows
     runs-on: windows-latest
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
-        # https://github.com/vedantmgoyal2009/winget-releaser
+      - uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
+# https://github.com/vedantmgoyal9/winget-releaser
         with:
           identifier: ProjectJupyter.JupyterLab
           token: ${{ secrets.WINGET_TOKEN }}

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -7,6 +7,9 @@ on:
         description: Version to release
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     # Action can only be run on windows

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -15,7 +15,7 @@ jobs:
     # Action can only be run on windows
     runs-on: windows-latest
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@v2
+      - uses: vedantmgoyal2009/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
         # https://github.com/vedantmgoyal2009/winget-releaser
         with:
           identifier: ProjectJupyter.JupyterLab

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 MANIFEST
+CLAUDE.md
 build
 dist
 lib

--- a/src/main/config/settings.ts
+++ b/src/main/config/settings.ts
@@ -326,10 +326,7 @@ export class WorkspaceSettings extends UserSettings {
     const exists = fs.existsSync(wsSettingsPath);
     if (Object.keys(wsSettings).length > 0 || exists) {
       if (!exists) {
-        const dirPath = path.dirname(wsSettingsPath);
-        if (!fs.existsSync(dirPath)) {
-          fs.mkdirSync(dirPath, { recursive: true });
-        }
+        fs.mkdirSync(path.dirname(wsSettingsPath), { recursive: true });
       }
       fs.writeFileSync(wsSettingsPath, JSON.stringify(wsSettings, null, 2));
     }

--- a/src/main/pythonenvdialog/pythonenvdialog.ts
+++ b/src/main/pythonenvdialog/pythonenvdialog.ts
@@ -985,7 +985,7 @@ export class ManagePythonEnvironmentDialog {
           } else {
             const envPath = getEnvInstallPath();
             createCommandPreview.value = \`python -m venv \$\{envPath\}\n\$\{envPath\}\$\{pathSeparator\}${activateRelPath.replace(
-              '\\',
+              /\\/g,
               '\\\\'
             )}\npython -m pip install \$\{getPackageList()\}\`;
           }

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -300,7 +300,11 @@ export class JupyterServer {
 
         console.debug(
           `Server launch parameters:\n  [script]: ${launchScriptPath}\n  [options]: ${JSON.stringify(
-            execOptions
+            {
+              cwd: execOptions.cwd,
+              shell: execOptions.shell,
+              envVarCount: Object.keys(execOptions.env || {}).length
+            }
           )}`
         );
 


### PR DESCRIPTION
Addresses the CodeQL alerts that opened on master. Each commit maps to one finding so they can be reviewed independently.

## Code fixes (high)

- Incomplete string escaping (CWE-116) in the venv activate path preview: `String.replace` with a string pattern only replaced the first backslash, leaving a Windows path partially escaped. Switched to a global regex.
- Clear-text logging (CWE-312) in the server launcher: the debug log stringified the full `execOptions`, which embeds the process environment and any user-set server env vars. It now logs only cwd, shell, and the env var count.
- File-system race (CWE-367) in workspace settings save: `existsSync` followed by `mkdirSync` was a redundant TOCTOU pattern, since `mkdirSync({ recursive: true })` is already idempotent. The guard is gone.

## CI hardening

- Added least-privilege `GITHUB_TOKEN` permissions to the workflows that lacked them. ~~Release workflows get `contents: write` plus `pull-requests: write`; winget and publish default to `contents: read`.~~ All four default to `contents: read`: the release workflows authenticate their writes with `secrets.JLAB_APP_TOKEN`, so `GITHUB_TOKEN` never needs write (per Copilot review, 1183eee).
- Pinned every workflow action to a full-length commit SHA with the version in a trailing comment. Several actions are third-party and run with the release/signing secrets, so a moved tag was the higher-value risk. Dependabot's existing github-actions config keeps the pins current. This also delivers the hardening discussed in #963.

## Not changed here (by design)

A set of medium alerts flag the Python launcher building shell commands (`spawn`/`exec` for env activation, the installer unpack, and the terminal-open helpers) and the env installer download. Those commands are built from local, user-controlled configuration rather than remote input, and a correct fix means refactoring the terminal launchers to `execFile` across macOS/Windows/Linux, which needs manual GUI testing rather than CI. Leaving them open for a dedicated, tested follow-up rather than shipping an unverified refactor that could break launching a terminal.

Local verification: `yarn build` green, `npx tsc --noEmit` exit 0, all five workflow YAML files parse.

Note: AI-assisted (Claude Code). Manually verified the build and type-check, confirmed each action SHA resolves from its tag via the GitHub API, and checked the redacted log no longer references the env object.
