### PR TITLE
ci: update the pinned actions to their current releases

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,8 +32,8 @@ jobs:
       # on CI runners, so skip it and install the binary deterministically below.
       ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           # Match the Node that the target Electron bundles (Electron 42 -> Node
           # 24); do not run ahead of it. Node 26 broke Electron's install tooling.
@@ -92,7 +92,7 @@ jobs:
           else
             yarn test:e2e
           fi
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !cancelled() }}
         with:
           name: playwright-report-${{ matrix.os }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       
       - name: Get package info
         shell: bash
@@ -19,7 +19,7 @@ jobs:
         run: echo "version=$(python scripts/get_package_version.py)" >> $GITHUB_OUTPUT
 
       - name: 'Find Release with tag v${{ steps.package-info.outputs.version}}'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         id: release-exists
         env:
           APP_VERSION: ${{ steps.package-info.outputs.version}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,8 +20,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24.x'
           cache: 'yarn'
@@ -46,7 +46,7 @@ jobs:
         shell: bash -el {0}
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3
         with:
           auto-update-conda: true
@@ -57,7 +57,7 @@ jobs:
       - run: conda install --file ./workflow_env/conda-${{ matrix.cfg.build_platform }}.lock -y
 
       - name: Install node
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24.x'
           cache: 'yarn'
@@ -81,7 +81,7 @@ jobs:
         run: echo "version=$(python scripts/get_package_version.py)" >> $GITHUB_OUTPUT
 
       - name: 'Find Release with tag v${{ steps.package-info.outputs.version}}'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         id: release-exists
         env:
           APP_VERSION: ${{ steps.package-info.outputs.version}}
@@ -154,7 +154,7 @@ jobs:
 
       - name: Upload Debian x64 Installer
         if: matrix.cfg.platform == 'linux-64'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: debian-installer-x64
           path: |
@@ -162,7 +162,7 @@ jobs:
 
       - name: Upload Fedora x64 Installer
         if: matrix.cfg.platform == 'linux-64'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: fedora-installer-x64
           path: |
@@ -170,7 +170,7 @@ jobs:
       
       - name: Upload Snap Installer
         if: matrix.cfg.platform == 'linux-64'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         id: snap-artifact
         with:
           name: snap-installer
@@ -179,7 +179,7 @@ jobs:
 
       - name: Upload macOS x64 Installer
         if: matrix.cfg.platform == 'osx-64'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: mac-installer-x64
           path: |
@@ -187,7 +187,7 @@ jobs:
 
       - name: Upload macOS arm64 Installer
         if: matrix.cfg.platform == 'osx-arm64'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: mac-installer-arm64
           path: |
@@ -195,7 +195,7 @@ jobs:
 
       - name: Upload Windows x64 Installer
         if: matrix.cfg.platform == 'win-64'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: windows-installer-x64
           path: |

--- a/.github/workflows/sync_lab_release.yml
+++ b/.github/workflows/sync_lab_release.yml
@@ -24,7 +24,7 @@ jobs:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -36,7 +36,7 @@ jobs:
 
       - name: Get latest JupyterLab version
         id: get-latest-jupyterlab-version
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -61,7 +61,7 @@ jobs:
           fi
 
       - name: Upload updated version spec files
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: steps.check-update.outputs.update_available == 'true'
         with:
           name: updated-version-info
@@ -82,16 +82,16 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Download updated version info
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: updated-version-info
           path: .
 
       - name: Install Node
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24.x'
 
@@ -134,7 +134,7 @@ jobs:
           done
 
       - name: Upload updated repo as artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: updated-repo
           path: changed-files/
@@ -155,12 +155,12 @@ jobs:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Download updated lock files and sign lists
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: updated-repo
           path: .

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -19,8 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           # Match the Node that the target Electron bundles (Electron 42 -> Node 24).
           node-version: '24.x'


### PR DESCRIPTION
Updates the SHA-pinned actions in the workflows to their current releases: `checkout` v7, `setup-node` v6, `github-script` v9, `upload-artifact` v7, `download-artifact` v8. The old pins still run on Node 20, so every job has been printing the runner's Node 20 deprecation warning; this clears that too.

These go further than the open Dependabot bumps (#917, #926, #929, #932), which were opened a while ago and propose older targets (v8, v5, v6, v6). Rather than land those and bump again later, this takes each one to the latest in a single change. Dependabot closes its own PRs once the same dependency lands on the default branch, so #917, #926, #929 and #932 should close themselves when this merges. This also covers `upload-artifact`, which has no Dependabot PR but was on the same Node 20 pin.

I read each changelog against how the workflows actually use the action, and none of the breaking changes apply here:

- `checkout` v7 blocks checking out a fork PR in `pull_request_target` and `workflow_run` workflows. We don't have either trigger.
- `github-script` v9 is ESM-only and drops `require('@actions/github')`. The three scripts use the injected `github` and `context` objects, no `require` and no `getOctokit`.
- `setup-node` v6 narrows automatic caching to npm. We set `cache: yarn` explicitly and there is no `packageManager` field in package.json, so nothing changes.
- `upload-artifact` v7's direct (unzipped) upload is opt-in via `archive: false`; every step here uploads by name and path.
- `download-artifact` v8 stops unzipping non-zip files and turns a digest mismatch into an error. Both downloads are name-based and the artifacts are the default zipped uploads.

One thing worth a look: `checkout` v6 changed where it stores the persisted git credentials. The only place that pushes after checkout is the `sync_lab_release` PR job, which passes an explicit `token:` and isn't a container action, so the push still works on the hosted runners. Calling it out in case I've missed a case.

Note: AI-assisted (Claude Code). I read each action changelog against how the workflows use it, confirmed the YAML parses and the pins resolve to the latest tags; the bump itself is mechanical.
