### PR TITLE
Auto-discover project-local Pixi environments

### DIFF
--- a/src/main/env.ts
+++ b/src/main/env.ts
@@ -456,6 +456,8 @@ export async function getEnvironmentInfoFromPythonPath(
         ? IEnvironmentType.CondaRoot
         : envInfo.type === 'conda-env'
         ? IEnvironmentType.CondaEnv
+        : envInfo.type === 'pixi-env'
+        ? IEnvironmentType.PixiEnv
         : IEnvironmentType.VirtualEnv;
     const envName = `${EnvironmentTypeName[envType]}: ${envInfo.name}`;
 
@@ -483,6 +485,8 @@ export function getEnvironmentInfoFromPythonPathSync(
       ? IEnvironmentType.CondaRoot
       : envInfo.type === 'conda-env'
       ? IEnvironmentType.CondaEnv
+      : envInfo.type === 'pixi-env'
+      ? IEnvironmentType.PixiEnv
       : IEnvironmentType.VirtualEnv;
   const envName = `${EnvironmentTypeName[envType]}: ${envInfo.name}`;
 

--- a/src/main/env_info.py
+++ b/src/main/env_info.py
@@ -13,6 +13,29 @@ versions = {
   "python": python_version
 }
 
+def is_pixi_pyproject(pyproject_path):
+  try:
+    with open(pyproject_path, encoding="utf-8") as pyproject:
+      for line in pyproject:
+        stripped = line.strip().replace(" ", "")
+        if (
+          stripped.startswith("[tool.pixi]") or
+          stripped.startswith("[tool.pixi.") or
+          stripped.startswith("[[tool.pixi.")
+        ):
+          return True
+  except OSError:
+    pass
+
+  return False
+
+def has_pixi_manifest(workspace_path):
+  if os.path.isfile(os.path.join(workspace_path, "pixi.toml")):
+    return True
+
+  pyproject_path = os.path.join(workspace_path, "pyproject.toml")
+  return os.path.isfile(pyproject_path) and is_pixi_pyproject(pyproject_path)
+
 for requirement in requirements:
   try:
     module = importlib.import_module(requirement)
@@ -23,7 +46,20 @@ for requirement in requirements:
 if (getattr(sys, "base_prefix", None) or getattr(sys, "real_prefix", None) or sys.prefix) != sys.prefix:
   env_type = 'venv'
 
-if env_type != 'venv' and os.path.exists(os.path.join(sys.prefix, "conda-meta")):
+if env_type != 'venv':
+  env_path = os.path.normpath(sys.prefix)
+  envs_path = os.path.dirname(env_path)
+  pixi_path = os.path.dirname(envs_path)
+  workspace_path = os.path.dirname(pixi_path)
+  if (
+    os.path.basename(env_path) and
+    os.path.basename(envs_path) == "envs" and
+    os.path.basename(pixi_path) == ".pixi" and
+    has_pixi_manifest(workspace_path)
+  ):
+    env_type = 'pixi-env'
+
+if env_type == 'system' and os.path.exists(os.path.join(sys.prefix, "conda-meta")):
   is_root = os.path.exists(os.path.join(sys.prefix, "condabin"))
   env_type = 'conda-root' if is_root else 'conda-env'
 

--- a/src/main/pythonenvselectpopup/pythonenvselectpopup.ts
+++ b/src/main/pythonenvselectpopup/pythonenvselectpopup.ts
@@ -8,7 +8,10 @@ import { ThemedView } from '../dialog/themedview';
 import { EventTypeRenderer } from '../eventtypes';
 import { IPythonEnvironment } from '../tokens';
 import { IApplication } from '../app';
-import { getRelativePathToUserHome } from '../utils';
+import {
+  getRelativePathToUserHome,
+  getUniquePythonEnvironments
+} from '../utils';
 
 export class PythonEnvironmentSelectPopup {
   constructor(options: PythonEnvironmentSelectView.IOptions) {
@@ -482,11 +485,18 @@ export class PythonEnvironmentSelectPopup {
   }
 
   setPythonEnvironmentList(envs: IPythonEnvironment[]) {
-    this._envs = envs;
+    this._envs = getUniquePythonEnvironments([
+      ...envs,
+      ...this._projectEnvironments
+    ]);
     this._view.view.webContents.send(
       EventTypeRenderer.SetPythonEnvironmentList,
-      envs
+      this._envs
     );
+  }
+
+  setProjectEnvironmentList(envs: IPythonEnvironment[]) {
+    this._projectEnvironments = envs;
   }
 
   private async _onEnvironmentListUpdated() {
@@ -497,6 +507,7 @@ export class PythonEnvironmentSelectPopup {
   private _view: ThemedView;
   private _pageBody: string;
   private _envs: IPythonEnvironment[];
+  private _projectEnvironments: IPythonEnvironment[] = [];
   private _app: IApplication;
 }
 

--- a/src/main/registry.ts
+++ b/src/main/registry.ts
@@ -17,9 +17,12 @@ import {
 } from './tokens';
 import {
   envPathForPythonPath,
+  findPixiManifestPath,
   getBundledPythonEnvPath,
   getBundledPythonPath,
   getEnvironmentPath,
+  getPixiManifestPathForEnvPath,
+  getUniquePythonEnvironments,
   getUserHomeDir,
   isBaseCondaEnv,
   isCondaEnv,
@@ -60,6 +63,9 @@ export interface IRegistry {
   getRequirementsInstallCommand: (envPath: string) => string;
   getEnvironmentInfo(pythonPath: string): Promise<IPythonEnvironment>;
   getRunningServerList(): Promise<string[]>;
+  discoverProjectEnvironments: (
+    workingDirectory: string
+  ) => Promise<IPythonEnvironment[]>;
   dispose(): Promise<void>;
   environmentListUpdated: ISignal<this, void>;
   clearUserSetPythonEnvs(): void;
@@ -77,7 +83,10 @@ export class Registry implements IRegistry, IDisposable {
     this._environments = [
       ...appData.discoveredPythonEnvs,
       ...appData.userSetPythonEnvs
-    ].filter(env => this._pathExistsSync(env.path));
+    ].filter(
+      env =>
+        env.type !== IEnvironmentType.PixiEnv && this._pathExistsSync(env.path)
+    );
 
     // initialize default environment to user set or bundled
     // TODO: try to use userSettings.pythonPath and bundled python path separately
@@ -179,10 +188,9 @@ export class Registry implements IRegistry, IDisposable {
       .then(async environments => {
         let discoveredEnvs = [].concat(...environments);
 
-        this._userSetEnvironments = await this._resolveEnvironments(
-          this._getUserSetPythonEnvs(),
-          true
-        );
+        this._userSetEnvironments = (
+          await this._resolveEnvironments(this._getUserSetPythonEnvs(), true)
+        ).filter(env => env.type !== IEnvironmentType.PixiEnv);
 
         // filter out user set environments
         discoveredEnvs = discoveredEnvs.filter(env => {
@@ -192,7 +200,9 @@ export class Registry implements IRegistry, IDisposable {
         });
 
         discoveredEnvs = await this._resolveEnvironments(discoveredEnvs, true);
-        this._discoveredEnvironments = discoveredEnvs;
+        this._discoveredEnvironments = discoveredEnvs.filter(
+          env => env.type !== IEnvironmentType.PixiEnv
+        );
 
         this._updateEnvironments();
 
@@ -283,7 +293,7 @@ export class Registry implements IRegistry, IDisposable {
     sort?: boolean
   ): Promise<IPythonEnvironment[]> {
     let filteredEnvs = envs.filter(env => this._pathExistsSync(env.path));
-    const uniqueEnvs = this._getUniqueEnvs(filteredEnvs);
+    const uniqueEnvs = getUniquePythonEnvironments(filteredEnvs);
     const resolvedEnvs = await Promise.all(
       uniqueEnvs.map(async env => await this._resolveEnvironment(env.path))
     );
@@ -343,13 +353,15 @@ export class Registry implements IRegistry, IDisposable {
       JUPYTER_ENV_REQUIREMENTS.forEach(req => {
         versionsFound.push(`${req.name}: ${env.versions[req.name]}`);
       });
+      const installCommand = this.getRequirementsInstallCommand(envPath);
+      const installHint = installCommand
+        ? ` You can install missing packages using '${installCommand}'.`
+        : ' Update the pixi manifest and run pixi install.';
 
       log.error(
         `Required Python packages not found in the environment path "${envPath}". Versions found are: ${versionsFound.join(
           ','
-        )}. You can install missing packages using '${this.getRequirementsInstallCommand(
-          envPath
-        )}'.`
+        )}.${installHint}`
       );
       throw {
         type: PythonEnvResolveErrorType.RequirementsNotSatisfied
@@ -444,19 +456,18 @@ export class Registry implements IRegistry, IDisposable {
       return inUserSetEnvList;
     }
 
-    try {
-      const env = this._resolveEnvironmentSync(pythonPath);
-      if (env) {
-        if (!this._defaultEnv) {
-          this._defaultEnv = env;
-        }
-        this._userSetEnvironments.push(env);
-        this._updateEnvironments();
-        this._environmentListUpdated.emit();
+    const env = this._resolveEnvironmentSync(pythonPath);
+    if (env) {
+      if (env.type === IEnvironmentType.PixiEnv) {
         return env;
       }
-    } catch (error) {
-      //
+      if (!this._defaultEnv) {
+        this._defaultEnv = env;
+      }
+      this._userSetEnvironments.push(env);
+      this._updateEnvironments();
+      this._environmentListUpdated.emit();
+      return env;
     }
   }
 
@@ -581,6 +592,10 @@ export class Registry implements IRegistry, IDisposable {
   }
 
   getRequirementsInstallCommand(envPath: string): string {
+    if (getPixiManifestPathForEnvPath(envPath)) {
+      return '';
+    }
+
     const isConda = isCondaEnv(envPath);
     const condaChannels = getCondaChannels();
     const channels = condaChannels.map(channel => `-c ${channel}`);
@@ -674,8 +689,49 @@ export class Registry implements IRegistry, IDisposable {
     return bundledEnvInstallationLatest;
   }
 
+  async discoverProjectEnvironments(
+    workingDirectory: string
+  ): Promise<IPythonEnvironment[]> {
+    if (!workingDirectory) {
+      return [];
+    }
+
+    const discovery = this._projectEnvironmentDiscoveries.get(workingDirectory);
+    if (discovery) {
+      return discovery;
+    }
+
+    const newDiscovery = this._discoverProjectEnvironments(
+      workingDirectory
+    ).finally(() => {
+      this._projectEnvironmentDiscoveries.delete(workingDirectory);
+    });
+    this._projectEnvironmentDiscoveries.set(workingDirectory, newDiscovery);
+
+    return newDiscovery;
+  }
+
+  private async _discoverProjectEnvironments(
+    workingDirectory: string
+  ): Promise<IPythonEnvironment[]> {
+    await this._registryBuilt;
+
+    const pixiEnvs = await this._resolveEnvironments(
+      this._loadPixiEnvironments(workingDirectory),
+      true
+    );
+    return pixiEnvs.filter(env => {
+      return (
+        !this._discoveredEnvironments.find(
+          existing => existing.path === env.path
+        ) &&
+        !this._userSetEnvironments.find(existing => existing.path === env.path)
+      );
+    });
+  }
+
   private _updateEnvironments() {
-    this._environments = this._getUniqueEnvs([
+    this._environments = getUniquePythonEnvironments([
       ...this._userSetEnvironments,
       ...this._discoveredEnvironments
     ]);
@@ -724,6 +780,50 @@ export class Registry implements IRegistry, IDisposable {
 
       return newPythonEnvironment;
     });
+  }
+
+  private _loadPixiEnvironments(
+    workingDirectory: string
+  ): IPythonEnvironment[] {
+    const manifestPath = findPixiManifestPath(workingDirectory);
+    if (!manifestPath) {
+      return [];
+    }
+
+    const envsPath = path.join(path.dirname(manifestPath), '.pixi', 'envs');
+    try {
+      if (!fs.existsSync(envsPath) || !fs.statSync(envsPath).isDirectory()) {
+        return [];
+      }
+
+      return fs
+        .readdirSync(envsPath)
+        .filter(envName => {
+          const envPath = path.join(envsPath, envName);
+          try {
+            return fs.statSync(envPath).isDirectory();
+          } catch (error) {
+            return false;
+          }
+        })
+        .map(envName => {
+          const envPath = path.join(envsPath, envName);
+          return {
+            name: `pixi: ${envName}`,
+            path: pythonPathForEnvPath(envPath, true),
+            type: IEnvironmentType.PixiEnv,
+            versions: {},
+            defaultKernel: 'python3'
+          } as IPythonEnvironment;
+        })
+        .filter(env => this._pathExistsSync(env.path));
+    } catch (error) {
+      log.error(
+        `Failed to discover pixi environments in "${envsPath}".`,
+        error
+      );
+      return [];
+    }
   }
 
   private async _loadCondaEnvironments(): Promise<IPythonEnvironment[]> {
@@ -1105,6 +1205,8 @@ export class Registry implements IRegistry, IDisposable {
         return 2;
       case IEnvironmentType.CondaEnv:
         return 3;
+      case IEnvironmentType.PixiEnv:
+        return 4;
       default:
         return 100;
     }
@@ -1116,19 +1218,6 @@ export class Registry implements IRegistry, IDisposable {
     return pythonPaths.filter(pythonPath => {
       if (!uniquePythonPaths.has(pythonPath)) {
         uniquePythonPaths.add(pythonPath);
-        return true;
-      }
-
-      return false;
-    });
-  }
-
-  private _getUniqueEnvs(envs: IPythonEnvironment[]): IPythonEnvironment[] {
-    const uniquePythonPaths = new Set<string>();
-
-    return envs.filter(env => {
-      if (!uniquePythonPaths.has(env.path)) {
-        uniquePythonPaths.add(env.path);
         return true;
       }
 
@@ -1153,6 +1242,10 @@ export class Registry implements IRegistry, IDisposable {
 
   private _environments: IPythonEnvironment[] = [];
   private _discoveredEnvironments: IPythonEnvironment[] = [];
+  private _projectEnvironmentDiscoveries = new Map<
+    string,
+    Promise<IPythonEnvironment[]>
+  >();
   private _userSetEnvironments: IPythonEnvironment[] = [];
   private _defaultEnv: IPythonEnvironment;
   private _registryBuilt: Promise<void>;

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -13,7 +13,9 @@ import {
   createTempFile,
   getEnvironmentPath,
   getFreePort,
+  getPixiManifestPathForEnvPath,
   getUserDataDir,
+  getUserHomeDir,
   waitForDuration
 } from './utils';
 import {
@@ -31,6 +33,57 @@ import { ManagePythonEnvironmentDialog } from './pythonenvdialog/pythonenvdialog
 
 const SERVER_LAUNCH_TIMEOUT = 30000; // milliseconds
 const SERVER_RESTART_LIMIT = 3; // max server restarts
+
+interface IPixiEnvironmentInfo {
+  envName: string;
+  manifestPath: string;
+}
+
+function getPixiEnvironmentInfoFromEnvPath(
+  envPath: string
+): IPixiEnvironmentInfo | undefined {
+  const normalizedEnvPath = path.normalize(envPath);
+  const envName = path.basename(normalizedEnvPath);
+  const manifestPath = getPixiManifestPathForEnvPath(normalizedEnvPath);
+  if (!envName || !manifestPath) {
+    return;
+  }
+
+  return {
+    envName,
+    manifestPath
+  };
+}
+
+function getPixiExecutablePath(): string {
+  const pixiExecutableName = process.platform === 'win32' ? 'pixi.exe' : 'pixi';
+  const pathDirs = process.env.PATH
+    ? process.env.PATH.split(path.delimiter)
+    : [];
+  const candidates = pathDirs
+    .filter(dirPath => dirPath)
+    .map(dirPath => path.join(dirPath, pixiExecutableName));
+
+  candidates.push(
+    path.join(getUserHomeDir(), '.pixi', 'bin', pixiExecutableName)
+  );
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+      return candidate;
+    }
+  }
+
+  return '';
+}
+
+function quoteShellArg(value: string, isWin: boolean): string {
+  if (isWin) {
+    return `"${value.replace(/%/g, '%%')}"`;
+  }
+
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
 
 function createLaunchScript(
   serverInfo: JupyterServer.IInfo,
@@ -65,6 +118,7 @@ function createLaunchScript(
   }
 
   let script: string;
+  const isPixi = serverInfo.environment.type === IEnvironmentType.PixiEnv;
   const isConda =
     serverInfo.environment.type === IEnvironmentType.CondaRoot ||
     serverInfo.environment.type === IEnvironmentType.CondaEnv;
@@ -109,6 +163,29 @@ function createLaunchScript(
 
   const envActivatePath = activatePathForEnvPath(envPath);
 
+  if (isPixi) {
+    const pixiInfo = getPixiEnvironmentInfoFromEnvPath(envPath);
+    const pixiPath = getPixiExecutablePath();
+    if (!pixiInfo) {
+      throw new Error(
+        `Error: pixi manifest not found for environment: ${envPath}`
+      );
+    }
+    if (!pixiPath) {
+      throw new Error(`Error: pixi executable not found.`);
+    }
+    launchCmd = `${quoteShellArg(
+      pixiPath,
+      isWin
+    )} run --as-is --manifest-path ${quoteShellArg(
+      pixiInfo.manifestPath,
+      isWin
+    )} --environment ${quoteShellArg(
+      pixiInfo.envName,
+      isWin
+    )} --executable ${launchCmd}`;
+  }
+
   if (isWin) {
     if (isConda) {
       const parentDir = path.dirname(condaActivatePath);
@@ -121,6 +198,8 @@ function createLaunchScript(
         ${isBaseCondaActivate ? `CALL conda activate ${envPath}` : ''}
         CALL cd /d "${serverInfo.workingDirectory}"
         CALL ${launchCmd}`;
+    } else if (isPixi) {
+      script = `CALL ${launchCmd}`;
     } else {
       script = `
         CALL ${envActivatePath}
@@ -136,6 +215,8 @@ function createLaunchScript(
             : ''
         }
         ${launchCmd}`;
+    } else if (isPixi) {
+      script = launchCmd;
     } else {
       script = `
         source "${envActivatePath}"
@@ -262,12 +343,18 @@ export class JupyterServer {
           baseCondaEnvPath = condaEnvPathForCondaExePath(condaPath);
         }
 
-        const launchScriptPath = createLaunchScript(
-          this._info,
-          baseCondaEnvPath,
-          this._info.port,
-          this._info.token
-        );
+        let launchScriptPath: string;
+        try {
+          launchScriptPath = createLaunchScript(
+            this._info,
+            baseCondaEnvPath,
+            this._info.port,
+            this._info.token
+          );
+        } catch (error) {
+          reject(error instanceof Error ? error.message : error);
+          return;
+        }
 
         const jlabWorkspacesDir = path.join(
           this._info.workingDirectory,

--- a/src/main/sessionwindow/sessionwindow.ts
+++ b/src/main/sessionwindow/sessionwindow.ts
@@ -146,7 +146,10 @@ export class SessionWindow implements IDisposable {
     return this._window;
   }
 
-  private async _createServerForSession() {
+  private async _createServerForSession(
+    projectEnvironments?: IPythonEnvironment[]
+  ) {
+    const environments = await this._registry.getEnvironmentList(false);
     const serverOptions: JupyterServer.IOptions = {
       workingDirectory: this._sessionConfig.resolvedWorkingDirectory
     };
@@ -154,9 +157,19 @@ export class SessionWindow implements IDisposable {
     const pythonPath = this._wsSettings.getValue(SettingType.pythonPath);
 
     if (pythonPath) {
-      serverOptions.environment = this._registry.getEnvironmentByPath(
-        pythonPath
+      serverOptions.environment = environments.find(
+        env => env.path === pythonPath
       );
+      if (!serverOptions.environment) {
+        const projectEnvs =
+          projectEnvironments ??
+          (await this._registry.discoverProjectEnvironments(
+            this._sessionConfig.resolvedWorkingDirectory
+          ));
+        serverOptions.environment = projectEnvs.find(
+          env => env.path === pythonPath
+        );
+      }
     }
 
     const server = await this.serverFactory.createServer(serverOptions);
@@ -718,6 +731,15 @@ export class SessionWindow implements IDisposable {
         const installCommand = this._registry.getRequirementsInstallCommand(
           envPath
         );
+        if (!installCommand) {
+          this._showProgressView(
+            'Unable to install required packages',
+            `<div class="message-row">Update the pixi manifest to include the required packages, then run pixi install.</div>
+            <div class="message-row"><a href="javascript:void(0);" onclick="sendMessageToMain('${EventTypeMain.HideProgressView}')">Close</a></div>`,
+            false
+          );
+          return;
+        }
 
         this._showProgressView('Installing required packages');
 
@@ -789,7 +811,9 @@ export class SessionWindow implements IDisposable {
         return;
       }
 
-      this._showEnvSelectPopup();
+      void this._showEnvSelectPopup().catch(error => {
+        console.error('Failed to show Python environment selector.', error);
+      });
     });
 
     this._evm.registerEventHandler(EventTypeMain.HideEnvSelectPopup, event => {
@@ -817,14 +841,23 @@ export class SessionWindow implements IDisposable {
           this._registry.addEnvironment(path);
         } catch (error) {
           let message = `Error! Python environment at '${path}' is not compatible.`;
+          let requirementsInstallCommand = '';
           if (
             error?.type === PythonEnvResolveErrorType.RequirementsNotSatisfied
           ) {
             const envPath = envPathForPythonPath(path);
-            const requirementInstallCmd = encodeURIComponent(
-              this._registry.getRequirementsInstallCommand(envPath)
+            requirementsInstallCommand = this._registry.getRequirementsInstallCommand(
+              envPath
             );
-            message = `Error! Required Python packages not found in the selected environment. You can install using <copyable-span label="${requirementInstallCmd}" copied="${requirementInstallCmd}"></copyable-span> command in the selected environment.`;
+            if (requirementsInstallCommand) {
+              const encodedInstallCommand = encodeURIComponent(
+                requirementsInstallCommand
+              );
+              message = `Error! Required Python packages not found in the selected environment. You can install using <copyable-span label="${encodedInstallCommand}" copied="${encodedInstallCommand}"></copyable-span> command in the selected environment.`;
+            } else {
+              message =
+                'Error! Required Python packages are missing. Update the pixi manifest and run pixi install.';
+            }
           } else if (error?.type === PythonEnvResolveErrorType.PathNotFound) {
             message = `Error! File not found at '${path}'.`;
           } else if (error?.type === PythonEnvResolveErrorType.ResolveError) {
@@ -834,7 +867,9 @@ export class SessionWindow implements IDisposable {
             'Invalid Environment',
             `<div class="message-row">${message}</div>
           ${
-            error?.type === PythonEnvResolveErrorType.RequirementsNotSatisfied
+            error?.type ===
+              PythonEnvResolveErrorType.RequirementsNotSatisfied &&
+            requirementsInstallCommand
               ? `<div class="message-row"><a href="javascript:void(0);" onclick="sendMessageToMain('${
                   EventTypeMain.InstallPythonEnvRequirements
                 }', '${encodeURIComponent(
@@ -1305,8 +1340,24 @@ export class SessionWindow implements IDisposable {
   }
 
   private async _showEnvSelectPopup() {
-    if (this._envSelectPopupVisible) {
+    if (this._envSelectPopupVisible || this._envSelectPopupOpening) {
       return;
+    }
+
+    this._envSelectPopupOpening = true;
+    try {
+      const workingDirectory = this._sessionConfig?.resolvedWorkingDirectory;
+      if (this._envSelectPopupWorkingDirectory !== workingDirectory) {
+        const [envs, projectEnvs] = await Promise.all([
+          this.registry.getEnvironmentList(false),
+          this.registry.discoverProjectEnvironments(workingDirectory)
+        ]);
+        this._envSelectPopup.setProjectEnvironmentList(projectEnvs);
+        this._envSelectPopup.setPythonEnvironmentList(envs);
+        this._envSelectPopupWorkingDirectory = workingDirectory;
+      }
+    } finally {
+      this._envSelectPopupOpening = false;
     }
 
     const serverInfo = this.getServerInfo();
@@ -1469,26 +1520,46 @@ export class SessionWindow implements IDisposable {
 
     pythonPath = this._wsSettings.getValue(SettingType.pythonPath);
 
+    let projectEnvironments: IPythonEnvironment[];
     if (pythonPath) {
       try {
-        this._registry.addEnvironment(pythonPath);
+        const environments = await this._registry.getEnvironmentList(false);
+        if (!environments.find(env => env.path === pythonPath)) {
+          projectEnvironments = await this._registry.discoverProjectEnvironments(
+            sessionConfig.resolvedWorkingDirectory
+          );
+        }
+        if (!projectEnvironments?.find(env => env.path === pythonPath)) {
+          this._registry.addEnvironment(pythonPath);
+        }
       } catch (error) {
         let message = `Error! Python environment at '${pythonPath}' is not compatible.`;
+        let requirementsInstallCommand = '';
         if (
           error?.type === PythonEnvResolveErrorType.RequirementsNotSatisfied
         ) {
           const envPath = envPathForPythonPath(pythonPath);
-          const requirementInstallCmd = encodeURIComponent(
-            this._registry.getRequirementsInstallCommand(envPath)
+          requirementsInstallCommand = this._registry.getRequirementsInstallCommand(
+            envPath
           );
-          message = `Error! Required packages not found in the Python environment. You can install using <copyable-span label="${requirementInstallCmd}" copied="${requirementInstallCmd}"></copyable-span> command in the selected environment.`;
+          if (requirementsInstallCommand) {
+            const encodedInstallCommand = encodeURIComponent(
+              requirementsInstallCommand
+            );
+            message = `Error! Required packages not found in the Python environment. You can install using <copyable-span label="${encodedInstallCommand}" copied="${encodedInstallCommand}"></copyable-span> command in the selected environment.`;
+          } else {
+            message =
+              'Error! Required Python packages are missing. Update the pixi manifest and run pixi install.';
+          }
         }
 
         this._showProgressView(
           'Invalid Environment configured for project',
           `<div class="message-row">${message}</div>
           ${
-            error?.type === PythonEnvResolveErrorType.RequirementsNotSatisfied
+            error?.type ===
+              PythonEnvResolveErrorType.RequirementsNotSatisfied &&
+            requirementsInstallCommand
               ? `<div class="message-row"><a href="javascript:void(0);" onclick="sendMessageToMain('${
                   EventTypeMain.InstallPythonEnvRequirements
                 }', '${encodeURIComponent(
@@ -1512,7 +1583,7 @@ export class SessionWindow implements IDisposable {
     }
 
     this._sessionConfig = sessionConfig;
-    await this._createServerForSession();
+    await this._createServerForSession(projectEnvironments);
 
     this._contentViewType = ContentViewType.Lab;
     this._updateContentView();
@@ -1728,6 +1799,8 @@ export class SessionWindow implements IDisposable {
   private _labView: LabView;
   private _contentViewType: ContentViewType = ContentViewType.Welcome;
   private _serverFactory: IServerFactory;
+  private _envSelectPopupWorkingDirectory = '';
+  private _envSelectPopupOpening = false;
   private _app: IApplication;
   private _registry: IRegistry;
   private _server: JupyterServerFactory.IFactoryItem;

--- a/src/main/tokens.ts
+++ b/src/main/tokens.ts
@@ -26,6 +26,10 @@ export enum IEnvironmentType {
    * This environment type is for environments that were derived from the WindowsRegistry
    */
   WindowsReg = 'windows-reg',
+  /**
+   * This environment type is for project-local pixi environments
+   */
+  PixiEnv = 'pixi-env',
   VirtualEnv = 'venv'
 }
 
@@ -34,6 +38,7 @@ export const EnvironmentTypeName: { [key in IEnvironmentType]: string } = {
   [IEnvironmentType.CondaRoot]: 'conda',
   [IEnvironmentType.CondaEnv]: 'conda',
   [IEnvironmentType.WindowsReg]: 'win',
+  [IEnvironmentType.PixiEnv]: 'pixi',
   [IEnvironmentType.VirtualEnv]: 'venv'
 };
 

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -72,6 +72,79 @@ export function getEnvironmentPath(environment: IPythonEnvironment): string {
   return envPathForPythonPath(environment.path);
 }
 
+export function getUniquePythonEnvironments(
+  envs: IPythonEnvironment[]
+): IPythonEnvironment[] {
+  const uniquePythonPaths = new Set<string>();
+
+  return envs.filter(env => {
+    if (!uniquePythonPaths.has(env.path)) {
+      uniquePythonPaths.add(env.path);
+      return true;
+    }
+
+    return false;
+  });
+}
+
+export function getPixiManifestPath(workspacePath: string): string {
+  try {
+    const pixiTomlPath = path.join(workspacePath, 'pixi.toml');
+    if (fs.existsSync(pixiTomlPath) && fs.statSync(pixiTomlPath).isFile()) {
+      return pixiTomlPath;
+    }
+
+    const pyprojectTomlPath = path.join(workspacePath, 'pyproject.toml');
+    if (
+      fs.existsSync(pyprojectTomlPath) &&
+      fs.statSync(pyprojectTomlPath).isFile()
+    ) {
+      const pyprojectToml = fs.readFileSync(pyprojectTomlPath, 'utf8');
+      if (/^\s*\[\[?\s*tool\.pixi(?:\s*\]|\.)/m.test(pyprojectToml)) {
+        return pyprojectTomlPath;
+      }
+    }
+  } catch (error) {
+    log.error(`Failed to inspect pixi manifest in "${workspacePath}".`, error);
+  }
+
+  return '';
+}
+
+export function findPixiManifestPath(startPath: string): string {
+  let workspacePath = path.resolve(startPath);
+  let reachedRoot = false;
+
+  while (!reachedRoot) {
+    const manifestPath = getPixiManifestPath(workspacePath);
+    if (manifestPath) {
+      return manifestPath;
+    }
+
+    const parentPath = path.dirname(workspacePath);
+    reachedRoot = parentPath === workspacePath;
+    workspacePath = parentPath;
+  }
+
+  return '';
+}
+
+export function getPixiManifestPathForEnvPath(envPath: string): string {
+  const normalizedEnvPath = path.normalize(envPath);
+  const envsPath = path.dirname(normalizedEnvPath);
+  const pixiPath = path.dirname(envsPath);
+
+  if (
+    !path.basename(normalizedEnvPath) ||
+    path.basename(envsPath) !== 'envs' ||
+    path.basename(pixiPath) !== '.pixi'
+  ) {
+    return '';
+  }
+
+  return getPixiManifestPath(path.dirname(pixiPath));
+}
+
 export function getBundledEnvInstallerPath(): string {
   const appDir = getAppDir();
   return path.join(appDir, 'env_installer', 'jlab_server.tar.gz');


### PR DESCRIPTION
Closes #834 

Adds project-local Pixi environment discovery for `pixi.toml` and `pyproject.toml` projects, classifies Pixi environments before Conda, exposes them per session, and launches JupyterLab through pixi run without persisting project-specific environments globally.