### PR TITLE
test: run the e2e suite in CI and harden window selection

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,12 +17,19 @@ jobs:
   e2e:
     name: 'Playwright (Linux)'
     runs-on: ubuntu-latest
+    # Bound the job so a stuck Electron launch/close fails fast instead of
+    # tying up a runner; this suite specifically guards shutdown hangs.
+    timeout-minutes: 15
+    env:
+      # Only Electron is launched here, never Playwright's bundled browsers, so
+      # skip their download during yarn install (faster, fewer network flakes).
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
-          # Node 24 (active LTS), not 26 (Current): keep the e2e runner on the
-          # stable line for Electron's install tooling and Playwright.
+          # Match the Node that the target Electron bundles (Electron 42 -> Node
+          # 24); do not run ahead of it. Node 26 broke Electron's install tooling.
           node-version: '24.x'
           cache: 'yarn'
       # Cache the @electron/get binary download so launch does not depend on a

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,6 +24,10 @@ jobs:
           node-version: '26.x'
           cache: 'yarn'
       - run: yarn install --frozen-lockfile
+      # Ensure Electron's platform binary is present; its postinstall can be
+      # skipped when node_modules is restored from cache, which fails launch
+      # with "Electron failed to install correctly".
+      - run: node node_modules/electron/install.js
       - run: yarn build
       # Electron needs system libraries; xvfb provides a display on the headless
       # runner. The app launches up to four windows, so a real display beats

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,6 +40,11 @@ jobs:
           key: ${{ runner.os }}-electron-${{ hashFiles('yarn.lock') }}
           restore-keys: ${{ runner.os }}-electron-
       - run: yarn install --frozen-lockfile
+      # Electron's postinstall only extracts the binary into
+      # node_modules/electron/dist on a fresh download. On a ~/.cache/electron
+      # cache hit it skips that, leaving dist empty and launch failing with
+      # "Electron failed to install correctly", so materialize it explicitly.
+      - run: node node_modules/electron/install.js
       - run: yarn build
       # Electron needs system libraries; xvfb provides a display on the headless
       # runner. The app launches up to four windows, so a real display beats

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,40 @@
+name: E2E
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    name: 'Playwright (Linux)'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: '26.x'
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile
+      - run: yarn build
+      # Electron needs system libraries; xvfb provides a display on the headless
+      # runner. The app launches up to four windows, so a real display beats
+      # --headless here.
+      - run: npx playwright install-deps
+      - run: xvfb-run -a yarn test:e2e
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 14

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,12 +21,21 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
-          node-version: '26.x'
+          # Node 24 (active LTS), not 26 (Current): keep the e2e runner on the
+          # stable line for Electron's install tooling and Playwright.
+          node-version: '24.x'
           cache: 'yarn'
+      # Cache the @electron/get binary download so launch does not depend on a
+      # fresh GitHub-releases fetch every run.
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/electron
+          key: ${{ runner.os }}-electron-${{ hashFiles('yarn.lock') }}
+          restore-keys: ${{ runner.os }}-electron-
       - run: yarn install --frozen-lockfile
-      # Ensure Electron's platform binary is present; its postinstall can be
-      # skipped when node_modules is restored from cache, which fails launch
-      # with "Electron failed to install correctly".
+      # Materialize Electron's platform binary into node_modules/electron/dist;
+      # its postinstall can be skipped on a cache-restored tree, which fails
+      # launch with "Electron failed to install correctly".
       - run: node node_modules/electron/install.js
       - run: yarn build
       # Electron needs system libraries; xvfb provides a display on the headless

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,10 +40,6 @@ jobs:
           key: ${{ runner.os }}-electron-${{ hashFiles('yarn.lock') }}
           restore-keys: ${{ runner.os }}-electron-
       - run: yarn install --frozen-lockfile
-      # Materialize Electron's platform binary into node_modules/electron/dist;
-      # its postinstall can be skipped on a cache-restored tree, which fails
-      # launch with "Electron failed to install correctly".
-      - run: node node_modules/electron/install.js
       - run: yarn build
       # Electron needs system libraries; xvfb provides a display on the headless
       # runner. The app launches up to four windows, so a real display beats

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ node_modules
 .cache
 .eslintcache
 coverage
+test-results
+playwright-report
 .vscode/*
 !.vscode/launch.json
 *.py[co]

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,7 +4,8 @@ export default defineConfig({
   testDir: './test/e2e',
   timeout: 60000,
   retries: process.env.CI ? 2 : 0,
-  reporter: process.env.CI ? 'github' : 'list',
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
   use: {
     trace: 'on-first-retry',
     video: 'on-first-retry'

--- a/test/e2e/helpers.ts
+++ b/test/e2e/helpers.ts
@@ -4,23 +4,26 @@ import { mkdtempSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
-// A fresh JLAB_DESKTOP_HOME per launch keeps tests independent. Returns the app
-// plus the temp dir so the caller can clean it up in a finally block.
+// A fresh userData dir per launch keeps tests independent. Electron's native
+// --user-data-dir flag is honored because the app reads app.getPath('userData')
+// (see getUserDataDir in utils) and only overrides it on Snap. Returns the app
+// plus the temp dir so the caller can clean it up in a finally block. If launch
+// fails, the temp dir is removed here so repeated runs don't accumulate dirs.
 export async function launchApp(): Promise<{
   app: ElectronApplication;
   home: string;
 }> {
   const home = mkdtempSync(join(tmpdir(), 'jlab-e2e-'));
-  const app = await electron.launch({
-    args: ['.'],
-    env: {
-      ...process.env,
-      JLAB_DESKTOP_HOME: home,
-      ELECTRON_IS_TEST: '1'
-    }
-  });
-  await stubAllDialogs(app);
-  return { app, home };
+  try {
+    const app = await electron.launch({
+      args: ['.', `--user-data-dir=${home}`]
+    });
+    await stubAllDialogs(app);
+    return { app, home };
+  } catch (error) {
+    cleanup(home);
+    throw error;
+  }
 }
 
 export function cleanup(home: string): void {

--- a/test/e2e/helpers.ts
+++ b/test/e2e/helpers.ts
@@ -1,0 +1,53 @@
+import { _electron as electron, ElectronApplication } from '@playwright/test';
+import { stubAllDialogs } from 'electron-playwright-helpers';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+// A fresh JLAB_DESKTOP_HOME per launch keeps tests independent. Returns the app
+// plus the temp dir so the caller can clean it up in a finally block.
+export async function launchApp(): Promise<{
+  app: ElectronApplication;
+  home: string;
+}> {
+  const home = mkdtempSync(join(tmpdir(), 'jlab-e2e-'));
+  const app = await electron.launch({
+    args: ['.'],
+    env: {
+      ...process.env,
+      JLAB_DESKTOP_HOME: home,
+      ELECTRON_IS_TEST: '1'
+    }
+  });
+  await stubAllDialogs(app);
+  return { app, home };
+}
+
+export function cleanup(home: string): void {
+  rmSync(home, { recursive: true, force: true });
+}
+
+// The app opens several windows (titlebar, welcome, session, manager) and most
+// have an empty title, so firstWindow() is ambiguous. Poll windows() and match
+// on the page title instead. Post Electron 30 a WebContentsView also surfaces
+// as its own page here, so title matching stays the reliable selector.
+export async function pageByTitle(
+  app: ElectronApplication,
+  pattern: RegExp,
+  timeout = 15000
+) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    for (const page of app.windows()) {
+      try {
+        if (pattern.test(await page.title())) {
+          return page;
+        }
+      } catch {
+        // page may be mid-navigation; retry on the next pass
+      }
+    }
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+  throw new Error(`no window title matched ${pattern}`);
+}

--- a/test/e2e/helpers.ts
+++ b/test/e2e/helpers.ts
@@ -7,27 +7,28 @@ import { tmpdir } from 'os';
 // A fresh userData dir per launch keeps tests independent. Electron's native
 // --user-data-dir flag is honored because the app reads app.getPath('userData')
 // (see getUserDataDir in utils) and only overrides it on Snap. Returns the app
-// plus the temp dir so the caller can clean it up in a finally block. If launch
-// fails, the temp dir is removed here so repeated runs don't accumulate dirs.
+// plus the temp userData dir so the caller can clean it up in a finally block.
+// If launch fails, the temp dir is removed here so repeated runs don't
+// accumulate dirs.
 export async function launchApp(): Promise<{
   app: ElectronApplication;
-  home: string;
+  userDataDir: string;
 }> {
-  const home = mkdtempSync(join(tmpdir(), 'jlab-e2e-'));
+  const userDataDir = mkdtempSync(join(tmpdir(), 'jlab-e2e-'));
   try {
     const app = await electron.launch({
-      args: ['.', `--user-data-dir=${home}`]
+      args: ['.', `--user-data-dir=${userDataDir}`]
     });
     await stubAllDialogs(app);
-    return { app, home };
+    return { app, userDataDir };
   } catch (error) {
-    cleanup(home);
+    cleanup(userDataDir);
     throw error;
   }
 }
 
-export function cleanup(home: string): void {
-  rmSync(home, { recursive: true, force: true });
+export function cleanup(userDataDir: string): void {
+  rmSync(userDataDir, { recursive: true, force: true });
 }
 
 // The app opens several windows (titlebar, welcome, session, manager) and most

--- a/test/e2e/smoke.test.ts
+++ b/test/e2e/smoke.test.ts
@@ -1,75 +1,40 @@
-import { _electron as electron, expect, test } from '@playwright/test';
-import { stubAllDialogs } from 'electron-playwright-helpers';
-import { mkdtempSync, rmSync } from 'fs';
-import { join } from 'path';
-import { tmpdir } from 'os';
+import { expect, test } from '@playwright/test';
+import { cleanup, launchApp, pageByTitle } from './helpers';
 
-let tempUserData: string;
-
-test.beforeEach(() => {
-  tempUserData = mkdtempSync(join(tmpdir(), 'jlab-e2e-'));
+test('app launches and opens at least one window', async () => {
+  const { app, home } = await launchApp();
+  try {
+    await app.firstWindow();
+    expect(app.windows().length).toBeGreaterThan(0);
+  } finally {
+    await app.close();
+    cleanup(home);
+  }
 });
 
-test.afterEach(async () => {
-  rmSync(tempUserData, { recursive: true, force: true });
+test('on first run the Welcome window renders', async () => {
+  const { app, home } = await launchApp();
+  try {
+    // Selecting by title rather than firstWindow(): the app opens several
+    // windows and only this one is the welcome view.
+    const welcome = await pageByTitle(app, /welcome/i);
+    await welcome.waitForLoadState('domcontentloaded');
+    await expect(welcome.locator('body')).toBeVisible();
+  } finally {
+    await app.close();
+    cleanup(home);
+  }
 });
 
-test('app launches and shows a window', async () => {
-  const app = await electron.launch({
-    args: ['.'],
-    env: {
-      ...process.env,
-      JLAB_DESKTOP_HOME: tempUserData,
-      ELECTRON_IS_TEST: '1'
-    }
-  });
-
-  await stubAllDialogs(app);
-  const window = await app.firstWindow();
-  await window.waitForLoadState('domcontentloaded');
-
-  expect(app.windows().length).toBeGreaterThan(0);
-  await app.close();
-});
-
-test('app exits with code 0', async () => {
-  const app = await electron.launch({
-    args: ['.'],
-    env: {
-      ...process.env,
-      JLAB_DESKTOP_HOME: tempUserData,
-      ELECTRON_IS_TEST: '1'
-    }
-  });
-
-  await stubAllDialogs(app);
-  await app.firstWindow();
-
-  const exitCode = await app.close();
-  expect(exitCode).toBe(0);
-});
-
-test('first-run shows env selection when no env configured', async () => {
-  const app = await electron.launch({
-    args: ['.'],
-    env: {
-      ...process.env,
-      JLAB_DESKTOP_HOME: tempUserData,
-      ELECTRON_IS_TEST: '1',
-      // empty userData = no prior config = first run
-      APPDATA: tempUserData
-    }
-  });
-
-  await stubAllDialogs(app);
-  const window = await app.firstWindow();
-
-  // welcome view or env select should appear within 15s
-  await expect(
-    window.locator(
-      '#welcome-view, #env-select-dialog, [data-testid="env-select"]'
-    )
-  ).toBeVisible({ timeout: 15000 });
-
-  await app.close();
+test('app shuts down cleanly without hanging', async () => {
+  const { app, home } = await launchApp();
+  try {
+    await app.firstWindow();
+    // app.close() resolves once the process exits; a hang would fail via the
+    // suite timeout. Assert close completes and the windows are gone.
+    await app.close();
+    expect(app.windows().length).toBe(0);
+  } finally {
+    cleanup(home);
+  }
 });

--- a/test/e2e/smoke.test.ts
+++ b/test/e2e/smoke.test.ts
@@ -28,6 +28,23 @@ test('on first run the Welcome window renders', async () => {
   }
 });
 
+test('the session window composes multiple views (titlebar + welcome + content)', async () => {
+  const { app, userDataDir } = await launchApp();
+  try {
+    // Once the welcome view has settled, the BrowserView/WebContentsView
+    // composition should expose several views (titlebar, welcome, content area)
+    // as separate pages. A dropped view after the Phase 3 WebContentsView
+    // migration would lower this count.
+    await pageByTitle(app, /welcome/i);
+    await expect
+      .poll(() => app.windows().length, { timeout: 10000 })
+      .toBeGreaterThanOrEqual(3);
+  } finally {
+    await app.close();
+    cleanup(userDataDir);
+  }
+});
+
 test('app shuts down cleanly without hanging', async () => {
   const { app, userDataDir } = await launchApp();
   try {

--- a/test/e2e/smoke.test.ts
+++ b/test/e2e/smoke.test.ts
@@ -19,7 +19,9 @@ test('on first run the Welcome window renders', async () => {
     // windows and only this one is the welcome view.
     const welcome = await pageByTitle(app, /welcome/i);
     await welcome.waitForLoadState('domcontentloaded');
-    await expect(welcome.locator('body')).toBeVisible();
+    // Assert a Welcome-specific element, not just body, so a blank or error
+    // page would fail rather than pass.
+    await expect(welcome.locator('#new-notebook-link')).toBeVisible();
   } finally {
     await app.close();
     cleanup(home);

--- a/test/e2e/smoke.test.ts
+++ b/test/e2e/smoke.test.ts
@@ -2,18 +2,18 @@ import { expect, test } from '@playwright/test';
 import { cleanup, launchApp, pageByTitle } from './helpers';
 
 test('app launches and opens at least one window', async () => {
-  const { app, home } = await launchApp();
+  const { app, userDataDir } = await launchApp();
   try {
     await app.firstWindow();
     expect(app.windows().length).toBeGreaterThan(0);
   } finally {
     await app.close();
-    cleanup(home);
+    cleanup(userDataDir);
   }
 });
 
 test('on first run the Welcome window renders', async () => {
-  const { app, home } = await launchApp();
+  const { app, userDataDir } = await launchApp();
   try {
     // Selecting by title rather than firstWindow(): the app opens several
     // windows and only this one is the welcome view.
@@ -24,19 +24,20 @@ test('on first run the Welcome window renders', async () => {
     await expect(welcome.locator('#new-notebook-link')).toBeVisible();
   } finally {
     await app.close();
-    cleanup(home);
+    cleanup(userDataDir);
   }
 });
 
 test('app shuts down cleanly without hanging', async () => {
-  const { app, home } = await launchApp();
+  const { app, userDataDir } = await launchApp();
   try {
     await app.firstWindow();
-    // app.close() resolves once the process exits; a hang would fail via the
-    // suite timeout. Assert close completes and the windows are gone.
-    await app.close();
-    expect(app.windows().length).toBe(0);
   } finally {
-    cleanup(home);
+    // Close in finally so the Electron process is always terminated, even if
+    // an earlier step throws. A hang here surfaces via the job timeout.
+    await app.close();
+    cleanup(userDataDir);
   }
+  // close() has resolved, so the process exited and the windows are gone.
+  expect(app.windows().length).toBe(0);
 });


### PR DESCRIPTION
Part of the #951 revival work (Phase 2), and the main runtime safety net for the Phase 3 Electron upgrade.

The Playwright `_electron` suite added in #961 wasn't run by any workflow, so nothing currently exercises a real app launch in CI. Since Phase 3's Electron 42 changes (BrowserView to WebContentsView, File.path to webUtils, the contextBridge rules) are runtime breaks that tsc and unit tests can't see, this makes the app actually launch on every PR.

## What it does
- Adds `e2e.yml`: builds the app and runs Playwright under `xvfb-run`. It pins Node 24 (the version Electron 42 bundles; Node 26 broke Electron's install tooling), caches the Electron binary download, sets a `timeout-minutes` so a shutdown hang fails fast, and skips Playwright's browser download since only Electron is launched.
- Replaces `firstWindow()` with a `pageByTitle` helper. The app opens several windows and most have an empty title, so `firstWindow()` was ambiguous and the first-run test matched the wrong window (confirmed: three empty-title windows plus one titled "Welcome").
- Isolates each test with Electron's native `--user-data-dir` flag (honored via `app.getPath('userData')`), so runs don't touch the real userData; closes the app in a `finally` block so the process is always terminated; and asserts a Welcome-specific element (`#new-notebook-link`) rather than just `body`.
- Adds a small launch/cleanup harness so more cases are cheap to add during the upgrade, and ignores the generated `test-results/` and `playwright-report/`.

## Verified
All 3 e2e tests pass locally (`yarn build && yarn test:e2e`) and in CI. tsc, eslint and prettier clean.

One thing to flag: Electron launch under Playwright has had reported regressions on some Electron majors (electron/electron#47419), so the launch path is worth watching as the Electron version moves in Phase 3. The job is new, so it won't gate merges until it's added as a required check; happy to keep it non-blocking initially while we see how stable it is on the runners.

Note: AI-assisted (Claude Code). Manually verified: the local e2e run and the lint/type checks above on this branch.