### PR TITLE
deps: move js-yaml 4 to 5, with a parse test on the real data

### DIFF
--- a/package.json
+++ b/package.json
@@ -225,7 +225,7 @@
     "electron-log": "^5.4.4",
     "fast-xml-parser": "^5.9.0",
     "fix-path": "^3.0.0",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^5.2.0",
     "semver": "^7.8.4",
     "tar": "^7.5.16",
     "update-electron-app": "^3.2.0",

--- a/test/unit/js-yaml-parse.test.ts
+++ b/test/unit/js-yaml-parse.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as yaml from 'js-yaml';
+
+// js-yaml moved from 4.x to 5.x. The two ways this repo uses it are
+// yaml.load() on the bundled-env spec (buildutil.js) and on the auto-updater's
+// latest.yml (app.ts). v5 parses numbers per YAML 1.2 and removed the safe*
+// helpers, so pin the behavior we actually rely on against the real files.
+
+describe('js-yaml load on the data this app parses', () => {
+  it('reads the bundled-env spec and finds the jupyterlab pin', () => {
+    const spec = yaml.load(
+      fs.readFileSync(
+        path.resolve(__dirname, '../../env_installer/jlab_server.yaml'),
+        'utf8'
+      )
+    ) as { dependencies: string[] };
+
+    const jlabPin = spec.dependencies.find(
+      pkg => typeof pkg === 'string' && pkg.startsWith('jupyterlab ')
+    );
+
+    expect(jlabPin).toMatch(/^jupyterlab \d+\.\d+\.\d+/);
+  });
+
+  it('reads a release manifest and keeps the version as a string', () => {
+    // The shape app.ts pulls from the published latest.yml.
+    const manifest = yaml.load(
+      ['version: 4.6.0', 'path: JupyterLab.dmg'].join('\n')
+    ) as { version: string };
+
+    expect(manifest.version).toBe('4.6.0');
+    expect(typeof manifest.version).toBe('string');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3020,10 +3020,10 @@ js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
-js-yaml@^4.2.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
-  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
+js-yaml@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-5.2.0.tgz#b559a892cae3e32fc5afecc9f18e1672378ddb68"
+  integrity sha512-YeLUMlvR4Ou1B119LIaM0r65JvbOBooJDc9yEu0dClb/uSC5P4FrLU8OCCz/HXWvtPoIrR0dRzABTjo1sTN9Bw==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
js-yaml 5 drops the `safe*` helpers (we never used them) and parses numbers per YAML 1.2 instead of 1.1. The only two uses here are `yaml.load()` on the bundled-env spec (`buildutil.js`) and on the updater's `latest.yml` (`app.ts`), both reading version strings, so neither depends on the old number behavior. v5 still ships a CommonJS build, so the main process keeps requiring it.

I added `test/unit/js-yaml-parse.test.ts` that loads the real `env_installer/jlab_server.yaml` and a `latest.yml`-shaped manifest and pins what those two call sites actually read (the jupyterlab pin, the version string).

Easy to verify on your side: `yarn test` runs the new parse test, and a `yarn build` still resolves the bundled jupyterlab version. The YAML 1.2 number-parsing change is the thing I checked against our data before bumping.