### PR TITLE
test: main-process unit coverage with CI-enforced thresholds (C2)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,7 @@ jobs:
   test:
     name: 'Unit tests'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -25,7 +26,7 @@ jobs:
           node-version: '20.x'
           cache: 'yarn'
       - run: yarn install --frozen-lockfile
-      - run: yarn test:unit
+      - run: yarn test:coverage
 
   publish:
     needs: test

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules
 .npmrc
 .cache
 .eslintcache
+coverage
 .vscode/*
 !.vscode/launch.json
 *.py[co]

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "yarn test:unit",
     "test:unit": "vitest run",
     "test:unit:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "clean": "rimraf build dist",
     "watch:tsc": "tsc -w",

--- a/src/main/env.ts
+++ b/src/main/env.ts
@@ -349,6 +349,7 @@ export async function validateCondaPath(
                         resolve({
                           valid: true
                         });
+                        return;
                       }
                     } catch (error) {
                       //

--- a/src/main/eventmanager.ts
+++ b/src/main/eventmanager.ts
@@ -67,7 +67,9 @@ export class EventManager implements IDisposable {
     const handlers = this._syncEventHandlers.get(eventType);
     const index = handlers.indexOf(handler);
     if (index !== -1) {
-      ipcMain.removeListener(eventType, handler);
+      // sync handlers register via ipcMain.handle, which is unbound with
+      // removeHandler(channel); removeListener only applies to ipcMain.on.
+      ipcMain.removeHandler(eventType);
       handlers.splice(index, 1);
     }
   }
@@ -85,13 +87,9 @@ export class EventManager implements IDisposable {
   }
 
   unregisterAllSyncEventHandlers() {
-    this._syncEventHandlers.forEach(
-      (handlers: SyncEventHandlerMain[], eventType: EventTypeMain) => {
-        for (const handler of handlers) {
-          ipcMain.removeListener(eventType, handler);
-        }
-      }
-    );
+    for (const eventType of this._syncEventHandlers.keys()) {
+      ipcMain.removeHandler(eventType);
+    }
 
     this._syncEventHandlers.clear();
   }

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -407,6 +407,9 @@ export async function deletePythonEnvironment(
         'Environment cannot be deleted since it was not installed by JupyterLab Desktop.'
       );
       reject();
+      // without this return the guard is advisory only: execution falls
+      // through and rmSync deletes the directory the guard just refused.
+      return;
     }
 
     try {

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -124,9 +124,15 @@ export function clearSession(session: Electron.Session): Promise<void> {
         session.clearAuthCache(),
         session.clearStorageData(),
         session.flushStorageData()
-      ]).then(() => {
-        resolve();
-      });
+      ])
+        .then(() => {
+          resolve();
+        })
+        // without a rejection handler an async failure in any clear*() call
+        // leaves this promise pending forever; the try/catch only sees sync throws.
+        .catch(() => {
+          reject();
+        });
     } catch (error) {
       reject();
     }
@@ -630,6 +636,7 @@ export async function runCommand(
     execFile(executablePath, commands, options, (error, stdout, stderr) => {
       if (error) {
         reject(error);
+        return;
       }
       if (stdout) {
         resolve(stdout);

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -117,24 +117,19 @@ export function isDarkTheme(themeType: string) {
 }
 
 export function clearSession(session: Electron.Session): Promise<void> {
-  return new Promise((resolve, reject) => {
-    try {
-      Promise.all([
-        session.clearCache(),
-        session.clearAuthCache(),
-        session.clearStorageData(),
-        session.flushStorageData()
-      ])
-        .then(() => {
-          resolve();
-        })
-        // without a rejection handler an async failure in any clear*() call
-        // leaves this promise pending forever; the try/catch only sees sync throws.
-        .catch(() => {
-          reject();
-        });
-    } catch (error) {
-      reject();
+  // best-effort teardown: callers await this before closing windows, so a
+  // failure to clear one cache must not reject and skip that cleanup, nor hang
+  // (Promise.all with no catch would). allSettled always resolves; log failures.
+  return Promise.allSettled([
+    session.clearCache(),
+    session.clearAuthCache(),
+    session.clearStorageData(),
+    session.flushStorageData()
+  ]).then(results => {
+    for (const result of results) {
+      if (result.status === 'rejected') {
+        log.error('Failed to clear part of the session', result.reason);
+      }
     }
   });
 }

--- a/test/setup/electron-mock.ts
+++ b/test/setup/electron-mock.ts
@@ -17,6 +17,7 @@ vi.mock('electron', () => ({
     on: vi.fn(),
     handle: vi.fn(),
     removeHandler: vi.fn(),
+    removeListener: vi.fn(),
     removeAllListeners: vi.fn(),
     emit: vi.fn()
   },

--- a/test/unit/appdata.test.ts
+++ b/test/unit/appdata.test.ts
@@ -228,6 +228,16 @@ describe('ApplicationData.addSessionToRecents', () => {
     expect(appData.recentSessions[0].remoteURL).toBe('https://hub.example.com');
   });
 
+  it('caps the recents list at 20 entries', async () => {
+    for (let i = 0; i < 25; i++) {
+      await appData.addSessionToRecents({
+        workingDirectory: `/data/nb${i}`,
+        filesToOpen: []
+      });
+    }
+    expect(appData.recentSessions).toHaveLength(20);
+  });
+
   it('updates date of duplicate local session without duplicating', async () => {
     const oldDate = new Date(Date.now() - 5000);
     appData.recentSessions = [

--- a/test/unit/appdata.test.ts
+++ b/test/unit/appdata.test.ts
@@ -1,0 +1,292 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: vi.fn(() => false),
+    readFileSync: vi.fn(() => {
+      throw new Error('ENOENT');
+    }),
+    writeFileSync: vi.fn(),
+    mkdirSync: vi.fn()
+  };
+});
+
+import { appData, ApplicationData } from '../../src/main/config/appdata';
+
+const mockFs = vi.mocked(fs);
+
+function resetAppData() {
+  appData.pythonPath = '';
+  appData.condaPath = '';
+  appData.systemPythonPath = '';
+  appData.recentRemoteURLs = [];
+  appData.recentSessions = [];
+  appData.discoveredPythonEnvs = [];
+  appData.userSetPythonEnvs = [];
+  appData.newsList = [];
+  appData.sessions = [];
+  appData.updateBundledEnvOnRestart = false;
+}
+
+describe('ApplicationData.getAppDataPath', () => {
+  it('returns a path ending with app-data.json', () => {
+    const p = ApplicationData.getAppDataPath();
+    expect(p).toMatch(/app-data\.json$/);
+  });
+
+  it('includes the userData directory', () => {
+    const p = ApplicationData.getAppDataPath();
+    expect(p).toContain('jlab-test-userdata');
+  });
+});
+
+describe('ApplicationData.read', () => {
+  beforeEach(() => {
+    resetAppData();
+  });
+
+  it('no-ops gracefully when file does not exist', () => {
+    mockFs.existsSync = vi.fn(() => false);
+    expect(() => appData.read()).not.toThrow();
+  });
+
+  it('reads pythonPath from JSON', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.readFileSync = vi.fn(() =>
+      Buffer.from(JSON.stringify({ pythonPath: '/usr/bin/python3' }))
+    );
+    appData.read();
+    expect(appData.pythonPath).toBe('/usr/bin/python3');
+  });
+
+  it('reads condaPath from JSON', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.readFileSync = vi.fn(() =>
+      Buffer.from(JSON.stringify({ condaPath: '/opt/conda/bin/conda' }))
+    );
+    appData.read();
+    expect(appData.condaPath).toBe('/opt/conda/bin/conda');
+  });
+
+  it('migrates legacy condaRootPath to condaPath', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.readFileSync = vi.fn(() =>
+      Buffer.from(JSON.stringify({ condaRootPath: '/opt/conda' }))
+    );
+    appData.read();
+    expect(appData.condaPath).toContain('conda');
+    expect(appData.condaPath).toContain('/opt/conda');
+  });
+
+  it('reads recentRemoteURLs list', () => {
+    const date = new Date('2024-01-01').toISOString();
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.readFileSync = vi.fn(() =>
+      Buffer.from(
+        JSON.stringify({
+          recentRemoteURLs: [{ url: 'https://example.com', date }]
+        })
+      )
+    );
+    appData.read();
+    expect(appData.recentRemoteURLs).toHaveLength(1);
+    expect(appData.recentRemoteURLs[0].url).toBe('https://example.com');
+  });
+
+  it('reads updateBundledEnvOnRestart flag', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.readFileSync = vi.fn(() =>
+      Buffer.from(JSON.stringify({ updateBundledEnvOnRestart: true }))
+    );
+    appData.read();
+    expect(appData.updateBundledEnvOnRestart).toBe(true);
+  });
+});
+
+describe('ApplicationData.save', () => {
+  beforeEach(() => {
+    resetAppData();
+    mockFs.existsSync = vi.fn(() => false);
+    mockFs.writeFileSync = vi.fn();
+  });
+
+  it('calls writeFileSync with app-data.json path', () => {
+    appData.save();
+    expect(mockFs.writeFileSync).toHaveBeenCalledOnce();
+    const [writePath] = (mockFs.writeFileSync as any).mock.calls[0];
+    expect(writePath).toMatch(/app-data\.json$/);
+  });
+
+  it('omits empty pythonPath from saved JSON', () => {
+    appData.pythonPath = '';
+    appData.save();
+    const content = (mockFs.writeFileSync as any).mock.calls[0][1] as string;
+    const json = JSON.parse(content);
+    expect(json).not.toHaveProperty('pythonPath');
+  });
+
+  it('includes non-empty pythonPath in saved JSON', () => {
+    appData.pythonPath = '/usr/bin/python3';
+    appData.save();
+    const content = (mockFs.writeFileSync as any).mock.calls[0][1] as string;
+    const json = JSON.parse(content);
+    expect(json.pythonPath).toBe('/usr/bin/python3');
+  });
+
+  it('saves recentRemoteURLs with ISO date strings', () => {
+    appData.recentRemoteURLs = [
+      { url: 'https://example.com', date: new Date('2024-06-01') }
+    ];
+    appData.save();
+    const content = (mockFs.writeFileSync as any).mock.calls[0][1] as string;
+    const json = JSON.parse(content);
+    expect(json.recentRemoteURLs).toHaveLength(1);
+    expect(json.recentRemoteURLs[0].url).toBe('https://example.com');
+    expect(typeof json.recentRemoteURLs[0].date).toBe('string');
+  });
+});
+
+describe('ApplicationData.addRemoteURLToRecents', () => {
+  beforeEach(() => {
+    appData.recentRemoteURLs = [];
+  });
+
+  it('adds a new URL', () => {
+    appData.addRemoteURLToRecents('https://example.com');
+    expect(appData.recentRemoteURLs).toHaveLength(1);
+    expect(appData.recentRemoteURLs[0].url).toBe('https://example.com');
+  });
+
+  it('new entry gets a date close to now', () => {
+    const before = Date.now();
+    appData.addRemoteURLToRecents('https://example.com');
+    expect(appData.recentRemoteURLs[0].date.valueOf()).toBeGreaterThanOrEqual(
+      before
+    );
+  });
+
+  it('updates date of existing URL without duplicating', () => {
+    const oldDate = new Date(Date.now() - 5000);
+    appData.recentRemoteURLs = [{ url: 'https://example.com', date: oldDate }];
+    appData.addRemoteURLToRecents('https://example.com');
+    expect(appData.recentRemoteURLs).toHaveLength(1);
+    expect(appData.recentRemoteURLs[0].date.valueOf()).toBeGreaterThan(
+      oldDate.valueOf()
+    );
+  });
+
+  it('treats different URLs as separate entries', () => {
+    appData.addRemoteURLToRecents('https://a.com');
+    appData.addRemoteURLToRecents('https://b.com');
+    expect(appData.recentRemoteURLs).toHaveLength(2);
+  });
+});
+
+describe('ApplicationData.removeRemoteURLFromRecents', () => {
+  beforeEach(() => {
+    appData.recentRemoteURLs = [
+      { url: 'https://a.com', date: new Date() },
+      { url: 'https://b.com', date: new Date() }
+    ];
+  });
+
+  it('removes the matching URL', () => {
+    appData.removeRemoteURLFromRecents('https://a.com');
+    expect(appData.recentRemoteURLs).toHaveLength(1);
+    expect(appData.recentRemoteURLs[0].url).toBe('https://b.com');
+  });
+
+  it('no-ops when URL is not in list', () => {
+    appData.removeRemoteURLFromRecents('https://missing.com');
+    expect(appData.recentRemoteURLs).toHaveLength(2);
+  });
+});
+
+describe('ApplicationData.addSessionToRecents', () => {
+  beforeEach(() => {
+    appData.recentSessions = [];
+  });
+
+  it('adds a new local session', async () => {
+    await appData.addSessionToRecents({
+      workingDirectory: '/data/nb',
+      filesToOpen: []
+    });
+    expect(appData.recentSessions).toHaveLength(1);
+    expect(appData.recentSessions[0].workingDirectory).toBe('/data/nb');
+  });
+
+  it('adds a new remote session', async () => {
+    await appData.addSessionToRecents({
+      remoteURL: 'https://hub.example.com',
+      filesToOpen: []
+    });
+    expect(appData.recentSessions).toHaveLength(1);
+    expect(appData.recentSessions[0].remoteURL).toBe('https://hub.example.com');
+  });
+
+  it('updates date of duplicate local session without duplicating', async () => {
+    const oldDate = new Date(Date.now() - 5000);
+    appData.recentSessions = [
+      {
+        workingDirectory: '/data/nb',
+        filesToOpen: [],
+        date: oldDate
+      }
+    ];
+    await appData.addSessionToRecents({
+      workingDirectory: '/data/nb',
+      filesToOpen: []
+    });
+    expect(appData.recentSessions).toHaveLength(1);
+    expect(appData.recentSessions[0].date.valueOf()).toBeGreaterThan(
+      oldDate.valueOf()
+    );
+  });
+
+  it('re-adding existing session updates date without duplicating', async () => {
+    await appData.addSessionToRecents({
+      workingDirectory: '/a',
+      filesToOpen: []
+    });
+    const before = appData.recentSessions[0].date.valueOf();
+    // small delay so new Date() advances
+    await new Promise(r => setTimeout(r, 5));
+    await appData.addSessionToRecents({
+      workingDirectory: '/a',
+      filesToOpen: []
+    });
+    expect(appData.recentSessions).toHaveLength(1);
+    expect(appData.recentSessions[0].date.valueOf()).toBeGreaterThanOrEqual(
+      before
+    );
+  });
+});
+
+describe('ApplicationData.removeSessionFromRecents', () => {
+  beforeEach(() => {
+    appData.recentSessions = [
+      { workingDirectory: '/a', filesToOpen: [], date: new Date() },
+      { workingDirectory: '/b', filesToOpen: [], date: new Date() }
+    ];
+  });
+
+  it('removes session at given index', async () => {
+    await appData.removeSessionFromRecents(0);
+    expect(appData.recentSessions).toHaveLength(1);
+    expect(appData.recentSessions[0].workingDirectory).toBe('/b');
+  });
+
+  it('no-ops for out-of-bounds index', async () => {
+    await appData.removeSessionFromRecents(99);
+    expect(appData.recentSessions).toHaveLength(2);
+  });
+
+  it('no-ops for negative index', async () => {
+    await appData.removeSessionFromRecents(-1);
+    expect(appData.recentSessions).toHaveLength(2);
+  });
+});

--- a/test/unit/appdata.test.ts
+++ b/test/unit/appdata.test.ts
@@ -48,9 +48,14 @@ describe('ApplicationData.read', () => {
     resetAppData();
   });
 
-  it('no-ops gracefully when file does not exist', () => {
+  it('does not read or mutate state when the file does not exist', () => {
     mockFs.existsSync = vi.fn(() => false);
-    expect(() => appData.read()).not.toThrow();
+    mockFs.readFileSync = vi.fn();
+    const pythonPathBefore = appData.pythonPath;
+    appData.read();
+    // the missing-file guard must short-circuit before parsing anything
+    expect(mockFs.readFileSync).not.toHaveBeenCalled();
+    expect(appData.pythonPath).toBe(pythonPathBefore);
   });
 
   it('reads pythonPath from JSON', () => {

--- a/test/unit/cli-handlers.test.ts
+++ b/test/unit/cli-handlers.test.ts
@@ -128,13 +128,13 @@ describe('addUserSetEnvironment', () => {
   it('pushes venv entry to appData.userSetPythonEnvs and saves', () => {
     addUserSetEnvironment('/home/user/myenv', false);
     expect(appData.userSetPythonEnvs).toHaveLength(1);
-    expect(appData.userSetPythonEnvs[0].name).toContain('venv');
+    expect(appData.userSetPythonEnvs[0].name).toBe('venv: myenv');
     expect(appData.save).toHaveBeenCalledOnce();
   });
 
   it('pushes conda entry when isConda=true', () => {
     addUserSetEnvironment('/home/user/myconda', true);
-    expect(appData.userSetPythonEnvs[0].name).toContain('conda');
+    expect(appData.userSetPythonEnvs[0].name).toBe('conda: myconda');
   });
 
   it('sets userSettings pythonPath when none configured and env python exists', () => {
@@ -177,7 +177,7 @@ describe('handleEnvSetPythonEnvsPathCommand', () => {
   it('logs error and skips save when no path provided', async () => {
     const spy = vi.spyOn(console, 'error').mockReturnValue(undefined);
     await handleEnvSetPythonEnvsPathCommand({ _: ['set-envs-path'] });
-    expect(spy).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledWith('Please set a valid envs directory');
     expect(userSettings.setValue).not.toHaveBeenCalled();
     spy.mockRestore();
   });
@@ -245,7 +245,7 @@ describe('handleEnvSetSystemPythonPathCommand', () => {
     await handleEnvSetSystemPythonPathCommand({
       _: ['set-sys-python', '/no/python']
     });
-    expect(spy).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledWith('Python path "/no/python" does not exist');
     expect(userSettings.setValue).not.toHaveBeenCalled();
     spy.mockRestore();
   });
@@ -260,7 +260,9 @@ describe('handleEnvSetSystemPythonPathCommand', () => {
     await handleEnvSetSystemPythonPathCommand({
       _: ['set-sys-python', '/bad/python']
     });
-    expect(spy).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledWith(
+      '"/bad/python" is not a valid Python path'
+    );
     expect(userSettings.setValue).not.toHaveBeenCalled();
     spy.mockRestore();
   });
@@ -268,7 +270,7 @@ describe('handleEnvSetSystemPythonPathCommand', () => {
   it('logs error when no path argument given', async () => {
     const spy = vi.spyOn(console, 'error').mockReturnValue(undefined);
     await handleEnvSetSystemPythonPathCommand({ _: ['set-sys-python'] });
-    expect(spy).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledWith('Please set a valid Python path');
     expect(userSettings.setValue).not.toHaveBeenCalled();
     spy.mockRestore();
   });
@@ -292,7 +294,7 @@ describe('handleEnvSetCondaPathCommand', () => {
     mockFs.existsSync = vi.fn(() => false);
     const spy = vi.spyOn(console, 'error').mockReturnValue(undefined);
     await handleEnvSetCondaPathCommand({ _: ['set-conda-path', '/no/conda'] });
-    expect(spy).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledWith('conda path "/no/conda" does not exist');
     expect(userSettings.setValue).not.toHaveBeenCalled();
     spy.mockRestore();
   });
@@ -305,7 +307,7 @@ describe('handleEnvSetCondaPathCommand', () => {
     });
     const spy = vi.spyOn(console, 'error').mockReturnValue(undefined);
     await handleEnvSetCondaPathCommand({ _: ['set-conda-path', '/bad/conda'] });
-    expect(spy).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledWith('"/bad/conda" is not a valid conda path');
     expect(userSettings.setValue).not.toHaveBeenCalled();
     spy.mockRestore();
   });
@@ -313,7 +315,7 @@ describe('handleEnvSetCondaPathCommand', () => {
   it('logs error when no path argument given', async () => {
     const spy = vi.spyOn(console, 'error').mockReturnValue(undefined);
     await handleEnvSetCondaPathCommand({ _: ['set-conda-path'] });
-    expect(spy).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledWith('Please set a valid conda path');
     expect(userSettings.setValue).not.toHaveBeenCalled();
     spy.mockRestore();
   });

--- a/test/unit/cli-handlers.test.ts
+++ b/test/unit/cli-handlers.test.ts
@@ -97,7 +97,7 @@ import {
   handleEnvSetSystemPythonPathCommand
 } from '../../src/main/cli';
 import { appData } from '../../src/main/config/appdata';
-import { userSettings } from '../../src/main/config/settings';
+import { SettingType, userSettings } from '../../src/main/config/settings';
 import * as envModule from '../../src/main/env';
 
 const mockFs = vi.mocked(fs);
@@ -145,7 +145,7 @@ describe('addUserSetEnvironment', () => {
     );
     addUserSetEnvironment('/home/user/myenv', false);
     expect(userSettings.setValue).toHaveBeenCalledWith(
-      expect.any(String),
+      SettingType.pythonPath,
       expect.stringContaining('/home/user/myenv')
     );
     expect(userSettings.save).toHaveBeenCalledOnce();
@@ -168,7 +168,7 @@ describe('handleEnvSetPythonEnvsPathCommand', () => {
       _: ['set-envs-path', '/my/envs']
     });
     expect(userSettings.setValue).toHaveBeenCalledWith(
-      expect.any(String),
+      SettingType.pythonEnvsPath,
       '/my/envs'
     );
     expect(userSettings.save).toHaveBeenCalledOnce();
@@ -205,7 +205,9 @@ describe('handleEnvSetCondaChannelsCommand', () => {
     await handleEnvSetCondaChannelsCommand({
       _: ['set-conda-channels', 'conda-forge', 'defaults']
     });
-    expect(userSettings.setValue).toHaveBeenCalledWith(expect.any(String), [
+    expect(
+      userSettings.setValue
+    ).toHaveBeenCalledWith(SettingType.condaChannels, [
       'conda-forge',
       'defaults'
     ]);
@@ -214,7 +216,10 @@ describe('handleEnvSetCondaChannelsCommand', () => {
 
   it('sets empty array when no channels given', async () => {
     await handleEnvSetCondaChannelsCommand({ _: ['set-conda-channels'] });
-    expect(userSettings.setValue).toHaveBeenCalledWith(expect.any(String), []);
+    expect(userSettings.setValue).toHaveBeenCalledWith(
+      SettingType.condaChannels,
+      []
+    );
   });
 });
 
@@ -228,7 +233,7 @@ describe('handleEnvSetSystemPythonPathCommand', () => {
       _: ['set-sys-python', '/usr/bin/python3']
     });
     expect(userSettings.setValue).toHaveBeenCalledWith(
-      expect.any(String),
+      SettingType.systemPythonPath,
       '/usr/bin/python3'
     );
     expect(userSettings.save).toHaveBeenCalledOnce();
@@ -277,7 +282,7 @@ describe('handleEnvSetCondaPathCommand', () => {
       _: ['set-conda-path', '/usr/bin/conda']
     });
     expect(userSettings.setValue).toHaveBeenCalledWith(
-      expect.any(String),
+      SettingType.condaPath,
       '/usr/bin/conda'
     );
     expect(userSettings.save).toHaveBeenCalledOnce();

--- a/test/unit/cli-handlers.test.ts
+++ b/test/unit/cli-handlers.test.ts
@@ -90,6 +90,7 @@ vi.mock('../../src/main/registry', () => ({ Registry: vi.fn() }));
 
 import {
   addUserSetEnvironment,
+  handleEnvActivateCommand,
   handleEnvSetCondaChannelsCommand,
   handleEnvSetCondaPathCommand,
   handleEnvSetPythonEnvsPathCommand,
@@ -316,5 +317,22 @@ describe('handleEnvSetCondaPathCommand', () => {
     expect(spy).toHaveBeenCalled();
     expect(userSettings.setValue).not.toHaveBeenCalled();
     spy.mockRestore();
+  });
+});
+
+describe('handleEnvActivateCommand', () => {
+  it('rejects an invalid environment directory and does not activate', async () => {
+    mockFs.existsSync = vi.fn(() => false);
+    const errorSpy = vi.spyOn(console, 'error').mockReturnValue(undefined);
+    const logSpy = vi.spyOn(console, 'log').mockReturnValue(undefined);
+    await handleEnvActivateCommand({ _: ['env-activate', '/nonexistent/env'] });
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Invalid environment directory')
+    );
+    expect(logSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('Activating')
+    );
+    errorSpy.mockRestore();
+    logSpy.mockRestore();
   });
 });

--- a/test/unit/cli-handlers.test.ts
+++ b/test/unit/cli-handlers.test.ts
@@ -1,0 +1,320 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: vi.fn(() => false),
+    writeFileSync: vi.fn(),
+    readFileSync: vi.fn(() => '{}'),
+    mkdirSync: vi.fn()
+  };
+});
+vi.mock('child_process', async () => {
+  const actual = await vi.importActual<typeof import('child_process')>(
+    'child_process'
+  );
+  return { ...actual, execFileSync: vi.fn(), spawn: vi.fn() };
+});
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => '/tmp/jlab-test'),
+    getVersion: vi.fn(() => '1.0.0'),
+    getName: vi.fn(() => 'JupyterLab')
+  },
+  shell: { openPath: vi.fn() }
+}));
+vi.mock('../../src/main/config/appdata', () => ({
+  appData: {
+    userSetPythonEnvs: [],
+    save: vi.fn()
+  },
+  ApplicationData: { getSingleton: vi.fn() }
+}));
+vi.mock('../../src/main/config/settings', () => ({
+  userSettings: {
+    getValue: vi.fn(() => ''),
+    setValue: vi.fn(),
+    save: vi.fn()
+  },
+  SettingType: {
+    pythonPath: 'pythonPath',
+    pythonEnvsPath: 'pythonEnvsPath',
+    condaPath: 'condaPath',
+    condaChannels: 'condaChannels',
+    systemPythonPath: 'systemPythonPath'
+  },
+  UserSettings: vi.fn(),
+  WorkspaceSettings: vi.fn()
+}));
+vi.mock('../../src/main/utils', () => ({
+  getBundledPythonPath: vi.fn(() => '/bundled/python'),
+  getBundledPythonEnvPath: vi.fn(() => '/bundled/env'),
+  getBundledEnvInstallerPath: vi.fn(() => '/bundled/installer'),
+  getLogFilePath: vi.fn(() => '/tmp/jlab.log'),
+  pythonPathForEnvPath: vi.fn((envPath: string) => `${envPath}/bin/python`),
+  envPathForPythonPath: vi.fn((pythonPath: string) =>
+    pythonPath.replace('/bin/python', '')
+  ),
+  createCommandScriptInEnv: vi.fn(),
+  createTempFile: vi.fn(),
+  installCondaPackEnvironment: vi.fn(),
+  isBaseCondaEnv: vi.fn(() => false),
+  isEnvInstalledByDesktopApp: vi.fn(() => false),
+  markEnvironmentAsJupyterInstalled: vi.fn(),
+  EnvironmentInstallStatus: {
+    RemovingExistingInstallation: 'RemovingExistingInstallation',
+    Started: 'Started',
+    Cancelled: 'Cancelled',
+    Failure: 'Failure',
+    Success: 'Success'
+  }
+}));
+vi.mock('../../src/main/env', () => ({
+  validateCondaPath: vi.fn(async () => ({ valid: true })),
+  validateSystemPythonPath: vi.fn(async () => ({ valid: true })),
+  validatePythonEnvironmentInstallDirectory: vi.fn(() => ({
+    valid: true,
+    message: ''
+  })),
+  getPythonEnvsDirectory: vi.fn(() => '/home/user/.jlab/envs'),
+  getCondaPath: vi.fn(() => ''),
+  getCondaChannels: vi.fn(() => []),
+  getSystemPythonPath: vi.fn(() => ''),
+  condaEnvPathForCondaExePath: vi.fn((p: string) => p),
+  runCommandInEnvironment: vi.fn(),
+  ICommandRunCallbacks: {}
+}));
+vi.mock('../../src/main/registry', () => ({ Registry: vi.fn() }));
+
+import {
+  addUserSetEnvironment,
+  handleEnvSetCondaChannelsCommand,
+  handleEnvSetCondaPathCommand,
+  handleEnvSetPythonEnvsPathCommand,
+  handleEnvSetSystemPythonPathCommand
+} from '../../src/main/cli';
+import { appData } from '../../src/main/config/appdata';
+import { userSettings } from '../../src/main/config/settings';
+import * as envModule from '../../src/main/env';
+
+const mockFs = vi.mocked(fs);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (appData as any).userSetPythonEnvs = [];
+  (appData as any).save = vi.fn();
+  mockFs.existsSync = vi.fn(() => false);
+  (userSettings as any).getValue = vi.fn(() => '');
+  (userSettings as any).setValue = vi.fn();
+  (userSettings as any).save = vi.fn();
+  vi.spyOn(envModule, 'validateCondaPath').mockResolvedValue({ valid: true });
+  vi.spyOn(envModule, 'validateSystemPythonPath').mockResolvedValue({
+    valid: true
+  });
+  vi.spyOn(
+    envModule,
+    'validatePythonEnvironmentInstallDirectory'
+  ).mockReturnValue({ valid: true, message: '' });
+});
+
+// ─── addUserSetEnvironment ────────────────────────────────────────────────────
+
+describe('addUserSetEnvironment', () => {
+  it('pushes venv entry to appData.userSetPythonEnvs and saves', () => {
+    addUserSetEnvironment('/home/user/myenv', false);
+    expect(appData.userSetPythonEnvs).toHaveLength(1);
+    expect(appData.userSetPythonEnvs[0].name).toContain('venv');
+    expect(appData.save).toHaveBeenCalledOnce();
+  });
+
+  it('pushes conda entry when isConda=true', () => {
+    addUserSetEnvironment('/home/user/myconda', true);
+    expect(appData.userSetPythonEnvs[0].name).toContain('conda');
+  });
+
+  it('sets userSettings pythonPath when none configured and env python exists', () => {
+    (userSettings as any).getValue = vi.fn(() => '');
+    // true only for paths under the env dir; bundled python path won't match regardless of mock
+    mockFs.existsSync = vi.fn((p: fs.PathLike) =>
+      p.toString().startsWith('/home/user/myenv')
+    );
+    addUserSetEnvironment('/home/user/myenv', false);
+    expect(userSettings.setValue).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining('/home/user/myenv')
+    );
+    expect(userSettings.save).toHaveBeenCalledOnce();
+  });
+
+  it('does not override existing pythonPath', () => {
+    (userSettings as any).getValue = vi.fn(() => '/existing/python');
+    addUserSetEnvironment('/home/user/myenv', false);
+    expect(userSettings.setValue).not.toHaveBeenCalled();
+  });
+});
+
+// ─── handleEnvSetPythonEnvsPathCommand ───────────────────────────────────────
+
+describe('handleEnvSetPythonEnvsPathCommand', () => {
+  it('sets pythonEnvsPath when dir is valid', async () => {
+    vi.spyOn(
+      envModule,
+      'validatePythonEnvironmentInstallDirectory'
+    ).mockReturnValue({ valid: true, message: '' });
+    await handleEnvSetPythonEnvsPathCommand({
+      _: ['set-envs-path', '/my/envs']
+    });
+    expect(userSettings.setValue).toHaveBeenCalledWith(
+      expect.any(String),
+      '/my/envs'
+    );
+    expect(userSettings.save).toHaveBeenCalledOnce();
+  });
+
+  it('logs error and skips save when no path provided', async () => {
+    const spy = vi.spyOn(console, 'error').mockReturnValue(undefined);
+    await handleEnvSetPythonEnvsPathCommand({ _: ['set-envs-path'] });
+    expect(spy).toHaveBeenCalled();
+    expect(userSettings.setValue).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('logs error and skips save when path is invalid', async () => {
+    vi.spyOn(
+      envModule,
+      'validatePythonEnvironmentInstallDirectory'
+    ).mockReturnValue({
+      valid: false,
+      message: 'not a directory'
+    });
+    const spy = vi.spyOn(console, 'error').mockReturnValue(undefined);
+    await handleEnvSetPythonEnvsPathCommand({
+      _: ['set-envs-path', '/bad/path']
+    });
+    expect(spy).toHaveBeenCalledWith('not a directory');
+    expect(userSettings.setValue).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+
+// ─── handleEnvSetCondaChannelsCommand ────────────────────────────────────────
+
+describe('handleEnvSetCondaChannelsCommand', () => {
+  it('sets conda channels from argv slice', async () => {
+    await handleEnvSetCondaChannelsCommand({
+      _: ['set-conda-channels', 'conda-forge', 'defaults']
+    });
+    expect(userSettings.setValue).toHaveBeenCalledWith(expect.any(String), [
+      'conda-forge',
+      'defaults'
+    ]);
+    expect(userSettings.save).toHaveBeenCalledOnce();
+  });
+
+  it('sets empty array when no channels given', async () => {
+    await handleEnvSetCondaChannelsCommand({ _: ['set-conda-channels'] });
+    expect(userSettings.setValue).toHaveBeenCalledWith(expect.any(String), []);
+  });
+});
+
+// ─── handleEnvSetSystemPythonPathCommand ─────────────────────────────────────
+
+describe('handleEnvSetSystemPythonPathCommand', () => {
+  it('sets systemPythonPath when path is valid', async () => {
+    mockFs.existsSync = vi.fn(() => true);
+    vi.spyOn(envModule, 'validateSystemPythonPath').mockResolvedValue({
+      valid: true
+    });
+    await handleEnvSetSystemPythonPathCommand({
+      _: ['set-sys-python', '/usr/bin/python3']
+    });
+    expect(userSettings.setValue).toHaveBeenCalledWith(
+      expect.any(String),
+      '/usr/bin/python3'
+    );
+    expect(userSettings.save).toHaveBeenCalledOnce();
+  });
+
+  it('logs error when path does not exist', async () => {
+    mockFs.existsSync = vi.fn(() => false);
+    const spy = vi.spyOn(console, 'error').mockReturnValue(undefined);
+    await handleEnvSetSystemPythonPathCommand({
+      _: ['set-sys-python', '/no/python']
+    });
+    expect(spy).toHaveBeenCalled();
+    expect(userSettings.setValue).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('logs error when path fails validation', async () => {
+    mockFs.existsSync = vi.fn(() => true);
+    vi.spyOn(envModule, 'validateSystemPythonPath').mockResolvedValue({
+      valid: false,
+      message: 'not python'
+    });
+    const spy = vi.spyOn(console, 'error').mockReturnValue(undefined);
+    await handleEnvSetSystemPythonPathCommand({
+      _: ['set-sys-python', '/bad/python']
+    });
+    expect(spy).toHaveBeenCalled();
+    expect(userSettings.setValue).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('logs error when no path argument given', async () => {
+    const spy = vi.spyOn(console, 'error').mockReturnValue(undefined);
+    await handleEnvSetSystemPythonPathCommand({ _: ['set-sys-python'] });
+    expect(spy).toHaveBeenCalled();
+    expect(userSettings.setValue).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+
+// ─── handleEnvSetCondaPathCommand ────────────────────────────────────────────
+
+describe('handleEnvSetCondaPathCommand', () => {
+  it('sets condaPath when path exists and is valid', async () => {
+    mockFs.existsSync = vi.fn(() => true);
+    vi.spyOn(envModule, 'validateCondaPath').mockResolvedValue({ valid: true });
+    await handleEnvSetCondaPathCommand({
+      _: ['set-conda-path', '/usr/bin/conda']
+    });
+    expect(userSettings.setValue).toHaveBeenCalledWith(
+      expect.any(String),
+      '/usr/bin/conda'
+    );
+    expect(userSettings.save).toHaveBeenCalledOnce();
+  });
+
+  it('logs error when path does not exist', async () => {
+    mockFs.existsSync = vi.fn(() => false);
+    const spy = vi.spyOn(console, 'error').mockReturnValue(undefined);
+    await handleEnvSetCondaPathCommand({ _: ['set-conda-path', '/no/conda'] });
+    expect(spy).toHaveBeenCalled();
+    expect(userSettings.setValue).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('logs error when conda path fails validation', async () => {
+    mockFs.existsSync = vi.fn(() => true);
+    vi.spyOn(envModule, 'validateCondaPath').mockResolvedValue({
+      valid: false,
+      message: 'not conda'
+    });
+    const spy = vi.spyOn(console, 'error').mockReturnValue(undefined);
+    await handleEnvSetCondaPathCommand({ _: ['set-conda-path', '/bad/conda'] });
+    expect(spy).toHaveBeenCalled();
+    expect(userSettings.setValue).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('logs error when no path argument given', async () => {
+    const spy = vi.spyOn(console, 'error').mockReturnValue(undefined);
+    await handleEnvSetCondaPathCommand({ _: ['set-conda-path'] });
+    expect(spy).toHaveBeenCalled();
+    expect(userSettings.setValue).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/test/unit/cli-handlers.test.ts
+++ b/test/unit/cli-handlers.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'fs';
 
 vi.mock('fs', async () => {
@@ -120,7 +120,9 @@ beforeEach(() => {
   ).mockReturnValue({ valid: true, message: '' });
 });
 
-// ─── addUserSetEnvironment ────────────────────────────────────────────────────
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('addUserSetEnvironment', () => {
   it('pushes venv entry to appData.userSetPythonEnvs and saves', () => {
@@ -155,8 +157,6 @@ describe('addUserSetEnvironment', () => {
     expect(userSettings.setValue).not.toHaveBeenCalled();
   });
 });
-
-// ─── handleEnvSetPythonEnvsPathCommand ───────────────────────────────────────
 
 describe('handleEnvSetPythonEnvsPathCommand', () => {
   it('sets pythonEnvsPath when dir is valid', async () => {
@@ -200,8 +200,6 @@ describe('handleEnvSetPythonEnvsPathCommand', () => {
   });
 });
 
-// ─── handleEnvSetCondaChannelsCommand ────────────────────────────────────────
-
 describe('handleEnvSetCondaChannelsCommand', () => {
   it('sets conda channels from argv slice', async () => {
     await handleEnvSetCondaChannelsCommand({
@@ -219,8 +217,6 @@ describe('handleEnvSetCondaChannelsCommand', () => {
     expect(userSettings.setValue).toHaveBeenCalledWith(expect.any(String), []);
   });
 });
-
-// ─── handleEnvSetSystemPythonPathCommand ─────────────────────────────────────
 
 describe('handleEnvSetSystemPythonPathCommand', () => {
   it('sets systemPythonPath when path is valid', async () => {
@@ -272,8 +268,6 @@ describe('handleEnvSetSystemPythonPathCommand', () => {
     spy.mockRestore();
   });
 });
-
-// ─── handleEnvSetCondaPathCommand ────────────────────────────────────────────
 
 describe('handleEnvSetCondaPathCommand', () => {
   it('sets condaPath when path exists and is valid', async () => {

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -1,0 +1,96 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/main/config/settings', () => ({
+  userSettings: { getValue: vi.fn(() => null), setValue: vi.fn() },
+  SettingType: { condaPath: 'condaPath', pythonPath: 'pythonPath' }
+}));
+vi.mock('../../src/main/config/appdata', () => ({
+  appData: { discoveredPythonEnvs: [], userSetPythonEnvs: [] }
+}));
+vi.mock('../../src/main/registry', () => ({
+  appRegistry: { getDefaultEnvironment: vi.fn() }
+}));
+vi.mock('../../src/main/env', () => ({
+  updateDiscoveredPythonPaths: vi.fn(() => Promise.resolve()),
+  getCondaPath: vi.fn(() => null),
+  getPythonEnvsDirectory: vi.fn(() => '/tmp/envs')
+}));
+vi.mock('../../src/main/utils', async () => {
+  const actual = await vi.importActual('../../src/main/utils');
+  return {
+    ...actual,
+    getUserDataDir: vi.fn(() => '/tmp/test-userdata'),
+    getUserHomeDir: vi.fn(() => '/tmp/home'),
+    getAppDir: vi.fn(() => '/tmp/app')
+  };
+});
+
+import { parseCLIArgs } from '../../src/main/cli';
+
+let exitSpy: ReturnType<typeof vi.spyOn>;
+
+beforeAll(() => {
+  exitSpy = vi
+    .spyOn(process, 'exit')
+    .mockImplementation(() => undefined as never);
+});
+afterAll(() => {
+  exitSpy.mockRestore();
+});
+
+async function parse(args: string[]) {
+  return parseCLIArgs(args);
+}
+
+describe('parseCLIArgs', () => {
+  it('parses --python-path', async () => {
+    const result = await parse(['--python-path', '/usr/bin/python3']);
+    expect(result['python-path']).toBe('/usr/bin/python3');
+  });
+
+  it('parses --working-dir', async () => {
+    const result = await parse(['--working-dir', '/home/user/notebooks']);
+    expect(result['working-dir']).toBe('/home/user/notebooks');
+  });
+
+  it('parses --log-level debug', async () => {
+    const result = await parse(['--log-level', 'debug']);
+    expect(result['log-level']).toBe('debug');
+  });
+
+  it('defaults log-level to warn', async () => {
+    const result = await parse([]);
+    expect(result['log-level']).toBe('warn');
+  });
+
+  it('defaults persist-session-data to true', async () => {
+    const result = await parse([]);
+    expect(result['persist-session-data']).toBe(true);
+  });
+
+  it('parses --no-persist-session-data', async () => {
+    const result = await parse(['--no-persist-session-data']);
+    expect(result['persist-session-data']).toBe(false);
+  });
+
+  it('parses positional file path', async () => {
+    const result = await parse(['/data/test.ipynb']);
+    expect(result._).toContain('/data/test.ipynb');
+  });
+
+  it('parses multiple positional paths', async () => {
+    const result = await parse(['/a.ipynb', '/b.ipynb']);
+    expect(result._).toContain('/a.ipynb');
+    expect(result._).toContain('/b.ipynb');
+  });
+
+  it('parses env subcommand', async () => {
+    const result = await parse(['env', 'list']);
+    expect(result._[0]).toBe('env');
+  });
+
+  it('invalid log-level calls process.exit', async () => {
+    await parse(['--log-level', 'invalid']);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/test/unit/eventmanager.test.ts
+++ b/test/unit/eventmanager.test.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ipcMain } from 'electron';
+import { EventManager } from '../../src/main/eventmanager';
+import { EventTypeMain } from '../../src/main/eventtypes';
+
+const mockIpcMain = vi.mocked(ipcMain);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('EventManager.registerEventHandler', () => {
+  it('calls ipcMain.on with the event type and handler', () => {
+    const mgr = new EventManager();
+    const handler = vi.fn();
+    mgr.registerEventHandler(EventTypeMain.OpenFile, handler);
+    expect(mockIpcMain.on).toHaveBeenCalledWith(
+      EventTypeMain.OpenFile,
+      handler
+    );
+  });
+
+  it('registers multiple handlers for same event type', () => {
+    const mgr = new EventManager();
+    const h1 = vi.fn();
+    const h2 = vi.fn();
+    mgr.registerEventHandler(EventTypeMain.OpenFile, h1);
+    mgr.registerEventHandler(EventTypeMain.OpenFile, h2);
+    expect(mockIpcMain.on).toHaveBeenCalledTimes(2);
+    expect(mockIpcMain.on).toHaveBeenCalledWith(EventTypeMain.OpenFile, h1);
+    expect(mockIpcMain.on).toHaveBeenCalledWith(EventTypeMain.OpenFile, h2);
+  });
+
+  it('registers handlers for different event types independently', () => {
+    const mgr = new EventManager();
+    const h1 = vi.fn();
+    const h2 = vi.fn();
+    mgr.registerEventHandler(EventTypeMain.OpenFile, h1);
+    mgr.registerEventHandler(EventTypeMain.OpenFolder, h2);
+    expect(mockIpcMain.on).toHaveBeenCalledWith(EventTypeMain.OpenFile, h1);
+    expect(mockIpcMain.on).toHaveBeenCalledWith(EventTypeMain.OpenFolder, h2);
+  });
+});
+
+describe('EventManager.registerSyncEventHandler', () => {
+  it('calls ipcMain.handle with the event type and handler', () => {
+    const mgr = new EventManager();
+    const handler = vi.fn();
+    mgr.registerSyncEventHandler(EventTypeMain.IsDarkTheme, handler);
+    expect(mockIpcMain.handle).toHaveBeenCalledWith(
+      EventTypeMain.IsDarkTheme,
+      handler
+    );
+  });
+
+  it('registers multiple sync handlers for same event', () => {
+    const mgr = new EventManager();
+    const h1 = vi.fn();
+    const h2 = vi.fn();
+    mgr.registerSyncEventHandler(EventTypeMain.IsDarkTheme, h1);
+    mgr.registerSyncEventHandler(EventTypeMain.IsDarkTheme, h2);
+    expect(mockIpcMain.handle).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('EventManager.unregisterEventHandler', () => {
+  it('calls ipcMain.removeListener and removes from internal map', () => {
+    const mgr = new EventManager();
+    const handler = vi.fn();
+    mgr.registerEventHandler(EventTypeMain.OpenFile, handler);
+    vi.clearAllMocks();
+    mgr.unregisterEventHandler(EventTypeMain.OpenFile, handler);
+    expect(mockIpcMain.removeListener).toHaveBeenCalledWith(
+      EventTypeMain.OpenFile,
+      handler
+    );
+  });
+
+  it('no-ops when event type was never registered', () => {
+    const mgr = new EventManager();
+    const handler = vi.fn();
+    expect(() =>
+      mgr.unregisterEventHandler(EventTypeMain.OpenFile, handler)
+    ).not.toThrow();
+    expect(mockIpcMain.removeListener).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when handler is not in the list', () => {
+    const mgr = new EventManager();
+    const h1 = vi.fn();
+    const h2 = vi.fn();
+    mgr.registerEventHandler(EventTypeMain.OpenFile, h1);
+    vi.clearAllMocks();
+    mgr.unregisterEventHandler(EventTypeMain.OpenFile, h2);
+    expect(mockIpcMain.removeListener).not.toHaveBeenCalled();
+  });
+
+  it('only removes the specified handler, leaves others intact', () => {
+    const mgr = new EventManager();
+    const h1 = vi.fn();
+    const h2 = vi.fn();
+    mgr.registerEventHandler(EventTypeMain.OpenFile, h1);
+    mgr.registerEventHandler(EventTypeMain.OpenFile, h2);
+    vi.clearAllMocks();
+    mgr.unregisterEventHandler(EventTypeMain.OpenFile, h1);
+    expect(mockIpcMain.removeListener).toHaveBeenCalledTimes(1);
+    expect(mockIpcMain.removeListener).toHaveBeenCalledWith(
+      EventTypeMain.OpenFile,
+      h1
+    );
+  });
+});
+
+describe('EventManager.unregisterSyncEventHandler', () => {
+  it('calls ipcMain.removeListener for sync handler', () => {
+    const mgr = new EventManager();
+    const handler = vi.fn();
+    mgr.registerSyncEventHandler(EventTypeMain.IsDarkTheme, handler);
+    vi.clearAllMocks();
+    mgr.unregisterSyncEventHandler(EventTypeMain.IsDarkTheme, handler);
+    expect(mockIpcMain.removeListener).toHaveBeenCalledWith(
+      EventTypeMain.IsDarkTheme,
+      handler
+    );
+  });
+
+  it('no-ops when event type was never registered', () => {
+    const mgr = new EventManager();
+    expect(() =>
+      mgr.unregisterSyncEventHandler(EventTypeMain.IsDarkTheme, vi.fn())
+    ).not.toThrow();
+    expect(mockIpcMain.removeListener).not.toHaveBeenCalled();
+  });
+});
+
+describe('EventManager.unregisterAllEventHandlers', () => {
+  it('removes all async handlers and calls ipcMain.removeListener for each', () => {
+    const mgr = new EventManager();
+    const h1 = vi.fn();
+    const h2 = vi.fn();
+    mgr.registerEventHandler(EventTypeMain.OpenFile, h1);
+    mgr.registerEventHandler(EventTypeMain.OpenFolder, h2);
+    vi.clearAllMocks();
+    mgr.unregisterAllEventHandlers();
+    expect(mockIpcMain.removeListener).toHaveBeenCalledWith(
+      EventTypeMain.OpenFile,
+      h1
+    );
+    expect(mockIpcMain.removeListener).toHaveBeenCalledWith(
+      EventTypeMain.OpenFolder,
+      h2
+    );
+  });
+
+  it('no-ops when no handlers registered', () => {
+    const mgr = new EventManager();
+    expect(() => mgr.unregisterAllEventHandlers()).not.toThrow();
+    expect(mockIpcMain.removeListener).not.toHaveBeenCalled();
+  });
+});
+
+describe('EventManager.unregisterAllSyncEventHandlers', () => {
+  it('removes all sync handlers', () => {
+    const mgr = new EventManager();
+    const h1 = vi.fn();
+    const h2 = vi.fn();
+    mgr.registerSyncEventHandler(EventTypeMain.IsDarkTheme, h1);
+    mgr.registerSyncEventHandler(EventTypeMain.IsDarkTheme, h2);
+    vi.clearAllMocks();
+    mgr.unregisterAllSyncEventHandlers();
+    expect(mockIpcMain.removeListener).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('EventManager.dispose', () => {
+  it('removes all async and sync handlers and returns a resolved Promise', async () => {
+    const mgr = new EventManager();
+    const async1 = vi.fn();
+    const sync1 = vi.fn();
+    mgr.registerEventHandler(EventTypeMain.OpenFile, async1);
+    mgr.registerSyncEventHandler(EventTypeMain.IsDarkTheme, sync1);
+    vi.clearAllMocks();
+    await expect(mgr.dispose()).resolves.toBeUndefined();
+    expect(mockIpcMain.removeListener).toHaveBeenCalledWith(
+      EventTypeMain.OpenFile,
+      async1
+    );
+    expect(mockIpcMain.removeListener).toHaveBeenCalledWith(
+      EventTypeMain.IsDarkTheme,
+      sync1
+    );
+  });
+
+  it('is safe to call dispose twice', async () => {
+    const mgr = new EventManager();
+    mgr.registerEventHandler(EventTypeMain.OpenFile, vi.fn());
+    await mgr.dispose();
+    vi.clearAllMocks();
+    await expect(mgr.dispose()).resolves.toBeUndefined();
+    expect(mockIpcMain.removeListener).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/eventmanager.test.ts
+++ b/test/unit/eventmanager.test.ts
@@ -53,13 +53,22 @@ describe('EventManager.registerSyncEventHandler', () => {
     );
   });
 
-  it('registers multiple sync handlers for same event', () => {
+  it('registers sync handlers for different event types independently', () => {
     const mgr = new EventManager();
     const h1 = vi.fn();
     const h2 = vi.fn();
+    // ipcMain.handle allows one handler per channel, so distinct channels is
+    // the real registration shape, not two handlers on the same channel.
     mgr.registerSyncEventHandler(EventTypeMain.IsDarkTheme, h1);
-    mgr.registerSyncEventHandler(EventTypeMain.IsDarkTheme, h2);
-    expect(mockIpcMain.handle).toHaveBeenCalledTimes(2);
+    mgr.registerSyncEventHandler(EventTypeMain.ValidatePythonPath, h2);
+    expect(mockIpcMain.handle).toHaveBeenCalledWith(
+      EventTypeMain.IsDarkTheme,
+      h1
+    );
+    expect(mockIpcMain.handle).toHaveBeenCalledWith(
+      EventTypeMain.ValidatePythonPath,
+      h2
+    );
   });
 });
 
@@ -112,16 +121,18 @@ describe('EventManager.unregisterEventHandler', () => {
 });
 
 describe('EventManager.unregisterSyncEventHandler', () => {
-  it('calls ipcMain.removeListener for sync handler', () => {
+  it('calls ipcMain.removeHandler with the channel for a sync handler', () => {
     const mgr = new EventManager();
     const handler = vi.fn();
     mgr.registerSyncEventHandler(EventTypeMain.IsDarkTheme, handler);
     vi.clearAllMocks();
     mgr.unregisterSyncEventHandler(EventTypeMain.IsDarkTheme, handler);
-    expect(mockIpcMain.removeListener).toHaveBeenCalledWith(
-      EventTypeMain.IsDarkTheme,
-      handler
+    // handle() handlers are removed by channel via removeHandler, not by
+    // (channel, handler) via removeListener.
+    expect(mockIpcMain.removeHandler).toHaveBeenCalledWith(
+      EventTypeMain.IsDarkTheme
     );
+    expect(mockIpcMain.removeListener).not.toHaveBeenCalled();
   });
 
   it('no-ops when event type was never registered', () => {
@@ -129,7 +140,17 @@ describe('EventManager.unregisterSyncEventHandler', () => {
     expect(() =>
       mgr.unregisterSyncEventHandler(EventTypeMain.IsDarkTheme, vi.fn())
     ).not.toThrow();
-    expect(mockIpcMain.removeListener).not.toHaveBeenCalled();
+    expect(mockIpcMain.removeHandler).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when the sync handler is not in the list', () => {
+    const mgr = new EventManager();
+    const registered = vi.fn();
+    const other = vi.fn();
+    mgr.registerSyncEventHandler(EventTypeMain.IsDarkTheme, registered);
+    vi.clearAllMocks();
+    mgr.unregisterSyncEventHandler(EventTypeMain.IsDarkTheme, other);
+    expect(mockIpcMain.removeHandler).not.toHaveBeenCalled();
   });
 });
 
@@ -160,15 +181,21 @@ describe('EventManager.unregisterAllEventHandlers', () => {
 });
 
 describe('EventManager.unregisterAllSyncEventHandlers', () => {
-  it('removes all sync handlers', () => {
+  it('calls removeHandler once per registered sync channel', () => {
     const mgr = new EventManager();
     const h1 = vi.fn();
     const h2 = vi.fn();
     mgr.registerSyncEventHandler(EventTypeMain.IsDarkTheme, h1);
-    mgr.registerSyncEventHandler(EventTypeMain.IsDarkTheme, h2);
+    mgr.registerSyncEventHandler(EventTypeMain.ValidatePythonPath, h2);
     vi.clearAllMocks();
     mgr.unregisterAllSyncEventHandlers();
-    expect(mockIpcMain.removeListener).toHaveBeenCalledTimes(2);
+    expect(mockIpcMain.removeHandler).toHaveBeenCalledTimes(2);
+    expect(mockIpcMain.removeHandler).toHaveBeenCalledWith(
+      EventTypeMain.IsDarkTheme
+    );
+    expect(mockIpcMain.removeHandler).toHaveBeenCalledWith(
+      EventTypeMain.ValidatePythonPath
+    );
   });
 });
 
@@ -185,9 +212,8 @@ describe('EventManager.dispose', () => {
       EventTypeMain.OpenFile,
       async1
     );
-    expect(mockIpcMain.removeListener).toHaveBeenCalledWith(
-      EventTypeMain.IsDarkTheme,
-      sync1
+    expect(mockIpcMain.removeHandler).toHaveBeenCalledWith(
+      EventTypeMain.IsDarkTheme
     );
   });
 

--- a/test/unit/eventtypes.test.ts
+++ b/test/unit/eventtypes.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+import { EventTypeMain, EventTypeRenderer } from '../../src/main/eventtypes';
+
+// Spot-check critical IPC event strings — a typo here silently breaks the IPC channel
+
+describe('EventTypeMain — window controls', () => {
+  it('MinimizeWindow', () =>
+    expect(EventTypeMain.MinimizeWindow).toBe('minimize-window'));
+  it('MaximizeWindow', () =>
+    expect(EventTypeMain.MaximizeWindow).toBe('maximize-window'));
+  it('RestoreWindow', () =>
+    expect(EventTypeMain.RestoreWindow).toBe('restore-window'));
+  it('CloseWindow', () =>
+    expect(EventTypeMain.CloseWindow).toBe('close-window'));
+});
+
+describe('EventTypeMain — session management', () => {
+  it('CreateNewSession', () =>
+    expect(EventTypeMain.CreateNewSession).toBe('create-new-session'));
+  it('CreateNewRemoteSession', () =>
+    expect(EventTypeMain.CreateNewRemoteSession).toBe(
+      'create-new-remote-session'
+    ));
+  it('OpenRecentSession', () =>
+    expect(EventTypeMain.OpenRecentSession).toBe('open-recent-session'));
+  it('DeleteRecentSession', () =>
+    expect(EventTypeMain.DeleteRecentSession).toBe('delete-recent-session'));
+  it('OpenDroppedFiles', () =>
+    expect(EventTypeMain.OpenDroppedFiles).toBe('open-dropped-files'));
+  it('RestartSession', () =>
+    expect(EventTypeMain.RestartSession).toBe('restart-session'));
+  it('LabUIReady', () => expect(EventTypeMain.LabUIReady).toBe('lab-ui-ready'));
+});
+
+describe('EventTypeMain — python environment', () => {
+  it('ValidatePythonPath', () =>
+    expect(EventTypeMain.ValidatePythonPath).toBe('validate-python-path'));
+  it('SetDefaultPythonPath', () =>
+    expect(EventTypeMain.SetDefaultPythonPath).toBe('set-default-python-path'));
+  it('InstallBundledPythonEnv', () =>
+    expect(EventTypeMain.InstallBundledPythonEnv).toBe(
+      'install-bundled-python-env'
+    ));
+  it('UpdateBundledPythonEnv', () =>
+    expect(EventTypeMain.UpdateBundledPythonEnv).toBe(
+      'update-bundled-python-env'
+    ));
+  it('GetPythonEnvironmentList', () =>
+    expect(EventTypeMain.GetPythonEnvironmentList).toBe(
+      'get-python-environment-list'
+    ));
+  it('DeletePythonEnvironment', () =>
+    expect(EventTypeMain.DeletePythonEnvironment).toBe(
+      'delete-python-environment'
+    ));
+  it('CreateNewPythonEnvironment', () =>
+    expect(EventTypeMain.CreateNewPythonEnvironment).toBe(
+      'create-new-python-environment'
+    ));
+  it('ValidateNewPythonEnvironmentName', () =>
+    expect(EventTypeMain.ValidateNewPythonEnvironmentName).toBe(
+      'validate-new-env-name'
+    ));
+  it('ValidateCondaChannels', () =>
+    expect(EventTypeMain.ValidateCondaChannels).toBe(
+      'validate-conda-channels'
+    ));
+});
+
+describe('EventTypeMain — settings', () => {
+  it('SetTheme', () => expect(EventTypeMain.SetTheme).toBe('set-theme'));
+  it('SetLogLevel', () =>
+    expect(EventTypeMain.SetLogLevel).toBe('set-log-level'));
+  it('SetStartupMode', () =>
+    expect(EventTypeMain.SetStartupMode).toBe('set-startup-mode'));
+  it('SetCtrlWBehavior', () =>
+    expect(EventTypeMain.SetCtrlWBehavior).toBe('set-ctrl-w-behavior'));
+  it('SetSettings', () =>
+    expect(EventTypeMain.SetSettings).toBe('set-settings'));
+  it('ClearHistory', () =>
+    expect(EventTypeMain.ClearHistory).toBe('clear-history'));
+  it('CheckForUpdates', () =>
+    expect(EventTypeMain.CheckForUpdates).toBe('check-for-updates'));
+});
+
+describe('EventTypeMain — all values are non-empty strings', () => {
+  it('every event has a non-empty string value', () => {
+    for (const [key, val] of Object.entries(EventTypeMain)) {
+      expect(typeof val, `EventTypeMain.${key}`).toBe('string');
+      expect(
+        (val as string).length,
+        `EventTypeMain.${key} is empty`
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  it('no duplicate event values', () => {
+    const values = Object.values(EventTypeMain);
+    const unique = new Set(values);
+    expect(unique.size).toBe(values.length);
+  });
+});
+
+describe('EventTypeRenderer', () => {
+  it('WorkingDirectorySelected', () =>
+    expect(EventTypeRenderer.WorkingDirectorySelected).toBe(
+      'working-directory-selected'
+    ));
+  it('InstallPythonEnvStatus', () =>
+    expect(EventTypeRenderer.InstallPythonEnvStatus).toBe(
+      'install-python-env-status'
+    ));
+  it('ShowProgress', () =>
+    expect(EventTypeRenderer.ShowProgress).toBe('show-progress'));
+  it('SetCurrentPythonPath', () =>
+    expect(EventTypeRenderer.SetCurrentPythonPath).toBe(
+      'set-current-python-path'
+    ));
+  it('SetRunningServerList', () =>
+    expect(EventTypeRenderer.SetRunningServerList).toBe(
+      'set-running-server-list'
+    ));
+  it('SetTitle', () => expect(EventTypeRenderer.SetTitle).toBe('set-title'));
+  it('SetRecentSessionList', () =>
+    expect(EventTypeRenderer.SetRecentSessionList).toBe(
+      'set-recent-session-list'
+    ));
+  it('SetPythonEnvironmentList', () =>
+    expect(EventTypeRenderer.SetPythonEnvironmentList).toBe(
+      'set-python-environment-list'
+    ));
+
+  it('all values are non-empty strings', () => {
+    for (const [key, val] of Object.entries(EventTypeRenderer)) {
+      expect(typeof val, `EventTypeRenderer.${key}`).toBe('string');
+      expect(
+        (val as string).length,
+        `EventTypeRenderer.${key} is empty`
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  it('no duplicate event values', () => {
+    const values = Object.values(EventTypeRenderer);
+    const unique = new Set(values);
+    expect(unique.size).toBe(values.length);
+  });
+});

--- a/test/unit/eventtypes.test.ts
+++ b/test/unit/eventtypes.test.ts
@@ -1,148 +1,72 @@
 import { describe, expect, it } from 'vitest';
 import { EventTypeMain, EventTypeRenderer } from '../../src/main/eventtypes';
 
-// Spot-check critical IPC event strings — a typo here silently breaks the IPC channel
+// IPC channel strings; a typo silently breaks the channel, so they are pinned.
 
-describe('EventTypeMain — window controls', () => {
-  it('MinimizeWindow', () =>
-    expect(EventTypeMain.MinimizeWindow).toBe('minimize-window'));
-  it('MaximizeWindow', () =>
-    expect(EventTypeMain.MaximizeWindow).toBe('maximize-window'));
-  it('RestoreWindow', () =>
-    expect(EventTypeMain.RestoreWindow).toBe('restore-window'));
-  it('CloseWindow', () =>
-    expect(EventTypeMain.CloseWindow).toBe('close-window'));
+describe('EventTypeMain channel strings', () => {
+  it.each([
+    [EventTypeMain.MinimizeWindow, 'minimize-window'],
+    [EventTypeMain.MaximizeWindow, 'maximize-window'],
+    [EventTypeMain.RestoreWindow, 'restore-window'],
+    [EventTypeMain.CloseWindow, 'close-window'],
+    [EventTypeMain.CreateNewSession, 'create-new-session'],
+    [EventTypeMain.CreateNewRemoteSession, 'create-new-remote-session'],
+    [EventTypeMain.OpenRecentSession, 'open-recent-session'],
+    [EventTypeMain.DeleteRecentSession, 'delete-recent-session'],
+    [EventTypeMain.OpenDroppedFiles, 'open-dropped-files'],
+    [EventTypeMain.RestartSession, 'restart-session'],
+    [EventTypeMain.LabUIReady, 'lab-ui-ready'],
+    [EventTypeMain.ValidatePythonPath, 'validate-python-path'],
+    [EventTypeMain.SetDefaultPythonPath, 'set-default-python-path'],
+    [EventTypeMain.InstallBundledPythonEnv, 'install-bundled-python-env'],
+    [EventTypeMain.UpdateBundledPythonEnv, 'update-bundled-python-env'],
+    [EventTypeMain.GetPythonEnvironmentList, 'get-python-environment-list'],
+    [EventTypeMain.DeletePythonEnvironment, 'delete-python-environment'],
+    [EventTypeMain.CreateNewPythonEnvironment, 'create-new-python-environment'],
+    [EventTypeMain.ValidateNewPythonEnvironmentName, 'validate-new-env-name'],
+    [EventTypeMain.ValidateCondaChannels, 'validate-conda-channels'],
+    [EventTypeMain.SetTheme, 'set-theme'],
+    [EventTypeMain.SetLogLevel, 'set-log-level'],
+    [EventTypeMain.SetStartupMode, 'set-startup-mode'],
+    [EventTypeMain.SetCtrlWBehavior, 'set-ctrl-w-behavior'],
+    [EventTypeMain.SetSettings, 'set-settings'],
+    [EventTypeMain.ClearHistory, 'clear-history'],
+    [EventTypeMain.CheckForUpdates, 'check-for-updates']
+  ])('"%s" stays stable', (value, expected) => {
+    expect(value).toBe(expected);
+  });
 });
 
-describe('EventTypeMain — session management', () => {
-  it('CreateNewSession', () =>
-    expect(EventTypeMain.CreateNewSession).toBe('create-new-session'));
-  it('CreateNewRemoteSession', () =>
-    expect(EventTypeMain.CreateNewRemoteSession).toBe(
-      'create-new-remote-session'
-    ));
-  it('OpenRecentSession', () =>
-    expect(EventTypeMain.OpenRecentSession).toBe('open-recent-session'));
-  it('DeleteRecentSession', () =>
-    expect(EventTypeMain.DeleteRecentSession).toBe('delete-recent-session'));
-  it('OpenDroppedFiles', () =>
-    expect(EventTypeMain.OpenDroppedFiles).toBe('open-dropped-files'));
-  it('RestartSession', () =>
-    expect(EventTypeMain.RestartSession).toBe('restart-session'));
-  it('LabUIReady', () => expect(EventTypeMain.LabUIReady).toBe('lab-ui-ready'));
+describe('EventTypeRenderer channel strings', () => {
+  it.each([
+    [EventTypeRenderer.WorkingDirectorySelected, 'working-directory-selected'],
+    [EventTypeRenderer.InstallPythonEnvStatus, 'install-python-env-status'],
+    [EventTypeRenderer.ShowProgress, 'show-progress'],
+    [EventTypeRenderer.SetCurrentPythonPath, 'set-current-python-path'],
+    [EventTypeRenderer.SetRunningServerList, 'set-running-server-list'],
+    [EventTypeRenderer.SetTitle, 'set-title'],
+    [EventTypeRenderer.SetRecentSessionList, 'set-recent-session-list'],
+    [EventTypeRenderer.SetPythonEnvironmentList, 'set-python-environment-list']
+  ])('"%s" stays stable', (value, expected) => {
+    expect(value).toBe(expected);
+  });
 });
 
-describe('EventTypeMain — python environment', () => {
-  it('ValidatePythonPath', () =>
-    expect(EventTypeMain.ValidatePythonPath).toBe('validate-python-path'));
-  it('SetDefaultPythonPath', () =>
-    expect(EventTypeMain.SetDefaultPythonPath).toBe('set-default-python-path'));
-  it('InstallBundledPythonEnv', () =>
-    expect(EventTypeMain.InstallBundledPythonEnv).toBe(
-      'install-bundled-python-env'
-    ));
-  it('UpdateBundledPythonEnv', () =>
-    expect(EventTypeMain.UpdateBundledPythonEnv).toBe(
-      'update-bundled-python-env'
-    ));
-  it('GetPythonEnvironmentList', () =>
-    expect(EventTypeMain.GetPythonEnvironmentList).toBe(
-      'get-python-environment-list'
-    ));
-  it('DeletePythonEnvironment', () =>
-    expect(EventTypeMain.DeletePythonEnvironment).toBe(
-      'delete-python-environment'
-    ));
-  it('CreateNewPythonEnvironment', () =>
-    expect(EventTypeMain.CreateNewPythonEnvironment).toBe(
-      'create-new-python-environment'
-    ));
-  it('ValidateNewPythonEnvironmentName', () =>
-    expect(EventTypeMain.ValidateNewPythonEnvironmentName).toBe(
-      'validate-new-env-name'
-    ));
-  it('ValidateCondaChannels', () =>
-    expect(EventTypeMain.ValidateCondaChannels).toBe(
-      'validate-conda-channels'
-    ));
-});
-
-describe('EventTypeMain — settings', () => {
-  it('SetTheme', () => expect(EventTypeMain.SetTheme).toBe('set-theme'));
-  it('SetLogLevel', () =>
-    expect(EventTypeMain.SetLogLevel).toBe('set-log-level'));
-  it('SetStartupMode', () =>
-    expect(EventTypeMain.SetStartupMode).toBe('set-startup-mode'));
-  it('SetCtrlWBehavior', () =>
-    expect(EventTypeMain.SetCtrlWBehavior).toBe('set-ctrl-w-behavior'));
-  it('SetSettings', () =>
-    expect(EventTypeMain.SetSettings).toBe('set-settings'));
-  it('ClearHistory', () =>
-    expect(EventTypeMain.ClearHistory).toBe('clear-history'));
-  it('CheckForUpdates', () =>
-    expect(EventTypeMain.CheckForUpdates).toBe('check-for-updates'));
-});
-
-describe('EventTypeMain — all values are non-empty strings', () => {
-  it('every event has a non-empty string value', () => {
-    for (const [key, val] of Object.entries(EventTypeMain)) {
-      expect(typeof val, `EventTypeMain.${key}`).toBe('string');
-      expect(
-        (val as string).length,
-        `EventTypeMain.${key} is empty`
-      ).toBeGreaterThan(0);
+describe.each([
+  ['EventTypeMain', EventTypeMain],
+  ['EventTypeRenderer', EventTypeRenderer]
+])('%s structural invariants', (name, registry) => {
+  it('every value is a non-empty string', () => {
+    for (const [key, val] of Object.entries(registry)) {
+      expect(typeof val, `${name}.${key}`).toBe('string');
+      expect((val as string).length, `${name}.${key} is empty`).toBeGreaterThan(
+        0
+      );
     }
   });
 
-  it('no duplicate event values', () => {
-    const values = Object.values(EventTypeMain);
-    const unique = new Set(values);
-    expect(unique.size).toBe(values.length);
-  });
-});
-
-describe('EventTypeRenderer', () => {
-  it('WorkingDirectorySelected', () =>
-    expect(EventTypeRenderer.WorkingDirectorySelected).toBe(
-      'working-directory-selected'
-    ));
-  it('InstallPythonEnvStatus', () =>
-    expect(EventTypeRenderer.InstallPythonEnvStatus).toBe(
-      'install-python-env-status'
-    ));
-  it('ShowProgress', () =>
-    expect(EventTypeRenderer.ShowProgress).toBe('show-progress'));
-  it('SetCurrentPythonPath', () =>
-    expect(EventTypeRenderer.SetCurrentPythonPath).toBe(
-      'set-current-python-path'
-    ));
-  it('SetRunningServerList', () =>
-    expect(EventTypeRenderer.SetRunningServerList).toBe(
-      'set-running-server-list'
-    ));
-  it('SetTitle', () => expect(EventTypeRenderer.SetTitle).toBe('set-title'));
-  it('SetRecentSessionList', () =>
-    expect(EventTypeRenderer.SetRecentSessionList).toBe(
-      'set-recent-session-list'
-    ));
-  it('SetPythonEnvironmentList', () =>
-    expect(EventTypeRenderer.SetPythonEnvironmentList).toBe(
-      'set-python-environment-list'
-    ));
-
-  it('all values are non-empty strings', () => {
-    for (const [key, val] of Object.entries(EventTypeRenderer)) {
-      expect(typeof val, `EventTypeRenderer.${key}`).toBe('string');
-      expect(
-        (val as string).length,
-        `EventTypeRenderer.${key} is empty`
-      ).toBeGreaterThan(0);
-    }
-  });
-
-  it('no duplicate event values', () => {
-    const values = Object.values(EventTypeRenderer);
-    const unique = new Set(values);
-    expect(unique.size).toBe(values.length);
+  it('has no duplicate channel values', () => {
+    const values = Object.values(registry);
+    expect(new Set(values).size).toBe(values.length);
   });
 });

--- a/test/unit/sessionconfig.test.ts
+++ b/test/unit/sessionconfig.test.ts
@@ -249,6 +249,31 @@ describe('SessionConfig.createFromArgs', () => {
     expect(result.remoteURL).toBe('https://example.com/lab?token=tok');
   });
 
+  it('uses a persist: partition when persistSessionData is true', () => {
+    const result = SessionConfig.createFromArgs({
+      _: ['https://example.com/lab?token=tok'],
+      $0: '',
+      cwd: '/cwd',
+      pythonPath: '',
+      workingDir: '',
+      persistSessionData: true
+    });
+    expect(result.persistSessionData).toBe(true);
+    expect(result.partition.startsWith('persist:')).toBe(true);
+  });
+
+  it('uses a non-persistent partition when persistSessionData is not set', () => {
+    const result = SessionConfig.createFromArgs({
+      _: ['https://example.com/lab?token=tok'],
+      $0: '',
+      cwd: '/cwd',
+      pythonPath: '',
+      workingDir: ''
+    });
+    expect(result.persistSessionData).toBe(false);
+    expect(result.partition.startsWith('partition:')).toBe(true);
+  });
+
   it('creates remote session for http URL', () => {
     const result = SessionConfig.createFromArgs({
       _: ['http://localhost:8888/lab?token=abc'],

--- a/test/unit/sessionconfig.test.ts
+++ b/test/unit/sessionconfig.test.ts
@@ -1,0 +1,524 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return { ...actual, existsSync: vi.fn(), lstatSync: vi.fn() };
+});
+vi.mock('../../src/main/config/settings', () => ({
+  userSettings: {
+    getValue: vi.fn(() => ''),
+    resolvedWorkingDirectory: '/home/user'
+  },
+  SettingType: {
+    defaultWorkingDirectory: 'defaultWorkingDirectory',
+    pythonPath: 'pythonPath'
+  },
+  DEFAULT_WIN_WIDTH: 1024,
+  DEFAULT_WIN_HEIGHT: 768,
+  resolveWorkingDirectory: vi.fn((dir: string) => dir || '/home/user')
+}));
+vi.mock('../../src/main/config/appdata', () => ({
+  appData: { recentSessions: [] }
+}));
+
+import { SessionConfig } from '../../src/main/config/sessionconfig';
+
+const mockFs = vi.mocked(fs);
+
+describe('SessionConfig defaults', () => {
+  it('x and y default to 0', () => {
+    const s = new SessionConfig();
+    expect(s.x).toBe(0);
+    expect(s.y).toBe(0);
+  });
+
+  it('width and height default to 1024x768', () => {
+    const s = new SessionConfig();
+    expect(s.width).toBe(1024);
+    expect(s.height).toBe(768);
+  });
+
+  it('persistSessionData defaults to true', () => {
+    expect(new SessionConfig().persistSessionData).toBe(true);
+  });
+
+  it('filesToOpen defaults to empty array', () => {
+    expect(new SessionConfig().filesToOpen).toEqual([]);
+  });
+
+  it('remoteURL defaults to empty string', () => {
+    expect(new SessionConfig().remoteURL).toBe('');
+  });
+});
+
+describe('SessionConfig.isRemote', () => {
+  it('false when remoteURL is empty', () => {
+    expect(new SessionConfig().isRemote).toBe(false);
+  });
+
+  it('true when remoteURL is set', () => {
+    const s = new SessionConfig();
+    s.remoteURL = 'http://localhost:8888/lab';
+    expect(s.isRemote).toBe(true);
+  });
+});
+
+describe('SessionConfig.createLocal', () => {
+  it('returns a SessionConfig', () => {
+    expect(SessionConfig.createLocal()).toBeInstanceOf(SessionConfig);
+  });
+
+  it('sets workingDirectory from argument', () => {
+    const s = SessionConfig.createLocal('/data/notebooks');
+    expect(s.workingDirectory).toBe('/data/notebooks');
+  });
+
+  it('sets filesToOpen when files exist', () => {
+    mockFs.lstatSync = vi.fn(() => ({ isFile: () => true } as fs.Stats));
+    const s = SessionConfig.createLocal('/data', ['a.ipynb', 'b.ipynb']);
+    expect(s.filesToOpen).toEqual(['a.ipynb', 'b.ipynb']);
+  });
+
+  it('skips files that do not exist', () => {
+    mockFs.lstatSync = vi.fn(() => {
+      throw new Error('ENOENT');
+    });
+    const s = SessionConfig.createLocal('/data', ['missing.ipynb']);
+    expect(s.filesToOpen).toEqual([]);
+  });
+
+  it('skips paths that are not files', () => {
+    mockFs.lstatSync = vi.fn(() => ({ isFile: () => false } as fs.Stats));
+    const s = SessionConfig.createLocal('/data', ['subdir']);
+    expect(s.filesToOpen).toEqual([]);
+  });
+
+  it('sets pythonPath when provided', () => {
+    const s = SessionConfig.createLocal('/data', undefined, '/usr/bin/python3');
+    expect(s.pythonPath).toBe('/usr/bin/python3');
+  });
+});
+
+describe('SessionConfig.createRemote', () => {
+  it('sets remoteURL', () => {
+    const s = SessionConfig.createRemote(
+      'http://localhost:8888/lab?token=abc',
+      true,
+      ''
+    );
+    expect(s.remoteURL).toBe('http://localhost:8888/lab?token=abc');
+    expect(s.isRemote).toBe(true);
+  });
+
+  it('extracts token from URL', () => {
+    const s = SessionConfig.createRemote(
+      'http://localhost:8888/lab?token=mysecret',
+      true,
+      ''
+    );
+    expect(s.token).toBe('mysecret');
+  });
+
+  it('persist partition when persistSessionData is true', () => {
+    const s = SessionConfig.createRemote(
+      'http://localhost:8888/lab?token=x',
+      true,
+      ''
+    );
+    expect(s.partition).toMatch(/^persist:/);
+  });
+
+  it('non-persist partition when persistSessionData is false', () => {
+    const s = SessionConfig.createRemote(
+      'http://localhost:8888/lab?token=x',
+      false,
+      ''
+    );
+    expect(s.partition).toMatch(/^partition:/);
+  });
+
+  it('uses provided partition instead of generating one', () => {
+    const s = SessionConfig.createRemote(
+      'http://localhost:8888/lab?token=x',
+      true,
+      'persist:my-custom-id'
+    );
+    expect(s.partition).toBe('persist:my-custom-id');
+  });
+
+  it('sets persistSessionData to false correctly', () => {
+    const s = SessionConfig.createRemote(
+      'http://localhost:8888/lab?token=x',
+      false,
+      ''
+    );
+    expect(s.persistSessionData).toBe(false);
+  });
+
+  it('persistSessionData defaults to true when not false', () => {
+    const s = SessionConfig.createRemote(
+      'http://localhost:8888/lab?token=x',
+      true,
+      ''
+    );
+    expect(s.persistSessionData).toBe(true);
+  });
+});
+
+describe('SessionConfig.createLocalForFilesOrFolders', () => {
+  it('creates session in parent dir of first file', () => {
+    mockFs.lstatSync = vi.fn(
+      () => ({ isFile: () => true, isDirectory: () => false } as fs.Stats)
+    );
+    const s = SessionConfig.createLocalForFilesOrFolders([
+      '/data/nb/test.ipynb'
+    ]);
+    expect(s.workingDirectory).toBe('/data/nb');
+  });
+
+  it('creates session at directory path', () => {
+    mockFs.lstatSync = vi.fn(
+      () => ({ isFile: () => false, isDirectory: () => true } as fs.Stats)
+    );
+    const s = SessionConfig.createLocalForFilesOrFolders(['/data/notebooks']);
+    expect(s.workingDirectory).toBe('/data/notebooks');
+  });
+
+  it('returns undefined for empty array', () => {
+    const s = SessionConfig.createLocalForFilesOrFolders([]);
+    expect(s).toBeUndefined();
+  });
+
+  it('skips paths where lstatSync throws', () => {
+    mockFs.lstatSync = vi.fn(() => {
+      throw new Error('ENOENT');
+    });
+    const s = SessionConfig.createLocalForFilesOrFolders([
+      '/missing/path.ipynb'
+    ]);
+    expect(s).toBeUndefined();
+  });
+
+  it('prefers files over folders when both given', () => {
+    let call = 0;
+    mockFs.lstatSync = vi.fn(() => {
+      call++;
+      if (call === 1)
+        return { isFile: () => false, isDirectory: () => true } as fs.Stats; // folder first
+      return { isFile: () => true, isDirectory: () => false } as fs.Stats; // then file
+    });
+    const s = SessionConfig.createLocalForFilesOrFolders([
+      '/some/folder',
+      '/some/folder/note.ipynb'
+    ]);
+    // files take precedence: working dir should be parent of the file
+    expect(s.workingDirectory).toBe('/some/folder');
+  });
+});
+
+describe('SessionConfig.createFromArgs', () => {
+  beforeEach(() => {
+    mockFs.existsSync = vi.fn(() => false);
+    mockFs.lstatSync = vi.fn(() => {
+      throw new Error('ENOENT');
+    });
+  });
+
+  it('returns undefined when no args', () => {
+    const result = SessionConfig.createFromArgs({
+      _: [],
+      $0: '',
+      cwd: '/cwd',
+      pythonPath: '',
+      workingDir: ''
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it('creates remote session for https URL', () => {
+    const result = SessionConfig.createFromArgs({
+      _: ['https://example.com/lab?token=tok'],
+      $0: '',
+      cwd: '/cwd',
+      pythonPath: '',
+      workingDir: ''
+    });
+    expect(result).toBeDefined();
+    expect(result.isRemote).toBe(true);
+    expect(result.remoteURL).toBe('https://example.com/lab?token=tok');
+  });
+
+  it('creates remote session for http URL', () => {
+    const result = SessionConfig.createFromArgs({
+      _: ['http://localhost:8888/lab?token=abc'],
+      $0: '',
+      cwd: '/cwd',
+      pythonPath: '',
+      workingDir: ''
+    });
+    expect(result.isRemote).toBe(true);
+  });
+
+  it('creates local session when workingDir exists', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    const result = SessionConfig.createFromArgs({
+      _: [],
+      $0: '',
+      cwd: '/cwd',
+      pythonPath: '',
+      workingDir: '/valid/dir'
+    });
+    expect(result).toBeDefined();
+    expect(result.isRemote).toBe(false);
+    expect(result.workingDirectory).toContain('valid');
+  });
+
+  it('returns undefined when workingDir does not exist and no files', () => {
+    mockFs.existsSync = vi.fn(() => false);
+    const result = SessionConfig.createFromArgs({
+      _: [],
+      $0: '',
+      cwd: '/cwd',
+      pythonPath: '',
+      workingDir: '/nonexistent'
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it('includes file paths resolved from cwd', () => {
+    mockFs.existsSync = vi.fn(() => false);
+    mockFs.lstatSync = vi.fn(
+      () => ({ isFile: () => true, isDirectory: () => false } as fs.Stats)
+    );
+    const result = SessionConfig.createFromArgs({
+      _: ['test.ipynb'],
+      $0: '',
+      cwd: '/cwd',
+      pythonPath: '',
+      workingDir: ''
+    });
+    expect(result).toBeDefined();
+  });
+
+  it('includes pythonPath when it exists', () => {
+    mockFs.existsSync = vi.fn((p: fs.PathLike) => {
+      const pathStr = p.toString();
+      return pathStr.includes('python3') || pathStr.includes('valid/dir');
+    });
+    const result = SessionConfig.createFromArgs({
+      _: [],
+      $0: '',
+      cwd: '/cwd',
+      pythonPath: '/usr/bin/python3',
+      workingDir: '/valid/dir'
+    });
+    expect(result).toBeDefined();
+    expect(result.pythonPath).toContain('python3');
+  });
+
+  it('excludes pythonPath when it does not exist', () => {
+    mockFs.existsSync = vi.fn((p: fs.PathLike) => {
+      return p.toString().includes('valid/dir');
+    });
+    const result = SessionConfig.createFromArgs({
+      _: [],
+      $0: '',
+      cwd: '/cwd',
+      pythonPath: '/nonexistent/python',
+      workingDir: '/valid/dir'
+    });
+    expect(result).toBeDefined();
+    expect(result.pythonPath).toBe('');
+  });
+});
+
+describe('SessionConfig.serialize', () => {
+  it('always includes x, y, width, height, lastOpened', () => {
+    const s = new SessionConfig();
+    const json = s.serialize();
+    expect(json).toHaveProperty('x');
+    expect(json).toHaveProperty('y');
+    expect(json).toHaveProperty('width');
+    expect(json).toHaveProperty('height');
+    expect(json).toHaveProperty('lastOpened');
+  });
+
+  it('omits remoteURL when empty', () => {
+    const json = new SessionConfig().serialize();
+    expect(json).not.toHaveProperty('remoteURL');
+  });
+
+  it('includes remoteURL when set', () => {
+    const s = new SessionConfig();
+    s.remoteURL = 'http://localhost:8888/lab';
+    expect(s.serialize()).toHaveProperty(
+      'remoteURL',
+      'http://localhost:8888/lab'
+    );
+  });
+
+  it('omits persistSessionData when true (default)', () => {
+    expect(new SessionConfig().serialize()).not.toHaveProperty(
+      'persistSessionData'
+    );
+  });
+
+  it('includes persistSessionData when false', () => {
+    const s = new SessionConfig();
+    s.persistSessionData = false;
+    expect(s.serialize()).toHaveProperty('persistSessionData', false);
+  });
+
+  it('omits partition when persistSessionData is false', () => {
+    const s = new SessionConfig();
+    s.persistSessionData = false;
+    s.partition = 'partition:123';
+    expect(s.serialize()).not.toHaveProperty('partition');
+  });
+
+  it('includes partition when persistSessionData is true', () => {
+    const s = new SessionConfig();
+    s.partition = 'persist:abc';
+    expect(s.serialize()).toHaveProperty('partition', 'persist:abc');
+  });
+
+  it('omits workingDirectory when empty', () => {
+    expect(new SessionConfig().serialize()).not.toHaveProperty(
+      'workingDirectory'
+    );
+  });
+
+  it('includes workingDirectory when set', () => {
+    const s = new SessionConfig();
+    s.workingDirectory = '/data/notebooks';
+    expect(s.serialize()).toHaveProperty('workingDirectory', '/data/notebooks');
+  });
+
+  it('omits filesToOpen when empty', () => {
+    expect(new SessionConfig().serialize()).not.toHaveProperty('filesToOpen');
+  });
+
+  it('includes filesToOpen when non-empty', () => {
+    const s = new SessionConfig();
+    s.filesToOpen = ['test.ipynb'];
+    expect(s.serialize()).toHaveProperty('filesToOpen', ['test.ipynb']);
+  });
+
+  it('lastOpened is ISO string', () => {
+    const s = new SessionConfig();
+    const json = s.serialize();
+    expect(() => new Date(json.lastOpened)).not.toThrow();
+    expect(new Date(json.lastOpened).getFullYear()).toBeGreaterThanOrEqual(
+      2020
+    );
+  });
+});
+
+describe('SessionConfig.deserialize', () => {
+  it('sets x, y, width, height', () => {
+    const s = new SessionConfig();
+    s.deserialize({ x: 10, y: 20, width: 800, height: 600 });
+    expect(s.x).toBe(10);
+    expect(s.y).toBe(20);
+    expect(s.width).toBe(800);
+    expect(s.height).toBe(600);
+  });
+
+  it('sets remoteURL', () => {
+    const s = new SessionConfig();
+    s.deserialize({ remoteURL: 'http://remote:8888/lab' });
+    expect(s.remoteURL).toBe('http://remote:8888/lab');
+  });
+
+  it('sets persistSessionData', () => {
+    const s = new SessionConfig();
+    s.deserialize({ persistSessionData: false });
+    expect(s.persistSessionData).toBe(false);
+  });
+
+  it('sets partition only when persistSessionData is true', () => {
+    const s = new SessionConfig();
+    s.deserialize({ persistSessionData: true, partition: 'persist:xyz' });
+    expect(s.partition).toBe('persist:xyz');
+  });
+
+  it('ignores partition when persistSessionData is false', () => {
+    const s = new SessionConfig();
+    s.deserialize({ persistSessionData: false, partition: 'persist:xyz' });
+    expect(s.partition).toBe('');
+  });
+
+  it('sets workingDirectory', () => {
+    const s = new SessionConfig();
+    s.deserialize({ workingDirectory: '/data/nb' });
+    expect(s.workingDirectory).toBe('/data/nb');
+  });
+
+  it('sets filesToOpen', () => {
+    const s = new SessionConfig();
+    s.deserialize({ filesToOpen: ['a.ipynb', 'b.ipynb'] });
+    expect(s.filesToOpen).toEqual(['a.ipynb', 'b.ipynb']);
+  });
+
+  it('parses lastOpened as Date', () => {
+    const s = new SessionConfig();
+    const iso = '2024-01-15T10:30:00.000Z';
+    s.deserialize({ lastOpened: iso });
+    expect(s.lastOpened).toBeInstanceOf(Date);
+    expect(s.lastOpened.getFullYear()).toBe(2024);
+  });
+
+  it('ignores unknown keys', () => {
+    const s = new SessionConfig();
+    expect(() => s.deserialize({ unknownKey: 'value' })).not.toThrow();
+  });
+});
+
+describe('SessionConfig serialize/deserialize round-trip', () => {
+  it('round-trips a local session', () => {
+    const original = new SessionConfig();
+    original.workingDirectory = '/data/notebooks';
+    original.filesToOpen = ['test.ipynb'];
+    original.x = 50;
+    original.y = 100;
+    original.width = 1200;
+    original.height = 900;
+
+    const copy = new SessionConfig();
+    copy.deserialize(original.serialize());
+
+    expect(copy.workingDirectory).toBe('/data/notebooks');
+    expect(copy.filesToOpen).toEqual(['test.ipynb']);
+    expect(copy.x).toBe(50);
+    expect(copy.width).toBe(1200);
+  });
+
+  it('round-trips a remote session', () => {
+    const original = SessionConfig.createRemote(
+      'http://remote:8888/lab?token=tok',
+      true,
+      'persist:id123'
+    );
+    const copy = new SessionConfig();
+    copy.deserialize(original.serialize());
+
+    expect(copy.remoteURL).toBe('http://remote:8888/lab?token=tok');
+    expect(copy.persistSessionData).toBe(true);
+    expect(copy.partition).toBe('persist:id123');
+    expect(copy.isRemote).toBe(true);
+  });
+
+  it('round-trips a non-persistent remote session', () => {
+    const original = SessionConfig.createRemote(
+      'http://remote:8888/lab?token=tok',
+      false,
+      ''
+    );
+    const copy = new SessionConfig();
+    copy.deserialize(original.serialize());
+
+    expect(copy.persistSessionData).toBe(false);
+    expect(copy.partition).toBe('');
+  });
+});

--- a/test/unit/sessionconfig.test.ts
+++ b/test/unit/sessionconfig.test.ts
@@ -323,7 +323,7 @@ describe('SessionConfig.createFromArgs', () => {
       pythonPath: '',
       workingDir: ''
     });
-    expect(result).toBeDefined();
+    expect(result.filesToOpen.some(f => f.includes('test.ipynb'))).toBe(true);
   });
 
   it('includes pythonPath when it exists', () => {
@@ -433,7 +433,7 @@ describe('SessionConfig.serialize', () => {
   it('lastOpened is ISO string', () => {
     const s = new SessionConfig();
     const json = s.serialize();
-    expect(() => new Date(json.lastOpened)).not.toThrow();
+    expect(Number.isNaN(new Date(json.lastOpened).getTime())).toBe(false);
     expect(new Date(json.lastOpened).getFullYear()).toBeGreaterThanOrEqual(
       2020
     );

--- a/test/unit/settings.test.ts
+++ b/test/unit/settings.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    lstatSync: vi.fn(),
+    mkdirSync: vi.fn()
+  };
+});
+
+import {
+  CtrlWBehavior,
+  DEFAULT_WIN_HEIGHT,
+  DEFAULT_WIN_WIDTH,
+  LogLevel,
+  resolveWorkingDirectory,
+  serverLaunchArgsDefault,
+  serverLaunchArgsFixed,
+  StartupMode,
+  ThemeType,
+  UIMode
+} from '../../src/main/config/settings';
+
+const mockFs = vi.mocked(fs);
+
+describe('constants', () => {
+  it('DEFAULT_WIN_WIDTH is 1024', () => expect(DEFAULT_WIN_WIDTH).toBe(1024));
+  it('DEFAULT_WIN_HEIGHT is 768', () => expect(DEFAULT_WIN_HEIGHT).toBe(768));
+});
+
+describe('enums', () => {
+  it('ThemeType has system/light/dark', () => {
+    expect(ThemeType.System).toBe('system');
+    expect(ThemeType.Light).toBe('light');
+    expect(ThemeType.Dark).toBe('dark');
+  });
+
+  it('StartupMode values are correct', () => {
+    expect(StartupMode.WelcomePage).toBe('welcome-page');
+    expect(StartupMode.LastSessions).toBe('restore-sessions');
+  });
+
+  it('LogLevel values are correct', () => {
+    expect(LogLevel.Error).toBe('error');
+    expect(LogLevel.Debug).toBe('debug');
+  });
+
+  it('CtrlWBehavior values are correct', () => {
+    expect(CtrlWBehavior.CloseWindow).toBe('close');
+    expect(CtrlWBehavior.Warn).toBe('warn');
+  });
+
+  it('UIMode values are correct', () => {
+    expect(UIMode.MultiDocument).toBe('multi-document');
+    expect(UIMode.Zen).toBe('zen');
+  });
+});
+
+describe('serverLaunchArgsFixed', () => {
+  it('contains --no-browser', () => {
+    expect(serverLaunchArgsFixed).toContain('--no-browser');
+  });
+
+  it('contains port placeholder', () => {
+    expect(serverLaunchArgsFixed.some(a => a.includes('{port}'))).toBe(true);
+  });
+
+  it('contains token placeholder', () => {
+    expect(serverLaunchArgsFixed.some(a => a.includes('{token}'))).toBe(true);
+  });
+
+  it('disables browser', () => {
+    expect(serverLaunchArgsFixed).toContain('--no-browser');
+  });
+
+  it('disables quit button', () => {
+    expect(serverLaunchArgsFixed).toContain('--LabApp.quit_button=False');
+  });
+});
+
+describe('serverLaunchArgsDefault', () => {
+  it('allows hidden files', () => {
+    expect(
+      serverLaunchArgsDefault.some(a => a.includes('allow_hidden=True'))
+    ).toBe(true);
+  });
+});
+
+describe('resolveWorkingDirectory', () => {
+  it('returns home when no directory given', () => {
+    // app.getPath mock returns /tmp/jlab-test-userdata/home
+    const result = resolveWorkingDirectory('');
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it('returns given path when it is a valid directory', () => {
+    mockFs.lstatSync = vi.fn(() => ({ isDirectory: () => true } as fs.Stats));
+    const result = resolveWorkingDirectory('/valid/dir');
+    expect(result).toBe('/valid/dir');
+  });
+
+  it('resets to home when path is a file not a directory', () => {
+    mockFs.lstatSync = vi.fn(() => ({ isDirectory: () => false } as fs.Stats));
+    const result = resolveWorkingDirectory('/some/file.txt');
+    expect(result).not.toBe('/some/file.txt');
+  });
+
+  it('resets to home when path does not exist', () => {
+    mockFs.lstatSync = vi.fn(() => {
+      throw new Error('ENOENT');
+    });
+    const result = resolveWorkingDirectory('/nonexistent/path');
+    expect(result).not.toBe('/nonexistent/path');
+  });
+
+  it('keeps invalid path when resetIfInvalid is false', () => {
+    mockFs.lstatSync = vi.fn(() => {
+      throw new Error('ENOENT');
+    });
+    const result = resolveWorkingDirectory('/bad/path', false);
+    expect(result).toBe('/bad/path');
+  });
+});

--- a/test/unit/settings.test.ts
+++ b/test/unit/settings.test.ts
@@ -7,7 +7,8 @@ vi.mock('fs', async () => {
     ...actual,
     existsSync: vi.fn(),
     lstatSync: vi.fn(),
-    mkdirSync: vi.fn()
+    mkdirSync: vi.fn(),
+    writeFileSync: vi.fn()
   };
 });
 
@@ -19,9 +20,12 @@ import {
   resolveWorkingDirectory,
   serverLaunchArgsDefault,
   serverLaunchArgsFixed,
+  Setting,
+  SettingType,
   StartupMode,
   ThemeType,
-  UIMode
+  UIMode,
+  UserSettings
 } from '../../src/main/config/settings';
 
 const mockFs = vi.mocked(fs);
@@ -123,5 +127,67 @@ describe('resolveWorkingDirectory', () => {
     });
     const result = resolveWorkingDirectory('/bad/path', false);
     expect(result).toBe('/bad/path');
+  });
+});
+
+describe('Setting', () => {
+  it('returns the default value until one is set', () => {
+    const s = new Setting<string>('def');
+    expect(s.value).toBe('def');
+    expect(s.valueSet).toBe(false);
+  });
+
+  it('returns the assigned value after it is set', () => {
+    const s = new Setting<string>('def');
+    s.value = 'changed';
+    expect(s.value).toBe('changed');
+    expect(s.valueSet).toBe(true);
+  });
+
+  it('reports differentThanDefault only after a real change', () => {
+    const s = new Setting<number>(10);
+    expect(s.differentThanDefault).toBe(false);
+    s.value = 11;
+    expect(s.differentThanDefault).toBe(true);
+  });
+
+  it('setToDefault restores the default value', () => {
+    const s = new Setting<string>('def');
+    s.value = 'x';
+    s.setToDefault();
+    expect(s.value).toBe('def');
+    expect(s.differentThanDefault).toBe(false);
+  });
+});
+
+describe('UserSettings', () => {
+  it('getValue returns the default before any change', () => {
+    const us = new UserSettings(false);
+    expect(us.getValue(SettingType.theme)).toBe(ThemeType.System);
+  });
+
+  it('setValue then getValue round-trips a non-default value', () => {
+    const us = new UserSettings(false);
+    us.setValue(SettingType.theme, ThemeType.Light);
+    expect(us.getValue(SettingType.theme)).toBe(ThemeType.Light);
+  });
+
+  it('unsetValue restores the default', () => {
+    const us = new UserSettings(false);
+    us.setValue(SettingType.theme, ThemeType.Light);
+    us.unsetValue(SettingType.theme);
+    expect(us.getValue(SettingType.theme)).toBe(ThemeType.System);
+  });
+
+  it('save persists only settings that differ from their default', () => {
+    mockFs.writeFileSync = vi.fn();
+    const us = new UserSettings(false);
+    us.setValue(SettingType.theme, ThemeType.Light);
+    us.save();
+    const written = JSON.parse(
+      (mockFs.writeFileSync as any).mock.calls[0][1] as string
+    );
+    expect(written).toHaveProperty('theme', ThemeType.Light);
+    expect(written).not.toHaveProperty('logLevel');
   });
 });

--- a/test/unit/tokens.test.ts
+++ b/test/unit/tokens.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EnvironmentTypeName,
+  IEnvironmentType,
+  PythonEnvResolveErrorType
+} from '../../src/main/tokens';
+
+describe('IEnvironmentType', () => {
+  it('Path is "path"', () => expect(IEnvironmentType.Path).toBe('path'));
+  it('CondaRoot is "conda-root"', () =>
+    expect(IEnvironmentType.CondaRoot).toBe('conda-root'));
+  it('CondaEnv is "conda-env"', () =>
+    expect(IEnvironmentType.CondaEnv).toBe('conda-env'));
+  it('WindowsReg is "windows-reg"', () =>
+    expect(IEnvironmentType.WindowsReg).toBe('windows-reg'));
+  it('VirtualEnv is "venv"', () =>
+    expect(IEnvironmentType.VirtualEnv).toBe('venv'));
+});
+
+describe('EnvironmentTypeName', () => {
+  it('Path maps to "system"', () =>
+    expect(EnvironmentTypeName[IEnvironmentType.Path]).toBe('system'));
+  it('CondaRoot maps to "conda"', () =>
+    expect(EnvironmentTypeName[IEnvironmentType.CondaRoot]).toBe('conda'));
+  it('CondaEnv maps to "conda"', () =>
+    expect(EnvironmentTypeName[IEnvironmentType.CondaEnv]).toBe('conda'));
+  it('WindowsReg maps to "win"', () =>
+    expect(EnvironmentTypeName[IEnvironmentType.WindowsReg]).toBe('win'));
+  it('VirtualEnv maps to "venv"', () =>
+    expect(EnvironmentTypeName[IEnvironmentType.VirtualEnv]).toBe('venv'));
+
+  it('all IEnvironmentType values have a display name', () => {
+    for (const key of Object.values(IEnvironmentType)) {
+      expect(EnvironmentTypeName[key]).toBeDefined();
+      expect(typeof EnvironmentTypeName[key]).toBe('string');
+    }
+  });
+});
+
+describe('PythonEnvResolveErrorType', () => {
+  it('PathNotFound is "path-not-found"', () => {
+    expect(PythonEnvResolveErrorType.PathNotFound).toBe('path-not-found');
+  });
+  it('InvalidPythonBinary is "invalid-python-binary"', () => {
+    expect(PythonEnvResolveErrorType.InvalidPythonBinary).toBe(
+      'invalid-python-binary'
+    );
+  });
+  it('ResolveError is "resolve-error"', () => {
+    expect(PythonEnvResolveErrorType.ResolveError).toBe('resolve-error');
+  });
+  it('RequirementsNotSatisfied is "requirements-not-satisfied"', () => {
+    expect(PythonEnvResolveErrorType.RequirementsNotSatisfied).toBe(
+      'requirements-not-satisfied'
+    );
+  });
+});

--- a/test/unit/tokens.test.ts
+++ b/test/unit/tokens.test.ts
@@ -5,53 +5,49 @@ import {
   PythonEnvResolveErrorType
 } from '../../src/main/tokens';
 
-describe('IEnvironmentType', () => {
-  it('Path is "path"', () => expect(IEnvironmentType.Path).toBe('path'));
-  it('CondaRoot is "conda-root"', () =>
-    expect(IEnvironmentType.CondaRoot).toBe('conda-root'));
-  it('CondaEnv is "conda-env"', () =>
-    expect(IEnvironmentType.CondaEnv).toBe('conda-env'));
-  it('WindowsReg is "windows-reg"', () =>
-    expect(IEnvironmentType.WindowsReg).toBe('windows-reg'));
-  it('VirtualEnv is "venv"', () =>
-    expect(IEnvironmentType.VirtualEnv).toBe('venv'));
+// These enum string values are IPC/persistence wire values; a change here
+// silently breaks saved appData and renderer messages, so they are pinned.
+
+describe('IEnvironmentType wire values', () => {
+  it.each([
+    [IEnvironmentType.Path, 'path'],
+    [IEnvironmentType.CondaRoot, 'conda-root'],
+    [IEnvironmentType.CondaEnv, 'conda-env'],
+    [IEnvironmentType.WindowsReg, 'windows-reg'],
+    [IEnvironmentType.VirtualEnv, 'venv']
+  ])('%s stays "%s"', (value, expected) => {
+    expect(value).toBe(expected);
+  });
 });
 
-describe('EnvironmentTypeName', () => {
-  it('Path maps to "system"', () =>
-    expect(EnvironmentTypeName[IEnvironmentType.Path]).toBe('system'));
-  it('CondaRoot maps to "conda"', () =>
-    expect(EnvironmentTypeName[IEnvironmentType.CondaRoot]).toBe('conda'));
-  it('CondaEnv maps to "conda"', () =>
-    expect(EnvironmentTypeName[IEnvironmentType.CondaEnv]).toBe('conda'));
-  it('WindowsReg maps to "win"', () =>
-    expect(EnvironmentTypeName[IEnvironmentType.WindowsReg]).toBe('win'));
-  it('VirtualEnv maps to "venv"', () =>
-    expect(EnvironmentTypeName[IEnvironmentType.VirtualEnv]).toBe('venv'));
+describe('EnvironmentTypeName display names', () => {
+  it.each([
+    [IEnvironmentType.Path, 'system'],
+    [IEnvironmentType.CondaRoot, 'conda'],
+    [IEnvironmentType.CondaEnv, 'conda'],
+    [IEnvironmentType.WindowsReg, 'win'],
+    [IEnvironmentType.VirtualEnv, 'venv']
+  ])('maps %s to "%s"', (type, name) => {
+    expect(EnvironmentTypeName[type]).toBe(name);
+  });
 
-  it('all IEnvironmentType values have a display name', () => {
-    for (const key of Object.values(IEnvironmentType)) {
-      expect(EnvironmentTypeName[key]).toBeDefined();
-      expect(typeof EnvironmentTypeName[key]).toBe('string');
+  it('has a string display name for every environment type', () => {
+    for (const type of Object.values(IEnvironmentType)) {
+      expect(typeof EnvironmentTypeName[type]).toBe('string');
     }
   });
 });
 
-describe('PythonEnvResolveErrorType', () => {
-  it('PathNotFound is "path-not-found"', () => {
-    expect(PythonEnvResolveErrorType.PathNotFound).toBe('path-not-found');
-  });
-  it('InvalidPythonBinary is "invalid-python-binary"', () => {
-    expect(PythonEnvResolveErrorType.InvalidPythonBinary).toBe(
-      'invalid-python-binary'
-    );
-  });
-  it('ResolveError is "resolve-error"', () => {
-    expect(PythonEnvResolveErrorType.ResolveError).toBe('resolve-error');
-  });
-  it('RequirementsNotSatisfied is "requirements-not-satisfied"', () => {
-    expect(PythonEnvResolveErrorType.RequirementsNotSatisfied).toBe(
+describe('PythonEnvResolveErrorType wire values', () => {
+  it.each([
+    [PythonEnvResolveErrorType.PathNotFound, 'path-not-found'],
+    [PythonEnvResolveErrorType.InvalidPythonBinary, 'invalid-python-binary'],
+    [PythonEnvResolveErrorType.ResolveError, 'resolve-error'],
+    [
+      PythonEnvResolveErrorType.RequirementsNotSatisfied,
       'requirements-not-satisfied'
-    );
+    ]
+  ])('%s stays "%s"', (value, expected) => {
+    expect(value).toBe(expected);
   });
 });

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -613,6 +613,9 @@ describe('deletePythonEnvironment', () => {
       EnvironmentDeleteStatus.Failure,
       expect.any(String)
     );
+    // the guard must stop here: a rejected promise is not enough, the
+    // directory must never be touched when it was not Desktop-installed.
+    expect(mockFs.rmSync).not.toHaveBeenCalled();
   });
 
   it('calls rmSync and resolves true when env.json exists', async () => {

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
+import { nativeTheme } from 'electron';
 
 vi.mock('fs', async () => {
   const actual = await vi.importActual<typeof import('fs')>('fs');
@@ -74,6 +75,20 @@ import * as net from 'net';
 
 const mockFs = vi.mocked(fs);
 
+// Reset the fs stubs to fresh no-op fns before every test so a value set in
+// one test cannot leak into a later one that does not set it.
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFs.existsSync = vi.fn();
+  mockFs.lstatSync = vi.fn();
+  mockFs.statSync = vi.fn();
+  mockFs.accessSync = vi.fn();
+  mockFs.readlinkSync = vi.fn();
+  mockFs.writeFileSync = vi.fn();
+  mockFs.mkdirSync = vi.fn();
+  mockFs.rmSync = vi.fn();
+});
+
 describe('isDarkTheme', () => {
   it.each([
     ['light', false],
@@ -83,8 +98,11 @@ describe('isDarkTheme', () => {
   });
 
   it('falls back to nativeTheme.shouldUseDarkColors for unknown value', () => {
-    // nativeTheme mock returns false
+    (nativeTheme as any).shouldUseDarkColors = false;
     expect(isDarkTheme('system')).toBe(false);
+    (nativeTheme as any).shouldUseDarkColors = true;
+    expect(isDarkTheme('system')).toBe(true);
+    (nativeTheme as any).shouldUseDarkColors = false;
   });
 });
 

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -1,0 +1,730 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    lstatSync: vi.fn(),
+    statSync: vi.fn(),
+    accessSync: vi.fn(),
+    readlinkSync: vi.fn(),
+    mkdtempSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    mkdirSync: vi.fn(),
+    rmSync: vi.fn()
+  };
+});
+vi.mock('net', async () => {
+  const actual = await vi.importActual<typeof import('net')>('net');
+  return { ...actual, Socket: vi.fn(), createServer: vi.fn() };
+});
+vi.mock('child_process', async () => {
+  const actual = await vi.importActual<typeof import('child_process')>(
+    'child_process'
+  );
+  return {
+    ...actual,
+    exec: vi.fn(),
+    execFile: vi.fn(),
+    execFileSync: vi.fn(),
+    execSync: vi.fn()
+  };
+});
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os');
+  return { ...actual, tmpdir: vi.fn(() => '/tmp') };
+});
+
+import {
+  activatePathForEnvPath,
+  bundledEnvironmentIsInstalled,
+  condaSourcePathForEnvPath,
+  createCommandScriptInEnv,
+  createTempFile,
+  DarkThemeBGColor,
+  deletePythonEnvironment,
+  EnvironmentDeleteStatus,
+  envPathForPythonPath,
+  getFreePort,
+  getJlabCLICommandSymlinkPath,
+  getJlabCLICommandTargetPath,
+  getLogFilePath,
+  getRelativePathToUserHome,
+  getUserHomeDir,
+  isBaseCondaEnv,
+  isCondaEnv,
+  isDarkTheme,
+  isEnvInstalledByDesktopApp,
+  isPortInUse,
+  jlabCLICommandIsSetup,
+  jupyterEnvInstallInfoPathForEnvPath,
+  LightThemeBGColor,
+  markEnvironmentAsJupyterInstalled,
+  openDirectoryInExplorer,
+  pythonPathForEnvPath,
+  versionWithoutSuffix,
+  waitForDuration,
+  waitForFunction
+} from '../../src/main/utils';
+import * as childProcess from 'child_process';
+import * as net from 'net';
+
+const mockFs = vi.mocked(fs);
+
+describe('isDarkTheme', () => {
+  it.each([
+    ['light', false],
+    ['dark', true]
+  ])('"%s" → %s', (theme, expected) => {
+    expect(isDarkTheme(theme)).toBe(expected);
+  });
+
+  it('falls back to nativeTheme.shouldUseDarkColors for unknown value', () => {
+    // nativeTheme mock returns false
+    expect(isDarkTheme('system')).toBe(false);
+  });
+});
+
+describe('versionWithoutSuffix', () => {
+  it.each([
+    ['3.6.0a1', '3.6.0'],
+    ['4.0.0b2', '4.0.0'],
+    ['4.4.7', '4.4.7'],
+    ['1.0.0rc1', '1.0.0']
+  ])('"%s" → "%s"', (input, expected) => {
+    expect(versionWithoutSuffix(input)).toBe(expected);
+  });
+});
+
+describe('pythonPathForEnvPath', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('returns bin/python on posix', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    mockFs.existsSync = vi.fn(() => false);
+    expect(pythonPathForEnvPath('/env')).toBe('/env/bin/python');
+  });
+
+  it('returns python.exe in root for conda on windows', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    mockFs.existsSync = vi.fn(() => true);
+    expect(pythonPathForEnvPath('/env', true)).toContain('python.exe');
+    expect(pythonPathForEnvPath('/env', true)).not.toContain('Scripts');
+  });
+
+  it('returns Scripts/python.exe for venv on windows', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    mockFs.existsSync = vi.fn(() => false);
+    expect(pythonPathForEnvPath('/env', false)).toContain('Scripts');
+    expect(pythonPathForEnvPath('/env', false)).toContain('python.exe');
+  });
+});
+
+describe('envPathForPythonPath', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('returns parent of bin/ on posix', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    const result = envPathForPythonPath('/env/bin/python');
+    expect(result).toContain('/env');
+  });
+
+  it('returns parent of Scripts/ on windows', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    // path.join uses host OS separator — just verify it doesn't include Scripts
+    const result = envPathForPythonPath('C:/env/Scripts/python.exe');
+    expect(result).not.toContain('Scripts');
+    expect(result).not.toContain('python.exe');
+  });
+});
+
+describe('activatePathForEnvPath', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('returns activate.bat on windows', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    expect(activatePathForEnvPath('/env')).toContain('activate.bat');
+  });
+
+  it('returns bin/activate on posix', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    expect(activatePathForEnvPath('/env')).toBe('/env/bin/activate');
+  });
+});
+
+describe('condaSourcePathForEnvPath', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('returns conda.sh path on posix', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    expect(condaSourcePathForEnvPath('/env')).toBe(
+      '/env/etc/profile.d/conda.sh'
+    );
+  });
+
+  it('returns undefined on windows', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    expect(condaSourcePathForEnvPath('/env')).toBeUndefined();
+  });
+});
+
+describe('jupyterEnvInstallInfoPathForEnvPath', () => {
+  it('returns .jupyter/env.json path', () => {
+    expect(jupyterEnvInstallInfoPathForEnvPath('/env')).toBe(
+      '/env/.jupyter/env.json'
+    );
+  });
+});
+
+describe('isCondaEnv', () => {
+  it('returns true when conda-meta exists', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    expect(isCondaEnv('/env')).toBe(true);
+  });
+
+  it('returns false when conda-meta missing', () => {
+    mockFs.existsSync = vi.fn(() => false);
+    expect(isCondaEnv('/env')).toBe(false);
+  });
+});
+
+describe('isEnvInstalledByDesktopApp', () => {
+  it('returns true when env.json marker exists', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    expect(isEnvInstalledByDesktopApp('/env')).toBe(true);
+  });
+
+  it('returns false when marker missing', () => {
+    mockFs.existsSync = vi.fn(() => false);
+    expect(isEnvInstalledByDesktopApp('/env')).toBe(false);
+  });
+});
+
+describe('getRelativePathToUserHome', () => {
+  it('replaces home prefix with ~', () => {
+    const home = getUserHomeDir();
+    const abs = path.join(home, 'notebooks', 'file.ipynb');
+    expect(getRelativePathToUserHome(abs)).toBe(
+      `~${path.sep}${path.join('notebooks', 'file.ipynb')}`
+    );
+  });
+
+  it('returns undefined for a path outside the home directory', () => {
+    expect(getRelativePathToUserHome('/etc/passwd')).toBeUndefined();
+  });
+});
+
+describe('waitForDuration', () => {
+  it('resolves false after duration', async () => {
+    const result = await waitForDuration(10);
+    expect(result).toBe(false);
+  });
+});
+
+describe('waitForFunction', () => {
+  it('resolves immediately when fn returns true', async () => {
+    await expect(waitForFunction(() => true)).resolves.toBeUndefined();
+  });
+
+  it('rejects on timeout when fn never returns true', async () => {
+    await expect(waitForFunction(() => false, 100)).rejects.toThrow(
+      'Timed out'
+    );
+  });
+
+  it('resolves after fn eventually returns true', async () => {
+    let count = 0;
+    await expect(waitForFunction(() => ++count >= 3)).resolves.toBeUndefined();
+    expect(count).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe('theme constants', () => {
+  it('DarkThemeBGColor is valid hex', () => {
+    expect(DarkThemeBGColor).toMatch(/^#[0-9a-f]{6}$/i);
+  });
+
+  it('LightThemeBGColor is valid hex', () => {
+    expect(LightThemeBGColor).toMatch(/^#[0-9a-f]{6}$/i);
+  });
+});
+
+describe('isBaseCondaEnv', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('returns true when condabin/conda exists and is a file on posix', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.lstatSync = vi.fn(() => ({ isFile: () => true } as fs.Stats));
+    expect(isBaseCondaEnv('/env')).toBe(true);
+  });
+
+  it('returns false when condabin/conda does not exist', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    mockFs.existsSync = vi.fn(() => false);
+    expect(isBaseCondaEnv('/env')).toBe(false);
+  });
+
+  it('returns false when path exists but is not a file', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.lstatSync = vi.fn(() => ({ isFile: () => false } as fs.Stats));
+    expect(isBaseCondaEnv('/env')).toBe(false);
+  });
+
+  it('checks condabin/conda.bat on windows', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    let checkedPath = '';
+    mockFs.existsSync = vi.fn((p: fs.PathLike) => {
+      checkedPath = p.toString();
+      return true;
+    });
+    mockFs.lstatSync = vi.fn(() => ({ isFile: () => true } as fs.Stats));
+    isBaseCondaEnv('/env');
+    expect(checkedPath).toContain('conda.bat');
+  });
+});
+
+describe('bundledEnvironmentIsInstalled', () => {
+  it('returns true when bundled env path exists and is directory', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.statSync = vi.fn(() => ({ isDirectory: () => true } as fs.Stats));
+    expect(bundledEnvironmentIsInstalled()).toBe(true);
+  });
+
+  it('returns false when bundled env path does not exist', () => {
+    mockFs.existsSync = vi.fn(() => false);
+    expect(bundledEnvironmentIsInstalled()).toBe(false);
+  });
+
+  it('returns false when path is a file not directory', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.statSync = vi.fn(() => ({ isDirectory: () => false } as fs.Stats));
+    expect(bundledEnvironmentIsInstalled()).toBe(false);
+  });
+});
+
+describe('getLogFilePath', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('returns path containing main.log by default', () => {
+    expect(getLogFilePath()).toContain('main.log');
+  });
+
+  it('returns path containing renderer.log for renderer process', () => {
+    expect(getLogFilePath('renderer')).toContain('renderer.log');
+  });
+
+  it('returns path under Library/Logs on darwin', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    expect(getLogFilePath()).toContain('Library/Logs');
+  });
+
+  it('returns path under .config on linux', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    expect(getLogFilePath()).toContain('.config');
+  });
+
+  it('returns path under userData on windows', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    expect(getLogFilePath()).toContain('logs');
+  });
+});
+
+describe('getJlabCLICommandSymlinkPath', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('returns /usr/local/bin/jlab on darwin', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    expect(getJlabCLICommandSymlinkPath()).toBe('/usr/local/bin/jlab');
+  });
+
+  it('returns undefined on non-darwin', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    expect(getJlabCLICommandSymlinkPath()).toBeUndefined();
+  });
+});
+
+describe('getJlabCLICommandTargetPath', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  // darwin path requires require.main via isDevMode() — only test the non-darwin case here
+  it('returns undefined on non-darwin', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    expect(getJlabCLICommandTargetPath()).toBeUndefined();
+  });
+});
+
+describe('jlabCLICommandIsSetup', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('returns true on non-darwin platforms (linux)', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    expect(jlabCLICommandIsSetup()).toBe(true);
+  });
+
+  it('returns true on non-darwin platforms (win32)', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    expect(jlabCLICommandIsSetup()).toBe(true);
+  });
+});
+
+describe('openDirectoryInExplorer', () => {
+  const originalPlatform = process.platform;
+  const mockExec = vi.mocked(childProcess.exec);
+
+  beforeEach(() => {
+    mockExec.mockReset();
+  });
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('returns false when path does not exist', () => {
+    mockFs.existsSync = vi.fn(() => false);
+    expect(openDirectoryInExplorer('/nonexistent')).toBe(false);
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it('returns false when path is a file not a directory', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.statSync = vi.fn(() => ({ isDirectory: () => false } as fs.Stats));
+    expect(openDirectoryInExplorer('/some/file.txt')).toBe(false);
+  });
+
+  it('returns true and calls exec on darwin', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.statSync = vi.fn(() => ({ isDirectory: () => true } as fs.Stats));
+    const result = openDirectoryInExplorer('/data/notebooks');
+    expect(result).toBe(true);
+    expect(mockExec).toHaveBeenCalledWith(expect.stringContaining('open'));
+  });
+
+  it('returns true and calls exec on windows', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.statSync = vi.fn(() => ({ isDirectory: () => true } as fs.Stats));
+    const result = openDirectoryInExplorer('/data/notebooks');
+    expect(result).toBe(true);
+    expect(mockExec).toHaveBeenCalledWith(expect.stringContaining('explorer'));
+  });
+
+  it('returns true and calls exec on linux', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.statSync = vi.fn(() => ({ isDirectory: () => true } as fs.Stats));
+    const result = openDirectoryInExplorer('/data/notebooks');
+    expect(result).toBe(true);
+    expect(mockExec).toHaveBeenCalledWith(expect.stringContaining('xdg-open'));
+  });
+});
+
+describe('createCommandScriptInEnv', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('returns empty string when envPath is not a directory', () => {
+    mockFs.lstatSync = vi.fn(() => ({ isDirectory: () => false } as fs.Stats));
+    expect(createCommandScriptInEnv('/notadir', '/base', {})).toBe('');
+  });
+
+  it('returns empty string when envPath lstatSync throws and no activate exists', () => {
+    // when lstatSync throws, the try-catch swallows it and execution continues;
+    // if there's also no activate script, the function returns ''
+    mockFs.lstatSync = vi.fn(() => {
+      throw new Error('ENOENT');
+    });
+    mockFs.existsSync = vi.fn(() => false);
+    expect(createCommandScriptInEnv('/missing', '/base', {})).toBe('');
+  });
+
+  it('returns empty string when no activate script exists', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    mockFs.lstatSync = vi.fn(() => ({ isDirectory: () => true } as fs.Stats));
+    mockFs.existsSync = vi.fn(() => false); // no activate, no conda-meta
+    expect(createCommandScriptInEnv('/env', '/base', {})).toBe('');
+  });
+
+  it('includes source activate for venv on posix', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    mockFs.lstatSync = vi.fn(
+      () => ({ isDirectory: () => true, isFile: () => false } as fs.Stats)
+    );
+    mockFs.existsSync = vi.fn((p: fs.PathLike) =>
+      p.toString().includes('activate')
+    ); // has activate, not conda
+    const script = createCommandScriptInEnv('/env', '/base', {
+      command: 'pip install numpy'
+    });
+    expect(script).toContain('source');
+    expect(script).toContain('activate');
+    expect(script).toContain('pip install numpy');
+  });
+
+  it('includes CALL activate on windows venv', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    mockFs.lstatSync = vi.fn(
+      () => ({ isDirectory: () => true, isFile: () => false } as fs.Stats)
+    );
+    mockFs.existsSync = vi.fn((p: fs.PathLike) =>
+      p.toString().includes('activate')
+    );
+    const script = createCommandScriptInEnv('/env', '/base', {
+      command: 'pip install numpy'
+    });
+    expect(script).toContain('CALL');
+    expect(script).toContain('activate');
+  });
+
+  it('uses custom quoteChar and joinStr', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    mockFs.lstatSync = vi.fn(() => ({ isDirectory: () => true } as fs.Stats));
+    mockFs.existsSync = vi.fn((p: fs.PathLike) =>
+      p.toString().includes('activate')
+    );
+    const script = createCommandScriptInEnv('/env', '/base', {
+      command: 'echo hello',
+      quoteChar: "'",
+      joinStr: ' ; '
+    });
+    expect(script).toContain("'");
+    expect(script).toContain(' ; ');
+  });
+});
+
+describe('markEnvironmentAsJupyterInstalled', () => {
+  beforeEach(() => {
+    mockFs.existsSync = vi.fn(() => false);
+    mockFs.mkdirSync = vi.fn();
+    mockFs.writeFileSync = vi.fn();
+  });
+
+  it('creates .jupyter dir when missing and writes env.json', () => {
+    markEnvironmentAsJupyterInstalled('/env/myenv');
+    expect(mockFs.mkdirSync).toHaveBeenCalledWith(
+      expect.stringContaining('.jupyter'),
+      { recursive: true }
+    );
+    expect(mockFs.writeFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('env.json'),
+      expect.stringContaining('jupyterlab-desktop')
+    );
+  });
+
+  it('skips mkdirSync when .jupyter dir already exists', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    markEnvironmentAsJupyterInstalled('/env/myenv');
+    expect(mockFs.mkdirSync).not.toHaveBeenCalled();
+    expect(mockFs.writeFileSync).toHaveBeenCalled();
+  });
+
+  it('merges extraData into written JSON', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    markEnvironmentAsJupyterInstalled('/env/myenv', { version: '4.0.0' });
+    const content = (mockFs.writeFileSync as any).mock.calls[0][1] as string;
+    const json = JSON.parse(content);
+    expect(json.installer).toBe('jupyterlab-desktop');
+    expect(json.version).toBe('4.0.0');
+  });
+
+  it('does not throw when writeFileSync fails', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.writeFileSync = vi.fn(() => {
+      throw new Error('EACCES');
+    });
+    expect(() => markEnvironmentAsJupyterInstalled('/env/myenv')).not.toThrow();
+  });
+});
+
+describe('deletePythonEnvironment', () => {
+  beforeEach(() => {
+    mockFs.existsSync = vi.fn(() => false);
+    mockFs.rmSync = vi.fn();
+  });
+
+  it('rejects when env was not installed by Desktop (no env.json)', async () => {
+    // isEnvInstalledByDesktopApp → existsSync returns false
+    const listener = { onDeleteStatus: vi.fn() };
+    await expect(
+      deletePythonEnvironment('/env/foreign', listener)
+    ).rejects.toBeUndefined();
+    expect(listener.onDeleteStatus).toHaveBeenCalledWith(
+      EnvironmentDeleteStatus.Failure,
+      expect.any(String)
+    );
+  });
+
+  it('calls rmSync and resolves true when env.json exists', async () => {
+    // isEnvInstalledByDesktopApp → existsSync returns true
+    mockFs.existsSync = vi.fn(() => true);
+    const listener = { onDeleteStatus: vi.fn() };
+    const result = await deletePythonEnvironment('/env/myenv', listener);
+    expect(mockFs.rmSync).toHaveBeenCalledWith('/env/myenv', {
+      recursive: true,
+      force: true
+    });
+    expect(result).toBe(true);
+    expect(listener.onDeleteStatus).toHaveBeenCalledWith(
+      EnvironmentDeleteStatus.Success
+    );
+  });
+
+  it('rejects with Failure status when rmSync throws', async () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.rmSync = vi.fn(() => {
+      throw new Error('EPERM');
+    });
+    const listener = { onDeleteStatus: vi.fn() };
+    await expect(
+      deletePythonEnvironment('/env/myenv', listener)
+    ).rejects.toBeUndefined();
+    expect(listener.onDeleteStatus).toHaveBeenCalledWith(
+      EnvironmentDeleteStatus.Failure,
+      'EPERM'
+    );
+  });
+
+  it('works without a listener', async () => {
+    mockFs.existsSync = vi.fn(() => true);
+    await expect(deletePythonEnvironment('/env/myenv')).resolves.toBe(true);
+  });
+});
+
+describe('createTempFile', () => {
+  beforeEach(() => {
+    mockFs.mkdtempSync = vi.fn(() => '/tmp/jlab_desktop_abc');
+    mockFs.writeFileSync = vi.fn();
+  });
+
+  it('calls mkdtempSync with jlab_desktop prefix', () => {
+    createTempFile('test.sh', 'echo hi');
+    expect(mockFs.mkdtempSync).toHaveBeenCalledWith(
+      expect.stringContaining('jlab_desktop')
+    );
+  });
+
+  it('writes data to the temp file', () => {
+    createTempFile('test.sh', 'echo hi', 'utf8');
+    expect(mockFs.writeFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('test.sh'),
+      'echo hi',
+      { encoding: 'utf8' }
+    );
+  });
+
+  it('returns path inside the temp dir', () => {
+    const result = createTempFile('run.sh');
+    expect(result).toContain('run.sh');
+    expect(result).toContain('/tmp/jlab_desktop_abc');
+  });
+
+  it('uses defaults when called with no args', () => {
+    const result = createTempFile();
+    expect(result).toContain('temp');
+  });
+});
+
+describe('isPortInUse', () => {
+  it('resolves false on connection error (port not in use)', async () => {
+    const mockSocket = {
+      setTimeout: vi.fn(),
+      once: vi.fn((event: string, cb: () => void) => {
+        if (event === 'error') cb();
+      }),
+      on: vi.fn((event: string, cb: (v?: any) => void) => {
+        if (event === 'close') cb(false);
+      }),
+      connect: vi.fn(),
+      destroy: vi.fn()
+    };
+    vi.mocked(net.Socket).mockImplementation(function () {
+      return mockSocket;
+    } as any);
+    const result = await isPortInUse(9999);
+    expect(result).toBe(false);
+  });
+
+  it('resolves true on connect (port in use)', async () => {
+    let closeCallback: ((v?: any) => void) | null = null;
+    const mockSocket = {
+      setTimeout: vi.fn(),
+      once: vi.fn(),
+      on: vi.fn((event: string, cb: (v?: any) => void) => {
+        if (event === 'connect') {
+          cb();
+        }
+        if (event === 'close') {
+          closeCallback = cb;
+        }
+      }),
+      connect: vi.fn(() => {
+        if (closeCallback) closeCallback(false);
+      }),
+      destroy: vi.fn()
+    };
+    vi.mocked(net.Socket).mockImplementation(function () {
+      return mockSocket;
+    } as any);
+    const result = await isPortInUse(8080);
+    expect(result).toBe(true);
+  });
+});
+
+describe('getFreePort', () => {
+  it('resolves a numeric port from server address', async () => {
+    const mockServer = {
+      on: vi.fn((event: string, cb: (e?: any) => void) => {
+        if (event === 'listening') cb({});
+      }),
+      listen: vi.fn(),
+      close: vi.fn(),
+      address: vi.fn(() => ({ port: 54321 }))
+    };
+    vi.mocked(net.createServer).mockReturnValue(mockServer as any);
+    const port = await getFreePort();
+    expect(port).toBe(54321);
+  });
+});

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import { nativeTheme } from 'electron';
+import log from 'electron-log';
 
 vi.mock('fs', async () => {
   const actual = await vi.importActual<typeof import('fs')>('fs');
@@ -669,11 +670,17 @@ describe('clearSession', () => {
     await expect(clearSession(fakeSession())).resolves.toBeUndefined();
   });
 
-  it('rejects (does not hang) when a clear call rejects', async () => {
+  it('still resolves and logs when a clear call rejects, so teardown proceeds', async () => {
     const session = fakeSession({
       clearStorageData: vi.fn(() => Promise.reject(new Error('boom')))
     });
-    await expect(clearSession(session)).rejects.toBeUndefined();
+    // best-effort: callers close windows right after awaiting, so a failed
+    // clear must not reject (skipping cleanup) nor hang.
+    await expect(clearSession(session)).resolves.toBeUndefined();
+    expect(log.error).toHaveBeenCalledWith(
+      'Failed to clear part of the session',
+      expect.any(Error)
+    );
   });
 });
 

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -42,6 +42,7 @@ vi.mock('os', async () => {
 import {
   activatePathForEnvPath,
   bundledEnvironmentIsInstalled,
+  clearSession,
   condaSourcePathForEnvPath,
   createCommandScriptInEnv,
   createTempFile,
@@ -651,6 +652,28 @@ describe('deletePythonEnvironment', () => {
   it('works without a listener', async () => {
     mockFs.existsSync = vi.fn(() => true);
     await expect(deletePythonEnvironment('/env/myenv')).resolves.toBe(true);
+  });
+});
+
+describe('clearSession', () => {
+  const fakeSession = (overrides: Record<string, any> = {}) =>
+    (({
+      clearCache: vi.fn(() => Promise.resolve()),
+      clearAuthCache: vi.fn(() => Promise.resolve()),
+      clearStorageData: vi.fn(() => Promise.resolve()),
+      flushStorageData: vi.fn(() => Promise.resolve()),
+      ...overrides
+    } as unknown) as Electron.Session);
+
+  it('resolves once every clear call settles', async () => {
+    await expect(clearSession(fakeSession())).resolves.toBeUndefined();
+  });
+
+  it('rejects (does not hang) when a clear call rejects', async () => {
+    const session = fakeSession({
+      clearStorageData: vi.fn(() => Promise.reject(new Error('boom')))
+    });
+    await expect(clearSession(session)).rejects.toBeUndefined();
   });
 });
 

--- a/test/unit/workspacesettings.test.ts
+++ b/test/unit/workspacesettings.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    lstatSync: vi.fn(),
+    readFileSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    mkdirSync: vi.fn()
+  };
+});
+
+import {
+  SettingType,
+  ThemeType,
+  UIMode,
+  WorkspaceSettings
+} from '../../src/main/config/settings';
+
+const mockFs = vi.mocked(fs);
+
+describe('WorkspaceSettings.getWorkspaceSettingsPath', () => {
+  it('returns .jupyter/desktop-settings.json inside working dir', () => {
+    const result = WorkspaceSettings.getWorkspaceSettingsPath(
+      '/data/notebooks'
+    );
+    expect(result).toBe(
+      path.join('/data/notebooks', '.jupyter', 'desktop-settings.json')
+    );
+  });
+});
+
+describe('WorkspaceSettings — no workspace file', () => {
+  beforeEach(() => {
+    // user settings file does not exist, workspace settings file does not exist
+    mockFs.existsSync = vi.fn(() => false);
+    mockFs.readFileSync = vi.fn(() => {
+      throw new Error('ENOENT');
+    });
+  });
+
+  it('constructs without throwing', () => {
+    expect(() => new WorkspaceSettings('/data/nb')).not.toThrow();
+  });
+
+  it('hasValue returns false for any setting when no workspace file', () => {
+    const ws = new WorkspaceSettings('/data/nb');
+    expect(ws.hasValue(SettingType.theme)).toBe(false);
+  });
+
+  it('getValue falls through to user default when no workspace override', () => {
+    const ws = new WorkspaceSettings('/data/nb');
+    // theme default is 'system'
+    const val = ws.getValue(SettingType.theme);
+    expect(typeof val).toBe('string');
+  });
+});
+
+describe('WorkspaceSettings — with workspace file', () => {
+  beforeEach(() => {
+    mockFs.existsSync = vi.fn((p: fs.PathLike) => {
+      return p.toString().includes('desktop-settings.json');
+    });
+    mockFs.readFileSync = vi.fn((p: fs.PathLike | fs.promises.FileHandle) => {
+      if (p.toString().includes('desktop-settings.json')) {
+        // serverArgs and uiMode are wsOverridable
+        return Buffer.from(
+          JSON.stringify({ serverArgs: '--no-browser', uiMode: 'zen' })
+        );
+      }
+      throw new Error('ENOENT');
+    });
+  });
+
+  it('reads workspace-overridden serverArgs', () => {
+    const ws = new WorkspaceSettings('/data/nb');
+    expect(ws.getValue(SettingType.serverArgs)).toBe('--no-browser');
+  });
+
+  it('reads workspace-overridden uiMode', () => {
+    const ws = new WorkspaceSettings('/data/nb');
+    expect(ws.getValue(SettingType.uiMode)).toBe(UIMode.Zen);
+  });
+
+  it('hasValue returns true for overridden setting', () => {
+    const ws = new WorkspaceSettings('/data/nb');
+    expect(ws.hasValue(SettingType.serverArgs)).toBe(true);
+  });
+
+  it('hasValue returns false for non-overridden setting', () => {
+    const ws = new WorkspaceSettings('/data/nb');
+    expect(ws.hasValue(SettingType.theme)).toBe(false);
+  });
+
+  it('non-overridden settings still return global default', () => {
+    const ws = new WorkspaceSettings('/data/nb');
+    // theme is not wsOverridable, should still have default
+    expect(typeof ws.getValue(SettingType.theme)).toBe('string');
+  });
+});
+
+describe('WorkspaceSettings setValue / unsetValue', () => {
+  beforeEach(() => {
+    mockFs.existsSync = vi.fn(() => false);
+    mockFs.readFileSync = vi.fn(() => {
+      throw new Error('ENOENT');
+    });
+  });
+
+  it('setValue sets workspace-level value', () => {
+    const ws = new WorkspaceSettings('/data/nb');
+    ws.setValue(SettingType.theme, ThemeType.Dark);
+    expect(ws.getValue(SettingType.theme)).toBe(ThemeType.Dark);
+    expect(ws.hasValue(SettingType.theme)).toBe(true);
+  });
+
+  it('setValue overrides default', () => {
+    const ws = new WorkspaceSettings('/data/nb');
+    const before = ws.getValue(SettingType.theme);
+    expect(before).not.toBe(ThemeType.Light);
+    ws.setValue(SettingType.theme, ThemeType.Light);
+    expect(ws.getValue(SettingType.theme)).toBe(ThemeType.Light);
+  });
+
+  it('unsetValue removes workspace override', () => {
+    const ws = new WorkspaceSettings('/data/nb');
+    ws.setValue(SettingType.theme, ThemeType.Dark);
+    ws.unsetValue(SettingType.theme);
+    expect(ws.hasValue(SettingType.theme)).toBe(false);
+  });
+});
+
+describe('WorkspaceSettings save', () => {
+  beforeEach(() => {
+    mockFs.existsSync = vi.fn(() => false);
+    mockFs.readFileSync = vi.fn(() => {
+      throw new Error('ENOENT');
+    });
+    mockFs.writeFileSync = vi.fn();
+    mockFs.mkdirSync = vi.fn();
+  });
+
+  it('writes desktop-settings.json when workspace settings differ from user settings', () => {
+    const ws = new WorkspaceSettings('/data/nb');
+    // uiMode is wsOverridable and always saved when present
+    ws.setValue(SettingType.uiMode, UIMode.Zen);
+    ws.save();
+    expect(mockFs.writeFileSync).toHaveBeenCalled();
+    const [writePath, content] = (mockFs.writeFileSync as any).mock.calls[0];
+    expect(writePath).toContain('desktop-settings.json');
+    const parsed = JSON.parse(content as string);
+    expect(parsed.uiMode).toBe(UIMode.Zen);
+  });
+
+  it('creates parent directory when it does not exist', () => {
+    const ws = new WorkspaceSettings('/data/nb');
+    ws.setValue(SettingType.uiMode, UIMode.Zen);
+    ws.save();
+    expect(mockFs.mkdirSync).toHaveBeenCalled();
+  });
+
+  it('does not write when no workspace settings changed and file does not exist', () => {
+    const ws = new WorkspaceSettings('/data/nb');
+    ws.save();
+    expect(mockFs.writeFileSync).not.toHaveBeenCalled();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,8 +8,59 @@ export default defineConfig({
     setupFiles: ['test/setup/electron-mock.ts'],
     coverage: {
       provider: 'v8',
-      include: ['src/main/**/*.ts'],
-      exclude: ['src/main/**/*.d.ts', 'src/main/main.ts']
+      // Instrument the full tree of the unit-tested logic layer (all: true),
+      // not just the files a run happens to import, so untested branches count.
+      all: true,
+      // Scope to the main-process logic modules that are unit-testable. The
+      // window/view/dialog/preload UI and the process-entry modules
+      // (app, server, registry, connect, main) are integration surfaces; they
+      // are covered by the Playwright e2e suite, tracked for expansion in C3,
+      // and would otherwise dilute the denominator with code unit tests cannot
+      // reach without a running Electron process.
+      include: [
+        'src/main/env.ts',
+        'src/main/cli.ts',
+        'src/main/utils.ts',
+        'src/main/eventmanager.ts',
+        'src/main/eventtypes.ts',
+        'src/main/tokens.ts',
+        'src/main/config/**/*.ts'
+      ],
+      exclude: ['**/*.d.ts'],
+      thresholds: {
+        // Floor for the logic layer as a whole; cli.ts and env.ts still have
+        // large untested spawn/discovery branches that pull the aggregate down.
+        lines: 45,
+        statements: 45,
+        functions: 50,
+        branches: 35,
+        // Lock the well-covered modules at their current level so a future
+        // change cannot silently regress them.
+        'src/main/eventmanager.ts': {
+          lines: 100,
+          statements: 100,
+          functions: 100,
+          branches: 90
+        },
+        'src/main/config/sessionconfig.ts': {
+          lines: 90,
+          statements: 90,
+          functions: 90,
+          branches: 85
+        },
+        'src/main/config/settings.ts': {
+          lines: 78,
+          statements: 78,
+          functions: 60,
+          branches: 65
+        },
+        'src/main/config/appdata.ts': {
+          lines: 70,
+          statements: 70,
+          functions: 75,
+          branches: 58
+        }
+      }
     }
   }
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -30,10 +30,10 @@ export default defineConfig({
       thresholds: {
         // Floor for the logic layer as a whole; cli.ts and env.ts still have
         // large untested spawn/discovery branches that pull the aggregate down.
-        lines: 45,
-        statements: 45,
-        functions: 50,
-        branches: 35,
+        lines: 48,
+        statements: 48,
+        functions: 53,
+        branches: 37,
         // Lock the well-covered modules at their current level so a future
         // change cannot silently regress them.
         'src/main/eventmanager.ts': {
@@ -43,22 +43,22 @@ export default defineConfig({
           branches: 90
         },
         'src/main/config/sessionconfig.ts': {
-          lines: 90,
-          statements: 90,
-          functions: 90,
-          branches: 85
+          lines: 93,
+          statements: 93,
+          functions: 92,
+          branches: 88
         },
         'src/main/config/settings.ts': {
-          lines: 78,
-          statements: 78,
-          functions: 60,
-          branches: 65
+          lines: 90,
+          statements: 90,
+          functions: 86,
+          branches: 73
         },
         'src/main/config/appdata.ts': {
-          lines: 70,
-          statements: 70,
-          functions: 75,
-          branches: 58
+          lines: 75,
+          statements: 75,
+          functions: 82,
+          branches: 62
         }
       }
     }


### PR DESCRIPTION
Builds on #961 (C1 test infra). Adds unit coverage for the main-process logic layer and wires the coverage gate into CI.

## What's here
- Unit tests for tokens, eventtypes, utils, settings, workspacesettings, appdata, sessionconfig, cli + handlers, EventManager. 317 tests, 11 files. Table-driven (`it.each`) where the cases are wire values or structural invariants.
- v8 coverage with per-file locks on the well-covered modules (eventmanager 100%, sessionconfig 94%, settings 91%, appdata 77%) plus a conservative global floor.
- CI test step now runs `yarn test:coverage`, so a regression below any threshold fails the PR check. Added `timeout-minutes: 10` to the job.

## Where the substance is, if useful
A couple of spots that might be worth a closer look:
- `vitest.config.ts`: the `include` is scoped to unit-testable logic. cli.ts and env.ts read low on purpose, their spawn and Python-discovery branches need a running Electron+Python process and seem more like e2e/integration territory (C3) than mocked unit tests. The global floor reflects that; the per-file locks guard the parts that are genuinely unit-covered. Open to a different call on where that line sits.
- The negative/security cases (path resolution, conda-env detection, invalid activate dir, CLI arg guards) are where I focused the assertions, in case that's a helpful starting point.

## How I verified
Each test was mutation-checked: flip the operator or drop the line in the source, confirm a test fails, restore. The threshold gate itself was confirmed live (raised global lines to 99, saw exit 1 "does not meet global threshold", reverted). 317/317 pass, tsc clean, eslint clean.

Coverage % is a floor, not a target here. The goal is behavioral assertions that catch real regressions, not a number.

Note: AI-assisted (Claude Code). Manually verified: the mutation checks and the CI gate behavior described above, run locally on this branch.