### PR TITLE
build: drop @types/tar, tar 7 ships its own types

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,7 +192,6 @@
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^24",
     "@types/semver": "^7.7.1",
-    "@types/tar": "^6.1.13",
     "@types/yargs": "^17.0.35",
     "@vitest/coverage-v8": "^4.1.9",
     "electron": "^42.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -714,14 +714,6 @@
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.7.1.tgz#3ce3af1a5524ef327d2da9e4fd8b6d95c8d70528"
   integrity sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==
 
-"@types/tar@^6.1.13":
-  version "6.1.13"
-  resolved "https://registry.yarnpkg.com/@types/tar/-/tar-6.1.13.tgz#9b5801c02175344101b4b91086ab2bbc8e93a9b6"
-  integrity sha512-IznnlmU5f4WcGTh2ltRu/Ijpmk8wiWXfF0VA4s+HPjHZgvFggk1YaIkbo5krX/zUCzWF8N/l4+W/LNxnvAJ8nw==
-  dependencies:
-    "@types/node" "*"
-    minipass "^4.0.0"
-
 "@types/yargs-parser@*":
   version "21.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
@@ -3421,11 +3413,6 @@ minimizer-webpack-plugin@^5.6.1:
     jest-worker "^27.4.5"
     schema-utils "^4.3.0"
     terser "^5.31.1"
-
-minipass@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-4.0.1.tgz#2b9408c6e81bb8b338d600fb3685e375a370a057"
-  integrity sha512-V9esFpNbK0arbN3fm2sxDKqMYgIp7XtVdE4Esj+PE4Qaaxdg1wIw48ITQIOn1sc8xXSmUviVL3cyjMqPlrVkiA==
 
 minipass@^4.2.4:
   version "4.2.8"


### PR DESCRIPTION
`tar` 7 has shipped its own type declarations since the Electron 42 bump landed, so the separate `@types/tar` devDependency is just dead weight now. Removing it, the types resolve straight from `node_modules/tar/dist` and tsc doesn't notice.

You can check this one quickly: drop the dep, `yarn install`, and `yarn type-check` stays at zero errors (the only tar usage is the `tar.x` call in the env extract). That's the run I did before opening this; AI-assisted with Claude Code.