### PR TITLE
ci: add a tsc --noEmit type-check workflow

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,27 @@
+name: Type check
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  type-check:
+    name: 'tsc --noEmit'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: '26.x'
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile
+      - run: yarn type-check

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -21,7 +21,8 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
-          node-version: '26.x'
+          # Node 24 (active LTS, the version Electron 42 bundles), not 26.
+          node-version: '24.x'
           cache: 'yarn'
       - run: yarn install --frozen-lockfile
       - run: yarn type-check

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test:unit:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
+    "type-check": "tsc --noEmit",
     "clean": "rimraf build dist",
     "watch:tsc": "tsc -w",
     "watch:assets": "node ./scripts/extract.js && node ./scripts/copyassets.js watch",


### PR DESCRIPTION
Part of the #951 revival work (Phase 2), groundwork for the Phase 4 TypeScript upgrade.

Right now `tsc` only runs inside the ~8-minute installer build, so a type error isn't reported until late and behind a heavy job. This adds a `type-check` script (`tsc --noEmit`) and a small dedicated `typecheck.yml` that runs it on push/PR to master. It's fast (a couple of seconds) and gives an early, focused signal. That matters most for the upcoming TypeScript 4.2 to 6 bump, which will surface a lot of type errors and is much easier to work through against a quick gate.

Notes:
- Runs on Node 26 (build tooling only; unrelated to the Node that Electron bundles at runtime).
- `permissions: contents: read`, plus `concurrency` with `cancel-in-progress` for PRs.
- Actions are SHA-pinned with a `# vX` comment, matching publish.yml.
- New workflow, so it won't gate merges until it's added as a required check. Reuses the existing `tsconfig.json` unchanged.

## Verified
`yarn type-check` is 0 errors on this branch.

Note: AI-assisted (Claude Code). Manually verified: the type-check run above on this branch.