### PR TITLE
build: internalize fix-path PATH discovery with native child_process

### DIFF
--- a/package.json
+++ b/package.json
@@ -220,7 +220,6 @@
     "ejs": "^6.0.1",
     "electron-log": "^5.4.4",
     "fast-xml-parser": "^5.9.0",
-    "fix-path": "^3.0.0",
     "js-yaml": "^5.2.0",
     "semver": "^7.8.4",
     "tar": "^7.5.16",

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -9,6 +9,7 @@ import * as semver from 'semver';
 import {
   bundledEnvironmentIsInstalled,
   EnvironmentInstallStatus,
+  fixDarwinPath,
   getBundledPythonEnvPath,
   getBundledPythonPath,
   installBundledEnvironment,
@@ -49,7 +50,7 @@ async function appReady(): Promise<boolean> {
  * contain all the information that is usually set in .bashrc, .bash_profile, etc.
  * This package fixes the PATH variable
  */
-require('fix-path')();
+fixDarwinPath();
 
 /**
  * Update app home, appData, userData and logs paths to prevent

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -31,6 +31,39 @@ export function isDevMode(): boolean {
   return require.main.filename.indexOf('app.asar') === -1;
 }
 
+// On macOS a packaged GUI app inherits a minimal PATH that misses the entries a
+// login shell sets up in .bashrc / .zshrc / .bash_profile (pyenv, conda,
+// homebrew, nvm). Spawn the user's login shell, read its env, and adopt its
+// PATH. Replaces the fix-path -> shell-path -> shell-env -> execa dependency
+// chain; the login-shell spawn is preserved exactly.
+export function fixDarwinPath(): void {
+  if (process.platform !== 'darwin') {
+    return;
+  }
+
+  const shell = process.env.SHELL || '/bin/bash';
+  try {
+    const stdout = execFileSync(shell, ['-ilc', 'env; exit'], {
+      encoding: 'utf8'
+    });
+    // Strip ANSI escapes a chatty rc file may print before env runs.
+    // eslint-disable-next-line no-control-regex
+    const clean = stdout.replace(/\x1b\[[0-9;]*[A-Za-z]/g, '');
+    for (const line of clean.split('\n')) {
+      const eq = line.indexOf('=');
+      if (eq === -1) {
+        continue;
+      }
+      if (line.slice(0, eq) === 'PATH') {
+        process.env.PATH = line.slice(eq + 1);
+        return;
+      }
+    }
+  } catch (error) {
+    log.error('Failed to resolve login shell PATH', error);
+  }
+}
+
 export function getAppDir(): string {
   let appDir = app.getAppPath();
   if (!isDevMode()) {

--- a/test/unit/fix-darwin-path.test.ts
+++ b/test/unit/fix-darwin-path.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { execFileSync } from 'child_process';
+import { fixDarwinPath } from '../../src/main/utils';
+
+vi.mock('child_process', async orig => {
+  const actual = await orig<typeof import('child_process')>();
+  return { ...actual, execFileSync: vi.fn() };
+});
+
+const mockedExecFileSync = vi.mocked(execFileSync);
+
+describe('fixDarwinPath', () => {
+  let originalPlatform: PropertyDescriptor | undefined;
+  let originalPath: string | undefined;
+
+  const setPlatform = (value: string) => {
+    Object.defineProperty(process, 'platform', { value, configurable: true });
+  };
+
+  beforeEach(() => {
+    originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    originalPath = process.env.PATH;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform);
+    }
+    process.env.PATH = originalPath;
+  });
+
+  it('adopts the PATH the login shell reports on macOS', () => {
+    // Arrange
+    setPlatform('darwin');
+    process.env.PATH = '/usr/bin';
+    mockedExecFileSync.mockReturnValue(
+      ('HOME=/Users/x\nPATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin\nSHELL=/bin/zsh\n' as unknown) as Buffer
+    );
+
+    // Act
+    fixDarwinPath();
+
+    // Assert
+    expect(process.env.PATH).toBe('/opt/homebrew/bin:/usr/local/bin:/usr/bin');
+    expect(mockedExecFileSync).toHaveBeenCalledWith(
+      expect.any(String),
+      ['-ilc', 'env; exit'],
+      expect.objectContaining({ encoding: 'utf8' })
+    );
+  });
+
+  it('strips ANSI escapes a chatty rc file prints before env', () => {
+    // Arrange
+    setPlatform('darwin');
+    process.env.PATH = '/usr/bin';
+    mockedExecFileSync.mockReturnValue(
+      ('\x1b[32mwelcome\x1b[0m\nPATH=/opt/homebrew/bin:/usr/bin\n' as unknown) as Buffer
+    );
+
+    // Act
+    fixDarwinPath();
+
+    // Assert
+    expect(process.env.PATH).toBe('/opt/homebrew/bin:/usr/bin');
+  });
+
+  it('keeps a value containing = signs intact', () => {
+    // Arrange
+    setPlatform('darwin');
+    mockedExecFileSync.mockReturnValue(('PATH=/a=b:/c\n' as unknown) as Buffer);
+
+    // Act
+    fixDarwinPath();
+
+    // Assert
+    expect(process.env.PATH).toBe('/a=b:/c');
+  });
+
+  it('does not spawn a shell on non-macOS platforms', () => {
+    // Arrange
+    setPlatform('linux');
+    process.env.PATH = '/usr/bin';
+
+    // Act
+    fixDarwinPath();
+
+    // Assert
+    expect(mockedExecFileSync).not.toHaveBeenCalled();
+    expect(process.env.PATH).toBe('/usr/bin');
+  });
+
+  it('leaves the existing PATH untouched when the shell spawn throws', () => {
+    // Arrange
+    setPlatform('darwin');
+    process.env.PATH = '/usr/bin';
+    mockedExecFileSync.mockImplementation(() => {
+      throw new Error('shell not found');
+    });
+
+    // Act
+    fixDarwinPath();
+
+    // Assert
+    expect(process.env.PATH).toBe('/usr/bin');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1089,11 +1089,6 @@ ajv@^8.0.0, ajv@^8.18.0, ajv@^8.9.0:
     json-schema-traverse "^1.0.0"
     require-from-string "^2.0.2"
 
-ansi-regex@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
-  integrity sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==
-
 ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
@@ -1515,14 +1510,6 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
-cross-spawn@^4.0.0:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
-  integrity sha512-yAXz/pA1tD8Gtg2S98Ekf/sewp3Lcp3YoFKJ4Hkp5h5yLWnKVTDU0kwjKJ8NDCYcfTLfyGkzTikst+jWypT1iA==
-  dependencies:
-    lru-cache "^4.0.1"
-    which "^1.2.9"
-
 cross-spawn@^6.0.0:
   version "6.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.6.tgz#30d0efa0712ddb7eb5a76e1e8721bffafa6b5d57"
@@ -1582,11 +1569,6 @@ deep-is@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
-
-default-shell@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/default-shell/-/default-shell-1.0.1.tgz#752304bddc6174f49eb29cb988feea0b8813c8bc"
-  integrity sha512-/Os8tTMPSriNHCsVj3VLjMZblIl1sIg8EXz3qg7C5K+y9calfTA/qzlfPvCQ+LEgLWmtZ9wCnzE1w+S6TPPFyQ==
 
 defer-to-connect@^2.0.0:
   version "2.0.1"
@@ -2019,19 +2001,6 @@ events@^3.2.0:
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
-execa@^0.5.0:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-0.5.1.tgz#de3fb85cb8d6e91c85bcbceb164581785cb57b36"
-  integrity sha512-R66dW/hW3I8yV77Wg4xn6zMguRPUgt59VLm5e85NrOF05ZdPn7YOfPBSw0E9epJDvuzwVWEG+HmEaQ4muYuWKQ==
-  dependencies:
-    cross-spawn "^4.0.0"
-    get-stream "^2.2.0"
-    is-stream "^1.1.0"
-    npm-run-path "^2.0.0"
-    p-finally "^1.0.0"
-    signal-exit "^3.0.0"
-    strip-eof "^1.0.0"
-
 execa@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
@@ -2164,13 +2133,6 @@ find-up@^5.0.0:
   dependencies:
     locate-path "^6.0.0"
     path-exists "^4.0.0"
-
-fix-path@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/fix-path/-/fix-path-3.0.0.tgz#c6b82fd5f5928e520b392a63565ebfef0ddf037e"
-  integrity sha512-opGAl4+ip5jUikHR2C8Jo7czZ80pz8EK/0gMlAZu7xgDmBqIynlX8SMYg9KowYjAU6HT0nxsSJEWru0u+n+N2Q==
-  dependencies:
-    shell-path "^2.1.0"
 
 flat-cache@^4.0.0:
   version "4.0.1"
@@ -2317,14 +2279,6 @@ get-proto@^1.0.1:
   dependencies:
     dunder-proto "^1.0.1"
     es-object-atoms "^1.0.0"
-
-get-stream@^2.2.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-2.3.1.tgz#5f38f93f346009666ee0150a054167f91bdd95de"
-  integrity sha512-AUGhbbemXxrZJRD5cDvKtQxLuYaIbNtDTK8YqupCI393Q2KSTreEsLUN3ZxAWFGiKTzL6nKuzfcIvieflUX9qA==
-  dependencies:
-    object-assign "^4.0.1"
-    pinkie-promise "^2.0.0"
 
 get-stream@^4.0.0:
   version "4.1.0"
@@ -3060,14 +3014,6 @@ lowercase-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
   integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
 
-lru-cache@^4.0.1:
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
-  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
-  dependencies:
-    pseudomap "^1.0.2"
-    yallist "^2.1.2"
-
 lru-cache@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
@@ -3326,11 +3272,6 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-object-assign@^4.0.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
-  integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
-
 object-inspect@^1.12.2, object-inspect@^1.9.0:
   version "1.12.3"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.3.tgz#ba62dffd67ee256c8c086dfae69e016cd1f198b9"
@@ -3483,18 +3424,6 @@ picomatch@^4.0.3, picomatch@^4.0.4:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
   integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
 
-pinkie-promise@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
-  integrity sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==
-  dependencies:
-    pinkie "^2.0.0"
-
-pinkie@^2.0.0:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
-  integrity sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==
-
 pkg-dir@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
@@ -3596,11 +3525,6 @@ proper-lockfile@^4.1.2:
     graceful-fs "^4.2.4"
     retry "^0.12.0"
     signal-exit "^3.0.2"
-
-pseudomap@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
-  integrity sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==
 
 pump@^3.0.0:
   version "3.0.0"
@@ -3939,22 +3863,6 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-env@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/shell-env/-/shell-env-0.3.0.tgz#2250339022989165bda4eb7bf383afeaaa92dc34"
-  integrity sha512-VrC6OSm5riGAFWvlYExA80Rrlfi4STsztNXjyet9Jf20hbiVeeKvJIesb92gJk7zlmpQjB0wOZpy8ClzVdPVWQ==
-  dependencies:
-    default-shell "^1.0.0"
-    execa "^0.5.0"
-    strip-ansi "^3.0.0"
-
-shell-path@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/shell-path/-/shell-path-2.1.0.tgz#ea7d06ae1070874a1bac5c65bb9bdd62e4f67a38"
-  integrity sha512-w+mbrnpA+r5jSFS4MgFfxZJ1Wx8qMKkR4gvQ+wgaZEoZCMMYZ6Yl/dcNjW/zLMfmx5a9IVIFwGAtUJcnDMmFrg==
-  dependencies:
-    shell-env "^0.3.0"
-
 shelljs@^0.9.2:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.9.2.tgz#a8ac724434520cd7ae24d52071e37a18ac2bb183"
@@ -4096,13 +4004,6 @@ string_decoder@~1.1.1:
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
-
-strip-ansi@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
-  integrity sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==
-  dependencies:
-    ansi-regex "^2.0.0"
 
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
@@ -4652,11 +4553,6 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
-
-yallist@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
-  integrity sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==
 
 yallist@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
**What changes:** a new `fixDarwinPath` in `src/main/utils.ts`, `main.ts` calls it instead of `require('fix-path')()`, and `fix-path` leaves `package.json` (taking `shell-path`, `shell-env`, `execa` 0.5, `default-shell`, and `strip-ansi` 3 with it).

**Why:** a packaged macOS app inherits a bare PATH that misses what a login shell exports (homebrew, pyenv, conda), which is how the bundled Python and CLIs go missing. `fix-path` fixes that, but the whole thing reduces to one `execFileSync` of the login shell asking for its environment. Carrying a six-package subtree for that is not worth it.

**How it works:** on darwin only, it runs the login shell (`$SHELL -ilc 'env; exit'`), strips any ANSI a chatty rc file may print, reads the `PATH=` line, and assigns it. Off darwin it is a no-op, and a spawn failure leaves the existing PATH untouched.

I ran the exact mechanism on this machine and it brought back the full 29-entry login PATH (homebrew, miniforge/conda, cargo, the lot) that a packaged app would not see. Unit tests cover the parse, the ANSI stripping, the non-macOS no-op, and the spawn-failure path. The implementation is Claude Code's; the real-PATH recovery and the failure-mode tests are what I leaned on to trust it.


## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **<!-- YES or NO -->**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Claude Code
