### PR TITLE
ci: add a preload bundle size budget check

### DIFF
--- a/.github/workflows/bundle-budget.yml
+++ b/.github/workflows/bundle-budget.yml
@@ -1,0 +1,28 @@
+name: Preload bundle budget
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bundle-budget:
+    name: 'preload size budget'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: '26.x'
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile
+      - run: yarn build
+      - run: node scripts/check-preload-budget.js

--- a/scripts/check-preload-budget.js
+++ b/scripts/check-preload-budget.js
@@ -1,0 +1,93 @@
+// Fails if any bundled preload script exceeds its size budget, or if the set of
+// preload bundles drifts from the budget map. Runs after `yarn build` /
+// `yarn bundle:preload`. Zero dependencies on purpose: a regression net for the
+// Phase 3 preload rewrite, not a full bundle analyzer.
+
+const fs = require('fs');
+const path = require('path');
+
+// Per-file ceilings in bytes, set ~20% over the current built sizes. When a
+// preload grows past its ceiling (or a bundle is added/removed), update this
+// map deliberately so the change is visible in review.
+const BUDGETS = {
+  aboutdialog: 11600,
+  authdialog: 11650,
+  dialog: 11450,
+  labview: 11500,
+  progressview: 12600,
+  pythonenvdialog: 17250,
+  pythonenvselectpopup: 14550,
+  remoteserverselectdialog: 12650,
+  settingsdialog: 14750,
+  titlebarview: 13900,
+  updatedialog: 12000,
+  welcomeview: 15100
+};
+
+const mainDir = path.join(__dirname, '..', 'build', 'out', 'main');
+
+function findPreloadBundles() {
+  if (!fs.existsSync(mainDir)) {
+    console.error(
+      `Build output not found at ${mainDir}. Run "yarn build" first.`
+    );
+    process.exit(1);
+  }
+  const found = {};
+  for (const entry of fs.readdirSync(mainDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const bundle = path.join(mainDir, entry.name, 'preload.js');
+    if (fs.existsSync(bundle)) {
+      found[entry.name] = fs.statSync(bundle).size;
+    }
+  }
+  return found;
+}
+
+const found = findPreloadBundles();
+const budgeted = new Set(Object.keys(BUDGETS));
+const present = new Set(Object.keys(found));
+const errors = [];
+
+for (const name of budgeted) {
+  if (!present.has(name)) {
+    errors.push(`Missing expected preload bundle: ${name}/preload.js`);
+  }
+}
+for (const name of present) {
+  if (!budgeted.has(name)) {
+    errors.push(
+      `Unbudgeted preload bundle ${name}/preload.js (${found[name]} B). Add it to BUDGETS in scripts/check-preload-budget.js.`
+    );
+  }
+}
+for (const name of present) {
+  if (budgeted.has(name) && found[name] > BUDGETS[name]) {
+    errors.push(
+      `${name}/preload.js is ${found[name]} B, over its ${BUDGETS[name]} B budget.`
+    );
+  }
+}
+
+const sorted = Object.keys(found).sort();
+for (const name of sorted) {
+  const budget = BUDGETS[name];
+  const status = budget && found[name] <= budget ? 'ok' : 'OVER';
+  console.log(
+    `${status.padEnd(4)} ${name}/preload.js  ${found[name]} B${
+      budget ? ` / ${budget} B` : ''
+    }`
+  );
+}
+
+if (errors.length > 0) {
+  console.error('\nPreload bundle budget check failed:');
+  for (const e of errors) {
+    console.error(`  - ${e}`);
+  }
+  process.exit(1);
+}
+
+console.log('\nAll preload bundles are within budget.');


### PR DESCRIPTION
Part of the #951 revival work (Phase 2), groundwork for the Phase 3 Electron upgrade.

The 12 preload scripts are bundled by webpack. Phase 3 rewrites all of them under the Electron 29+ contextBridge rules, so I wanted a cheap tripwire for an unexpected size jump (or a bundle silently being added or removed).

## What it does
`scripts/check-preload-budget.js` (no dependencies) reads each `build/out/main/*/preload.js`, compares it to a per-file byte ceiling set ~20% over the current built size, and exits non-zero if any bundle is over budget, missing, or present but not in the budget map. `bundle-budget.yml` runs `yarn build` then the script on push/PR to master.

I went with a small node script rather than `size-limit` on purpose: size-limit's gzip/transfer modeling is aimed at web bundles and would add devDependencies, whereas here a raw file-size ceiling is all that's needed.

## Verified
The check passes at current sizes, and fails when a ceiling is lowered below the built size. Actions are SHA-pinned with a `# vX` comment matching publish.yml. New workflow, so it won't gate merges until added as a required check.

Note: AI-assisted (Claude Code). Manually verified: the pass and the deliberate-regression failure described above, locally.