### PR TITLE
test: characterize the 12 preload contextBridge contracts

### DIFF
--- a/test/setup/electron-mock.ts
+++ b/test/setup/electron-mock.ts
@@ -1,48 +1,27 @@
 import { vi } from 'vitest';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import * as electronStub from './electron-stub';
 
-const userDataPath = join(tmpdir(), 'jlab-test-userdata');
 const logFilePath = join(tmpdir(), 'jlab-test.log');
 
-vi.mock('electron', () => ({
-  app: {
-    getPath: vi.fn((name: string) => join(userDataPath, name)),
-    getVersion: vi.fn(() => '4.4.7'),
-    getName: vi.fn(() => 'JupyterLab'),
-    isPackaged: false,
-    whenReady: vi.fn(() => Promise.resolve())
-  },
-  ipcMain: {
-    on: vi.fn(),
-    handle: vi.fn(),
-    removeHandler: vi.fn(),
-    removeListener: vi.fn(),
-    removeAllListeners: vi.fn(),
-    emit: vi.fn()
-  },
-  dialog: {
-    showOpenDialog: vi.fn(),
-    showMessageBox: vi.fn(),
-    showMessageBoxSync: vi.fn(() => 0)
-  },
-  BrowserWindow: vi.fn().mockImplementation(() => ({
-    loadURL: vi.fn(),
-    webContents: { send: vi.fn(), on: vi.fn() },
-    on: vi.fn(),
-    once: vi.fn(),
-    show: vi.fn(),
-    close: vi.fn(),
-    isDestroyed: vi.fn(() => false)
-  })),
-  shell: { openExternal: vi.fn(), openPath: vi.fn() },
-  nativeTheme: { shouldUseDarkColors: false },
-  screen: {
-    getPrimaryDisplay: vi.fn(() => ({
-      workAreaSize: { width: 1920, height: 1080 }
-    }))
-  }
-}));
+// `electron` is mocked two ways pointing at the same ./electron-stub instances:
+//   - vitest.config `resolve.alias` redirects ESM `import ... from 'electron'`.
+//   - vitest leaves CJS `require('electron')` (used by the preload scripts)
+//     externalized, so it hits Node's require and would return the binary path
+//     string. Pre-seeding require.cache for electron's resolved id makes that
+//     require return the stub instead. Both paths share electronStub's vi.fns.
+try {
+  const electronId = require.resolve('electron');
+  (require.cache as Record<string, unknown>)[electronId] = {
+    id: electronId,
+    filename: electronId,
+    loaded: true,
+    exports: electronStub
+  };
+} catch {
+  // electron not resolvable in this environment; ESM alias still applies.
+}
 
 vi.mock('electron-log', () => ({
   default: {

--- a/test/setup/electron-stub.ts
+++ b/test/setup/electron-stub.ts
@@ -1,0 +1,64 @@
+// Single source of truth for the mocked `electron` module.
+// Aliased in vitest.config so BOTH `import ... from 'electron'` (ESM) and
+// `require('electron')` (used by the preload scripts) resolve here to the same
+// vi.fn instances. Native require would otherwise return the electron binary
+// path string and bypass vi.mock, leaving preload code untestable.
+import { vi } from 'vitest';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const userDataPath = join(tmpdir(), 'jlab-test-userdata');
+
+export const app = {
+  getPath: vi.fn((name: string) => join(userDataPath, name)),
+  getVersion: vi.fn(() => '4.4.7'),
+  getName: vi.fn(() => 'JupyterLab'),
+  isPackaged: false,
+  whenReady: vi.fn(() => Promise.resolve())
+};
+
+export const ipcMain = {
+  on: vi.fn(),
+  handle: vi.fn(),
+  removeHandler: vi.fn(),
+  removeListener: vi.fn(),
+  removeAllListeners: vi.fn(),
+  emit: vi.fn()
+};
+
+export const ipcRenderer = {
+  invoke: vi.fn(),
+  send: vi.fn(),
+  on: vi.fn(),
+  removeListener: vi.fn()
+};
+
+export const contextBridge = {
+  exposeInMainWorld: vi.fn()
+};
+
+export const dialog = {
+  showOpenDialog: vi.fn(),
+  showMessageBox: vi.fn(),
+  showMessageBoxSync: vi.fn(() => 0)
+};
+
+export const BrowserWindow = vi.fn().mockImplementation(() => ({
+  loadURL: vi.fn(),
+  webContents: { send: vi.fn(), on: vi.fn() },
+  on: vi.fn(),
+  once: vi.fn(),
+  show: vi.fn(),
+  close: vi.fn(),
+  isDestroyed: vi.fn(() => false)
+}));
+
+export const shell = { openExternal: vi.fn(), openPath: vi.fn() };
+
+export const nativeTheme = { shouldUseDarkColors: false };
+
+export const screen = {
+  getPrimaryDisplay: vi.fn(() => ({
+    workAreaSize: { width: 1920, height: 1080 }
+  }))
+};

--- a/test/unit/preload/aboutdialog.test.ts
+++ b/test/unit/preload/aboutdialog.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventTypeMain } from '../../../src/main/eventtypes';
+import { exposedAPI, ipcRenderer } from './helpers';
+
+async function load(): Promise<Record<string, any>> {
+  await import('../../../src/main/aboutdialog/preload');
+  return exposedAPI();
+}
+
+describe('aboutdialog preload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('exposes exactly the documented electronAPI keys', async () => {
+    const api = await load();
+    expect(Object.keys(api).sort()).toEqual(
+      ['getAppConfig', 'isDarkTheme', 'launchAboutJupyterPage'].sort()
+    );
+  });
+
+  it('getAppConfig returns the platform without touching IPC', async () => {
+    const api = await load();
+    expect(api.getAppConfig()).toEqual({ platform: process.platform });
+    expect(ipcRenderer.invoke).not.toHaveBeenCalled();
+    expect(ipcRenderer.send).not.toHaveBeenCalled();
+  });
+
+  it('isDarkTheme forwards to invoke on the IsDarkTheme channel', async () => {
+    const api = await load();
+    api.isDarkTheme();
+    expect(ipcRenderer.invoke).toHaveBeenCalledWith(EventTypeMain.IsDarkTheme);
+  });
+
+  it('launchAboutJupyterPage forwards to send on the LaunchAboutJupyterPage channel', async () => {
+    const api = await load();
+    api.launchAboutJupyterPage();
+    expect(ipcRenderer.send).toHaveBeenCalledWith(
+      EventTypeMain.LaunchAboutJupyterPage
+    );
+  });
+
+  it('does not expose the raw ipcRenderer object', async () => {
+    const api = await load();
+    expect(Object.values(api)).not.toContain(ipcRenderer);
+  });
+});

--- a/test/unit/preload/authdialog.test.ts
+++ b/test/unit/preload/authdialog.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventTypeMain } from '../../../src/main/eventtypes';
+import { exposedAPI, ipcRenderer } from './helpers';
+
+async function load(): Promise<Record<string, any>> {
+  await import('../../../src/main/authdialog/preload');
+  return exposedAPI();
+}
+
+describe('authdialog preload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('exposes exactly the documented electronAPI keys', async () => {
+    const api = await load();
+    expect(Object.keys(api).sort()).toEqual(
+      ['getAppConfig', 'isDarkTheme', 'setAuthDialogResponse'].sort()
+    );
+  });
+
+  it('getAppConfig returns the platform without touching IPC', async () => {
+    const api = await load();
+    expect(api.getAppConfig()).toEqual({ platform: process.platform });
+    expect(ipcRenderer.invoke).not.toHaveBeenCalled();
+    expect(ipcRenderer.send).not.toHaveBeenCalled();
+  });
+
+  it('isDarkTheme forwards to invoke on the IsDarkTheme channel', async () => {
+    const api = await load();
+    api.isDarkTheme();
+    expect(ipcRenderer.invoke).toHaveBeenCalledWith(EventTypeMain.IsDarkTheme);
+  });
+
+  it('setAuthDialogResponse forwards username and password on SetAuthDialogResponse', async () => {
+    const api = await load();
+    api.setAuthDialogResponse('user', 'pass');
+    expect(ipcRenderer.send).toHaveBeenCalledWith(
+      EventTypeMain.SetAuthDialogResponse,
+      'user',
+      'pass'
+    );
+  });
+
+  it('does not expose the raw ipcRenderer object', async () => {
+    const api = await load();
+    expect(Object.values(api)).not.toContain(ipcRenderer);
+  });
+});

--- a/test/unit/preload/dialog.test.ts
+++ b/test/unit/preload/dialog.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventTypeMain } from '../../../src/main/eventtypes';
+import { exposedAPI, ipcRenderer } from './helpers';
+
+async function load(): Promise<Record<string, any>> {
+  await import('../../../src/main/dialog/preload');
+  return exposedAPI();
+}
+
+describe('dialog preload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('exposes exactly the documented electronAPI keys', async () => {
+    const api = await load();
+    expect(Object.keys(api).sort()).toEqual(
+      ['getAppConfig', 'isDarkTheme'].sort()
+    );
+  });
+
+  it('getAppConfig returns the platform without touching IPC', async () => {
+    const api = await load();
+    expect(api.getAppConfig()).toEqual({ platform: process.platform });
+    expect(ipcRenderer.invoke).not.toHaveBeenCalled();
+    expect(ipcRenderer.send).not.toHaveBeenCalled();
+  });
+
+  it('isDarkTheme forwards to invoke on the IsDarkTheme channel', async () => {
+    const api = await load();
+    api.isDarkTheme();
+    expect(ipcRenderer.invoke).toHaveBeenCalledWith(EventTypeMain.IsDarkTheme);
+  });
+
+  it('does not expose the raw ipcRenderer object', async () => {
+    const api = await load();
+    expect(Object.values(api)).not.toContain(ipcRenderer);
+  });
+});

--- a/test/unit/preload/helpers.ts
+++ b/test/unit/preload/helpers.ts
@@ -1,0 +1,25 @@
+import { contextBridge, ipcRenderer } from 'electron';
+import { vi } from 'vitest';
+
+export { ipcRenderer };
+
+// The API object the preload handed to contextBridge.exposeInMainWorld('electronAPI', ...).
+export function exposedAPI(): Record<string, any> {
+  const call = vi
+    .mocked(contextBridge.exposeInMainWorld)
+    .mock.calls.find(c => c[0] === 'electronAPI');
+  if (!call) {
+    throw new Error('preload did not expose an "electronAPI" namespace');
+  }
+  return call[1] as Record<string, any>;
+}
+
+// The handler the preload registered for a given EventTypeRenderer channel via
+// ipcRenderer.on at module load. Invoke it to simulate a message from main.
+export function rendererHandler(channel: string): (...args: any[]) => void {
+  const call = vi.mocked(ipcRenderer.on).mock.calls.find(c => c[0] === channel);
+  if (!call) {
+    throw new Error(`no ipcRenderer.on listener registered for "${channel}"`);
+  }
+  return call[1] as (...args: any[]) => void;
+}

--- a/test/unit/preload/labview.test.ts
+++ b/test/unit/preload/labview.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventTypeMain } from '../../../src/main/eventtypes';
+import { exposedAPI, ipcRenderer } from './helpers';
+
+async function load(): Promise<Record<string, any>> {
+  await import('../../../src/main/labview/preload');
+  return exposedAPI();
+}
+
+describe('labview preload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('exposes exactly the documented electronAPI keys', async () => {
+    const api = await load();
+    expect(Object.keys(api).sort()).toEqual(
+      ['getServerInfo', 'broadcastLabUIReady'].sort()
+    );
+  });
+
+  it('getServerInfo forwards to invoke on the GetServerInfo channel', async () => {
+    const api = await load();
+    api.getServerInfo();
+    expect(ipcRenderer.invoke).toHaveBeenCalledWith(
+      EventTypeMain.GetServerInfo
+    );
+  });
+
+  it('broadcastLabUIReady forwards to send on the LabUIReady channel', async () => {
+    const api = await load();
+    api.broadcastLabUIReady();
+    expect(ipcRenderer.send).toHaveBeenCalledWith(EventTypeMain.LabUIReady);
+  });
+
+  it('does not expose the raw ipcRenderer object', async () => {
+    const api = await load();
+    expect(Object.values(api)).not.toContain(ipcRenderer);
+  });
+});

--- a/test/unit/preload/progressview.test.ts
+++ b/test/unit/preload/progressview.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventTypeMain, EventTypeRenderer } from '../../../src/main/eventtypes';
+import { exposedAPI, ipcRenderer, rendererHandler } from './helpers';
+
+async function load(): Promise<Record<string, any>> {
+  await import('../../../src/main/progressview/preload');
+  return exposedAPI();
+}
+
+describe('progressview preload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('exposes exactly the documented electronAPI keys', async () => {
+    const api = await load();
+    expect(Object.keys(api).sort()).toEqual(
+      [
+        'getAppConfig',
+        'isDarkTheme',
+        'onShowProgress',
+        'sendMessageToMain',
+        'onInstallBundledPythonEnvStatus',
+        'copyToClipboard'
+      ].sort()
+    );
+  });
+
+  it('getAppConfig returns the platform without touching IPC', async () => {
+    const api = await load();
+    expect(api.getAppConfig()).toEqual({ platform: process.platform });
+    expect(ipcRenderer.invoke).not.toHaveBeenCalled();
+  });
+
+  it('isDarkTheme forwards to invoke on the IsDarkTheme channel', async () => {
+    const api = await load();
+    api.isDarkTheme();
+    expect(ipcRenderer.invoke).toHaveBeenCalledWith(EventTypeMain.IsDarkTheme);
+  });
+
+  it('copyToClipboard forwards the content on CopyToClipboard', async () => {
+    const api = await load();
+    api.copyToClipboard('text');
+    expect(ipcRenderer.send).toHaveBeenCalledWith(
+      EventTypeMain.CopyToClipboard,
+      'text'
+    );
+  });
+
+  it('sendMessageToMain relays an arbitrary channel and args verbatim', async () => {
+    const api = await load();
+    api.sendMessageToMain('custom-channel', 1, 'two');
+    expect(ipcRenderer.send).toHaveBeenCalledWith('custom-channel', 1, 'two');
+  });
+
+  it('onShowProgress relays the ShowProgress message to the registered callback', async () => {
+    const api = await load();
+    const cb = vi.fn();
+    api.onShowProgress(cb);
+    rendererHandler(EventTypeRenderer.ShowProgress)(
+      {},
+      'title',
+      'detail',
+      true
+    );
+    expect(cb).toHaveBeenCalledWith('title', 'detail', true);
+  });
+
+  it('onInstallBundledPythonEnvStatus relays the InstallPythonEnvStatus message', async () => {
+    const api = await load();
+    const cb = vi.fn();
+    api.onInstallBundledPythonEnvStatus(cb);
+    rendererHandler(EventTypeRenderer.InstallPythonEnvStatus)({}, 'ok', 'msg');
+    expect(cb).toHaveBeenCalledWith('ok', 'msg');
+  });
+
+  it('does not expose the raw ipcRenderer object', async () => {
+    const api = await load();
+    expect(Object.values(api)).not.toContain(ipcRenderer);
+  });
+});

--- a/test/unit/preload/pythonenvdialog.test.ts
+++ b/test/unit/preload/pythonenvdialog.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventTypeMain, EventTypeRenderer } from '../../../src/main/eventtypes';
+import { exposedAPI, ipcRenderer, rendererHandler } from './helpers';
+
+async function load(): Promise<Record<string, any>> {
+  await import('../../../src/main/pythonenvdialog/preload');
+  return exposedAPI();
+}
+
+describe('pythonenvdialog preload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('exposes exactly the documented electronAPI keys', async () => {
+    const api = await load();
+    expect(Object.keys(api).sort()).toEqual(
+      [
+        'getAppConfig',
+        'isDarkTheme',
+        'getNextPythonEnvironmentName',
+        'getPythonEnvironmentList',
+        'createNewPythonEnvironment',
+        'selectDirectoryPath',
+        'selectFilePath',
+        'showPythonEnvironmentContextMenu',
+        'browsePythonPath',
+        'onSetPythonEnvironmentList',
+        'onEnvironmentListUpdateStatus',
+        'installBundledPythonEnv',
+        'updateBundledPythonEnv',
+        'onInstallBundledPythonEnvStatus',
+        'selectPythonPath',
+        'onCustomPythonPathSelected',
+        'setDefaultPythonPath',
+        'validatePythonPath',
+        'getEnvironmentByPythonPath',
+        'addEnvironmentByPythonPath',
+        'validateNewPythonEnvironmentName',
+        'validatePythonEnvironmentInstallDirectory',
+        'setPythonEnvironmentInstallDirectory',
+        'validateCondaPath',
+        'setCondaPath',
+        'validateCondaChannels',
+        'setCondaChannels',
+        'validateSystemPythonPath',
+        'setSystemPythonPath'
+      ].sort()
+    );
+  });
+
+  it('getAppConfig returns the platform without touching IPC', async () => {
+    const api = await load();
+    expect(api.getAppConfig()).toEqual({ platform: process.platform });
+  });
+
+  it('invoke-based queries forward to their channels', async () => {
+    const api = await load();
+    api.getNextPythonEnvironmentName();
+    api.getPythonEnvironmentList(true);
+    api.validatePythonPath('/usr/bin/python3');
+    api.getEnvironmentByPythonPath('/usr/bin/python3');
+    expect(ipcRenderer.invoke).toHaveBeenCalledWith(
+      EventTypeMain.GetNextPythonEnvironmentName
+    );
+    expect(ipcRenderer.invoke).toHaveBeenCalledWith(
+      EventTypeMain.GetPythonEnvironmentList,
+      true
+    );
+    expect(ipcRenderer.invoke).toHaveBeenCalledWith(
+      EventTypeMain.ValidatePythonPath,
+      '/usr/bin/python3'
+    );
+    expect(ipcRenderer.invoke).toHaveBeenCalledWith(
+      EventTypeMain.GetEnvironmentByPythonPath,
+      '/usr/bin/python3'
+    );
+  });
+
+  it('createNewPythonEnvironment forwards path, type and packages on CreateNewPythonEnvironment', async () => {
+    const api = await load();
+    api.createNewPythonEnvironment('/envs/a', 'conda', 'numpy');
+    expect(ipcRenderer.send).toHaveBeenCalledWith(
+      EventTypeMain.CreateNewPythonEnvironment,
+      '/envs/a',
+      'conda',
+      'numpy'
+    );
+  });
+
+  it('setCondaPath and setDefaultPythonPath forward their value on the right channel', async () => {
+    const api = await load();
+    api.setCondaPath('/opt/conda');
+    api.setDefaultPythonPath('/usr/bin/python3');
+    expect(ipcRenderer.send).toHaveBeenCalledWith(
+      EventTypeMain.SetCondaPath,
+      '/opt/conda'
+    );
+    expect(ipcRenderer.send).toHaveBeenCalledWith(
+      EventTypeMain.SetDefaultPythonPath,
+      '/usr/bin/python3'
+    );
+  });
+
+  it('onSetPythonEnvironmentList relays SetPythonEnvironmentList to the callback', async () => {
+    const api = await load();
+    const cb = vi.fn();
+    api.onSetPythonEnvironmentList(cb);
+    const envs = [{ name: 'base' }];
+    rendererHandler(EventTypeRenderer.SetPythonEnvironmentList)({}, envs);
+    expect(cb).toHaveBeenCalledWith(envs);
+  });
+
+  it('onEnvironmentListUpdateStatus relays SetEnvironmentListUpdateStatus to the callback', async () => {
+    const api = await load();
+    const cb = vi.fn();
+    api.onEnvironmentListUpdateStatus(cb);
+    rendererHandler(EventTypeRenderer.SetEnvironmentListUpdateStatus)(
+      {},
+      'fetching',
+      'msg'
+    );
+    expect(cb).toHaveBeenCalledWith('fetching', 'msg');
+  });
+
+  it('onCustomPythonPathSelected relays CustomPythonPathSelected to the callback', async () => {
+    const api = await load();
+    const cb = vi.fn();
+    api.onCustomPythonPathSelected(cb);
+    rendererHandler(EventTypeRenderer.CustomPythonPathSelected)({}, '/p');
+    expect(cb).toHaveBeenCalledWith('/p');
+  });
+
+  it('does not expose the raw ipcRenderer object', async () => {
+    const api = await load();
+    expect(Object.values(api)).not.toContain(ipcRenderer);
+  });
+});

--- a/test/unit/preload/pythonenvselectpopup.test.ts
+++ b/test/unit/preload/pythonenvselectpopup.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventTypeMain, EventTypeRenderer } from '../../../src/main/eventtypes';
+import { exposedAPI, ipcRenderer, rendererHandler } from './helpers';
+
+async function load(): Promise<Record<string, any>> {
+  await import('../../../src/main/pythonenvselectpopup/preload');
+  return exposedAPI();
+}
+
+describe('pythonenvselectpopup preload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('exposes exactly the documented electronAPI keys', async () => {
+    const api = await load();
+    expect(Object.keys(api).sort()).toEqual(
+      [
+        'getAppConfig',
+        'isDarkTheme',
+        'showManagePythonEnvsDialog',
+        'browsePythonPath',
+        'setSessionPythonPath',
+        'onCurrentPythonPathSet',
+        'onResetPythonEnvSelectPopup',
+        'onCustomPythonPathSelected',
+        'hideEnvSelectPopup',
+        'onSetPythonEnvironmentList',
+        'restartSession',
+        'copySessionInfo',
+        'updateBundledPythonEnv',
+        'onShowUpdateBundledEnvAction'
+      ].sort()
+    );
+  });
+
+  it('isDarkTheme forwards to invoke on the IsDarkTheme channel', async () => {
+    const api = await load();
+    api.isDarkTheme();
+    expect(ipcRenderer.invoke).toHaveBeenCalledWith(EventTypeMain.IsDarkTheme);
+  });
+
+  it('browsePythonPath forwards the current path on SelectPythonPath', async () => {
+    const api = await load();
+    api.browsePythonPath('/usr/bin/python3');
+    expect(ipcRenderer.send).toHaveBeenCalledWith(
+      EventTypeMain.SelectPythonPath,
+      '/usr/bin/python3'
+    );
+  });
+
+  it('setSessionPythonPath forwards the path on SetSessionPythonPath', async () => {
+    const api = await load();
+    api.setSessionPythonPath('/opt/py');
+    expect(ipcRenderer.send).toHaveBeenCalledWith(
+      EventTypeMain.SetSessionPythonPath,
+      '/opt/py'
+    );
+  });
+
+  it('no-arg actions forward to send on their channels', async () => {
+    const api = await load();
+    api.showManagePythonEnvsDialog();
+    api.hideEnvSelectPopup();
+    api.restartSession();
+    api.copySessionInfo();
+    api.updateBundledPythonEnv();
+    expect(ipcRenderer.send).toHaveBeenCalledWith(
+      EventTypeMain.ShowManagePythonEnvironmentsDialog
+    );
+    expect(ipcRenderer.send).toHaveBeenCalledWith(
+      EventTypeMain.HideEnvSelectPopup
+    );
+    expect(ipcRenderer.send).toHaveBeenCalledWith(EventTypeMain.RestartSession);
+    expect(ipcRenderer.send).toHaveBeenCalledWith(
+      EventTypeMain.CopySessionInfoToClipboard
+    );
+    expect(ipcRenderer.send).toHaveBeenCalledWith(
+      EventTypeMain.UpdateBundledPythonEnv
+    );
+  });
+
+  it('onCurrentPythonPathSet relays SetCurrentPythonPath to the callback', async () => {
+    const api = await load();
+    const cb = vi.fn();
+    api.onCurrentPythonPathSet(cb);
+    rendererHandler(EventTypeRenderer.SetCurrentPythonPath)({}, '/p', 'rel');
+    expect(cb).toHaveBeenCalledWith('/p', 'rel');
+  });
+
+  it('onResetPythonEnvSelectPopup relays ResetPythonEnvSelectPopup to the callback', async () => {
+    const api = await load();
+    const cb = vi.fn();
+    api.onResetPythonEnvSelectPopup(cb);
+    rendererHandler(EventTypeRenderer.ResetPythonEnvSelectPopup)({});
+    expect(cb).toHaveBeenCalled();
+  });
+
+  it('onShowUpdateBundledEnvAction relays ShowUpdateBundledEnvAction to the callback', async () => {
+    const api = await load();
+    const cb = vi.fn();
+    api.onShowUpdateBundledEnvAction(cb);
+    rendererHandler(EventTypeRenderer.ShowUpdateBundledEnvAction)({}, true);
+    expect(cb).toHaveBeenCalledWith(true);
+  });
+
+  it('does not expose the raw ipcRenderer object', async () => {
+    const api = await load();
+    expect(Object.values(api)).not.toContain(ipcRenderer);
+  });
+});

--- a/test/unit/preload/remoteserverselectdialog.test.ts
+++ b/test/unit/preload/remoteserverselectdialog.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventTypeMain, EventTypeRenderer } from '../../../src/main/eventtypes';
+import { exposedAPI, ipcRenderer, rendererHandler } from './helpers';
+
+async function load(): Promise<Record<string, any>> {
+  await import('../../../src/main/remoteserverselectdialog/preload');
+  return exposedAPI();
+}
+
+describe('remoteserverselectdialog preload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('exposes exactly the documented electronAPI keys', async () => {
+    const api = await load();
+    expect(Object.keys(api).sort()).toEqual(
+      [
+        'getAppConfig',
+        'isDarkTheme',
+        'setRemoteServerOptions',
+        'deleteRecentRemoteURL',
+        'onRecentRemoteURLsUpdated',
+        'onRunningServerListSet'
+      ].sort()
+    );
+  });
+
+  it('getAppConfig returns the platform without touching IPC', async () => {
+    const api = await load();
+    expect(api.getAppConfig()).toEqual({ platform: process.platform });
+  });
+
+  it('isDarkTheme forwards to invoke on the IsDarkTheme channel', async () => {
+    const api = await load();
+    api.isDarkTheme();
+    expect(ipcRenderer.invoke).toHaveBeenCalledWith(EventTypeMain.IsDarkTheme);
+  });
+
+  it('setRemoteServerOptions forwards url and persist flag on SetRemoteServerOptions', async () => {
+    const api = await load();
+    api.setRemoteServerOptions('https://example.org', true);
+    expect(ipcRenderer.send).toHaveBeenCalledWith(
+      EventTypeMain.SetRemoteServerOptions,
+      'https://example.org',
+      true
+    );
+  });
+
+  it('deleteRecentRemoteURL forwards the url on DeleteRecentRemoteURL', async () => {
+    const api = await load();
+    api.deleteRecentRemoteURL('https://example.org');
+    expect(ipcRenderer.send).toHaveBeenCalledWith(
+      EventTypeMain.DeleteRecentRemoteURL,
+      'https://example.org'
+    );
+  });
+
+  it('onRecentRemoteURLsUpdated relays UpdateRecentRemoteURLs to the callback', async () => {
+    const api = await load();
+    const cb = vi.fn();
+    api.onRecentRemoteURLsUpdated(cb);
+    const servers = [{ url: 'https://example.org' }];
+    rendererHandler(EventTypeRenderer.UpdateRecentRemoteURLs)({}, servers);
+    expect(cb).toHaveBeenCalledWith(servers);
+  });
+
+  it('onRunningServerListSet relays SetRunningServerList to the callback', async () => {
+    const api = await load();
+    const cb = vi.fn();
+    api.onRunningServerListSet(cb);
+    rendererHandler(EventTypeRenderer.SetRunningServerList)({}, ['a', 'b']);
+    expect(cb).toHaveBeenCalledWith(['a', 'b']);
+  });
+
+  it('does not expose the raw ipcRenderer object', async () => {
+    const api = await load();
+    expect(Object.values(api)).not.toContain(ipcRenderer);
+  });
+});

--- a/test/unit/preload/settingsdialog.test.ts
+++ b/test/unit/preload/settingsdialog.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventTypeMain, EventTypeRenderer } from '../../../src/main/eventtypes';
+import { exposedAPI, ipcRenderer, rendererHandler } from './helpers';
+
+async function load(): Promise<Record<string, any>> {
+  await import('../../../src/main/settingsdialog/preload');
+  return exposedAPI();
+}
+
+describe('settingsdialog preload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('exposes exactly the documented electronAPI keys', async () => {
+    const api = await load();
+    expect(Object.keys(api).sort()).toEqual(
+      [
+        'getAppConfig',
+        'isDarkTheme',
+        'restartApp',
+        'setCheckForUpdatesAutomatically',
+        'setInstallUpdatesAutomatically',
+        'checkForUpdates',
+        'showLogs',
+        'launchInstallerDownloadPage',
+        'setStartupMode',
+        'setTheme',
+        'setSyncJupyterLabTheme',
+        'setShowNewsFeed',
+        'selectWorkingDirectory',
+        'onWorkingDirectorySelected',
+        'setDefaultWorkingDirectory',
+        'clearHistory',
+        'setLogLevel',
+        'setServerLaunchArgs',
+        'setServerEnvVars',
+        'setCtrlWBehavior',
+        'setSettings',
+        'setupCLICommand'
+      ].sort()
+    );
+  });
+
+  it('getAppConfig returns the platform without touching IPC', async () => {
+    const api = await load();
+    expect(api.getAppConfig()).toEqual({ platform: process.platform });
+  });
+
+  it('isDarkTheme forwards to invoke on the IsDarkTheme channel', async () => {
+    const api = await load();
+    api.isDarkTheme();
+    expect(ipcRenderer.invoke).toHaveBeenCalledWith(EventTypeMain.IsDarkTheme);
+  });
+
+  it('restartApp forwards to send on the RestartApp channel', async () => {
+    const api = await load();
+    api.restartApp();
+    expect(ipcRenderer.send).toHaveBeenCalledWith(EventTypeMain.RestartApp);
+  });
+
+  it('setTheme forwards the theme on SetTheme', async () => {
+    const api = await load();
+    api.setTheme('dark');
+    expect(ipcRenderer.send).toHaveBeenCalledWith(
+      EventTypeMain.SetTheme,
+      'dark'
+    );
+  });
+
+  it('setServerLaunchArgs forwards args and the override flag on SetServerLaunchArgs', async () => {
+    const api = await load();
+    api.setServerLaunchArgs('--port 9999', true);
+    expect(ipcRenderer.send).toHaveBeenCalledWith(
+      EventTypeMain.SetServerLaunchArgs,
+      '--port 9999',
+      true
+    );
+  });
+
+  it('clearHistory forwards options via invoke on ClearHistory', async () => {
+    const api = await load();
+    const options = { sessions: true };
+    api.clearHistory(options);
+    expect(ipcRenderer.invoke).toHaveBeenCalledWith(
+      EventTypeMain.ClearHistory,
+      options
+    );
+  });
+
+  it('setupCLICommand uses invoke on SetupCLICommandWithElevatedRights', async () => {
+    const api = await load();
+    api.setupCLICommand();
+    expect(ipcRenderer.invoke).toHaveBeenCalledWith(
+      EventTypeMain.SetupCLICommandWithElevatedRights
+    );
+  });
+
+  it('onWorkingDirectorySelected relays WorkingDirectorySelected to the callback', async () => {
+    const api = await load();
+    const cb = vi.fn();
+    api.onWorkingDirectorySelected(cb);
+    rendererHandler(EventTypeRenderer.WorkingDirectorySelected)(
+      {},
+      '/tmp/work'
+    );
+    expect(cb).toHaveBeenCalledWith('/tmp/work');
+  });
+
+  it('does not expose the raw ipcRenderer object', async () => {
+    const api = await load();
+    expect(Object.values(api)).not.toContain(ipcRenderer);
+  });
+});

--- a/test/unit/preload/titlebarview.test.ts
+++ b/test/unit/preload/titlebarview.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventTypeMain, EventTypeRenderer } from '../../../src/main/eventtypes';
+import { exposedAPI, ipcRenderer, rendererHandler } from './helpers';
+
+async function load(): Promise<Record<string, any>> {
+  await import('../../../src/main/titlebarview/preload');
+  return exposedAPI();
+}
+
+describe('titlebarview preload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('exposes exactly the documented electronAPI keys', async () => {
+    const api = await load();
+    expect(Object.keys(api).sort()).toEqual(
+      [
+        'getAppConfig',
+        'showAppContextMenu',
+        'closeWindow',
+        'isDarkTheme',
+        'minimizeWindow',
+        'maximizeWindow',
+        'restoreWindow',
+        'getServerInfo',
+        'showEnvSelectPopup',
+        'sendMouseEvent',
+        'onSetTitle',
+        'onSetActive',
+        'onShowServerStatus',
+        'onShowServerNotificationBadge'
+      ].sort()
+    );
+  });
+
+  it('getAppConfig returns the platform without touching IPC', async () => {
+    const api = await load();
+    expect(api.getAppConfig()).toEqual({ platform: process.platform });
+  });
+
+  it('isDarkTheme and getServerInfo forward to invoke on their channels', async () => {
+    const api = await load();
+    api.isDarkTheme();
+    api.getServerInfo();
+    expect(ipcRenderer.invoke).toHaveBeenCalledWith(EventTypeMain.IsDarkTheme);
+    expect(ipcRenderer.invoke).toHaveBeenCalledWith(
+      EventTypeMain.GetServerInfo
+    );
+  });
+
+  it('window controls forward to send on their channels', async () => {
+    const api = await load();
+    api.closeWindow();
+    api.minimizeWindow();
+    api.maximizeWindow();
+    api.restoreWindow();
+    expect(ipcRenderer.send).toHaveBeenCalledWith(EventTypeMain.CloseWindow);
+    expect(ipcRenderer.send).toHaveBeenCalledWith(EventTypeMain.MinimizeWindow);
+    expect(ipcRenderer.send).toHaveBeenCalledWith(EventTypeMain.MaximizeWindow);
+    expect(ipcRenderer.send).toHaveBeenCalledWith(EventTypeMain.RestoreWindow);
+  });
+
+  it('sendMouseEvent forwards type and params on TitleBarMouseEvent', async () => {
+    const api = await load();
+    const params = { x: 1, y: 2 };
+    api.sendMouseEvent('mousedown', params);
+    expect(ipcRenderer.send).toHaveBeenCalledWith(
+      EventTypeMain.TitleBarMouseEvent,
+      'mousedown',
+      params
+    );
+  });
+
+  it('onSetTitle relays SetTitle to the callback', async () => {
+    const api = await load();
+    const cb = vi.fn();
+    api.onSetTitle(cb);
+    rendererHandler(EventTypeRenderer.SetTitle)({}, 'My Title');
+    expect(cb).toHaveBeenCalledWith('My Title');
+  });
+
+  it('onSetActive relays SetActive to the callback', async () => {
+    const api = await load();
+    const cb = vi.fn();
+    api.onSetActive(cb);
+    rendererHandler(EventTypeRenderer.SetActive)({}, true);
+    expect(cb).toHaveBeenCalledWith(true);
+  });
+
+  it('onShowServerStatus relays ShowServerStatus to the callback', async () => {
+    const api = await load();
+    const cb = vi.fn();
+    api.onShowServerStatus(cb);
+    rendererHandler(EventTypeRenderer.ShowServerStatus)({}, false);
+    expect(cb).toHaveBeenCalledWith(false);
+  });
+
+  it('onShowServerNotificationBadge relays ShowServerNotificationBadge to the callback', async () => {
+    const api = await load();
+    const cb = vi.fn();
+    api.onShowServerNotificationBadge(cb);
+    rendererHandler(EventTypeRenderer.ShowServerNotificationBadge)({}, true);
+    expect(cb).toHaveBeenCalledWith(true);
+  });
+
+  it('does not expose the raw ipcRenderer object', async () => {
+    const api = await load();
+    expect(Object.values(api)).not.toContain(ipcRenderer);
+  });
+});

--- a/test/unit/preload/updatedialog.test.ts
+++ b/test/unit/preload/updatedialog.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventTypeMain } from '../../../src/main/eventtypes';
+import { exposedAPI, ipcRenderer } from './helpers';
+
+async function load(): Promise<Record<string, any>> {
+  await import('../../../src/main/updatedialog/preload');
+  return exposedAPI();
+}
+
+describe('updatedialog preload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('exposes exactly the documented electronAPI keys', async () => {
+    const api = await load();
+    expect(Object.keys(api).sort()).toEqual(
+      [
+        'getAppConfig',
+        'isDarkTheme',
+        'setCheckForUpdatesAutomatically',
+        'setInstallUpdatesAutomatically',
+        'launchInstallerDownloadPage'
+      ].sort()
+    );
+  });
+
+  it('getAppConfig returns the platform without touching IPC', async () => {
+    const api = await load();
+    expect(api.getAppConfig()).toEqual({ platform: process.platform });
+    expect(ipcRenderer.invoke).not.toHaveBeenCalled();
+    expect(ipcRenderer.send).not.toHaveBeenCalled();
+  });
+
+  it('isDarkTheme forwards to invoke on the IsDarkTheme channel', async () => {
+    const api = await load();
+    api.isDarkTheme();
+    expect(ipcRenderer.invoke).toHaveBeenCalledWith(EventTypeMain.IsDarkTheme);
+  });
+
+  it('setCheckForUpdatesAutomatically forwards its flag on SetCheckForUpdatesAutomatically', async () => {
+    const api = await load();
+    api.setCheckForUpdatesAutomatically(true);
+    expect(ipcRenderer.send).toHaveBeenCalledWith(
+      EventTypeMain.SetCheckForUpdatesAutomatically,
+      true
+    );
+  });
+
+  it('setInstallUpdatesAutomatically forwards its flag on SetInstallUpdatesAutomatically', async () => {
+    const api = await load();
+    api.setInstallUpdatesAutomatically(false);
+    expect(ipcRenderer.send).toHaveBeenCalledWith(
+      EventTypeMain.SetInstallUpdatesAutomatically,
+      false
+    );
+  });
+
+  it('launchInstallerDownloadPage forwards to send on LaunchInstallerDownloadPage', async () => {
+    const api = await load();
+    api.launchInstallerDownloadPage();
+    expect(ipcRenderer.send).toHaveBeenCalledWith(
+      EventTypeMain.LaunchInstallerDownloadPage
+    );
+  });
+
+  it('does not expose the raw ipcRenderer object', async () => {
+    const api = await load();
+    expect(Object.values(api)).not.toContain(ipcRenderer);
+  });
+});

--- a/test/unit/preload/welcomeview.test.ts
+++ b/test/unit/preload/welcomeview.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventTypeMain, EventTypeRenderer } from '../../../src/main/eventtypes';
+import { exposedAPI, ipcRenderer, rendererHandler } from './helpers';
+
+async function load(): Promise<Record<string, any>> {
+  await import('../../../src/main/welcomeview/preload');
+  return exposedAPI();
+}
+
+describe('welcomeview preload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('exposes exactly the documented electronAPI keys', async () => {
+    const api = await load();
+    expect(Object.keys(api).sort()).toEqual(
+      [
+        'getAppConfig',
+        'isDarkTheme',
+        'newSession',
+        'openRecentSession',
+        'deleteRecentSession',
+        'openDroppedFiles',
+        'openNewsLink',
+        'sendMessageToMain',
+        'onSetRecentSessionList',
+        'onSetNewsList',
+        'onSetNotificationMessage',
+        'onEnableLocalServerActions',
+        'onInstallBundledPythonEnvStatus'
+      ].sort()
+    );
+  });
+
+  it('isDarkTheme forwards to invoke on the IsDarkTheme channel', async () => {
+    const api = await load();
+    api.isDarkTheme();
+    expect(ipcRenderer.invoke).toHaveBeenCalledWith(EventTypeMain.IsDarkTheme);
+  });
+
+  it('newSession maps each session type to the matching channel', async () => {
+    const api = await load();
+    api.newSession('notebook');
+    expect(ipcRenderer.send).toHaveBeenCalledWith(
+      EventTypeMain.CreateNewSession,
+      'notebook'
+    );
+    api.newSession('blank');
+    expect(ipcRenderer.send).toHaveBeenCalledWith(
+      EventTypeMain.CreateNewSession,
+      'blank'
+    );
+    api.newSession('open');
+    expect(ipcRenderer.send).toHaveBeenCalledWith(
+      EventTypeMain.OpenFileOrFolder
+    );
+    api.newSession('open-file');
+    expect(ipcRenderer.send).toHaveBeenCalledWith(EventTypeMain.OpenFile);
+    api.newSession('open-folder');
+    expect(ipcRenderer.send).toHaveBeenCalledWith(EventTypeMain.OpenFolder);
+    api.newSession('remote');
+    expect(ipcRenderer.send).toHaveBeenCalledWith(
+      EventTypeMain.CreateNewRemoteSession
+    );
+  });
+
+  it('openRecentSession forwards the index on OpenRecentSession', async () => {
+    const api = await load();
+    api.openRecentSession(3);
+    expect(ipcRenderer.send).toHaveBeenCalledWith(
+      EventTypeMain.OpenRecentSession,
+      3
+    );
+  });
+
+  it('openNewsLink forwards the link on OpenNewsLink', async () => {
+    const api = await load();
+    api.openNewsLink('https://blog.jupyter.org');
+    expect(ipcRenderer.send).toHaveBeenCalledWith(
+      EventTypeMain.OpenNewsLink,
+      'https://blog.jupyter.org'
+    );
+  });
+
+  it('sendMessageToMain relays an arbitrary channel and args verbatim', async () => {
+    const api = await load();
+    api.sendMessageToMain('custom', 'a', 'b');
+    expect(ipcRenderer.send).toHaveBeenCalledWith('custom', 'a', 'b');
+  });
+
+  it('onSetRecentSessionList relays SetRecentSessionList to the callback', async () => {
+    const api = await load();
+    const cb = vi.fn();
+    api.onSetRecentSessionList(cb);
+    rendererHandler(EventTypeRenderer.SetRecentSessionList)({}, ['s1'], true);
+    expect(cb).toHaveBeenCalledWith(['s1'], true);
+  });
+
+  it('onSetNotificationMessage relays SetNotificationMessage to the callback', async () => {
+    const api = await load();
+    const cb = vi.fn();
+    api.onSetNotificationMessage(cb);
+    rendererHandler(EventTypeRenderer.SetNotificationMessage)({}, 'hi', false);
+    expect(cb).toHaveBeenCalledWith('hi', false);
+  });
+
+  it('onInstallBundledPythonEnvStatus relays InstallPythonEnvStatus to the callback', async () => {
+    const api = await load();
+    const cb = vi.fn();
+    api.onInstallBundledPythonEnvStatus(cb);
+    rendererHandler(EventTypeRenderer.InstallPythonEnvStatus)({}, 'ok', 'done');
+    expect(cb).toHaveBeenCalledWith('ok', 'done');
+  });
+
+  it('does not expose the raw ipcRenderer object', async () => {
+    const api = await load();
+    expect(Object.values(api)).not.toContain(ipcRenderer);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,18 @@
+import { fileURLToPath } from 'url';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      // Route `require('electron')` (preload scripts) and ESM imports to one
+      // stub of vi.fn instances; native require would return the binary path
+      // string and bypass vi.mock. The vi.mock in electron-mock.ts targets the
+      // same stub, so both resolution paths share instances.
+      electron: fileURLToPath(
+        new URL('./test/setup/electron-stub.ts', import.meta.url)
+      )
+    }
+  },
   test: {
     environment: 'node',
     globals: true,


### PR DESCRIPTION
Part of the #951 revival work (Phase 2 test coverage), ahead of the Electron upgrade in Phase 3.

The 12 `src/main/*/preload.ts` scripts had no unit coverage. Since Phase 3 rewrites them under the Electron 29+ `contextBridge` rules, I wanted the current contract pinned first so the rewrite has a regression net rather than a manual recheck.

## What it does
Adds one characterization test per preload. Each pins:
- the exact set of keys exposed under the `electronAPI` namespace,
- the `EventTypeMain` channel and arguments each function forwards through `ipcRenderer.invoke`/`send`,
- the `EventTypeRenderer` channels each listener registers and relays to its callback,
- a guard that the exposed API does not contain the raw `ipcRenderer` object (the Electron 29 change where passing it whole yields an empty object). All 12 already wrap calls, so this passes today and should stay green after the migration.

## Testing change
The preloads use `require('electron')`. vitest leaves `electron` externalized, so that require returns the binary path string and bypasses `vi.mock`, which is why preload code wasn't unit-testable. I moved the existing inline `electron` mock into a single `test/setup/electron-stub.ts` reached two ways that share the same `vi.fn` instances: a `resolve.alias` for ESM imports, and a `require.cache` seed for the CJS require. The existing suite is unaffected.

## Verified
Full unit suite green (409 tests, the prior 320 plus 89 here). `tsc --noEmit`, eslint and prettier clean. Mutation check: flipping a forwarder channel (aboutdialog) and a listener channel (titlebarview) makes the relevant tests fail as expected, so they are not tautological.

Note: AI-assisted (Claude Code). Manually verified: the runs described above (full suite, tsc, lint, and the two mutation checks) on this branch.