### PR TITLE
ci: add zizmor static analysis for the workflows

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,41 @@
+# Static analysis of the GitHub Actions workflows with zizmor.
+# https://github.com/zizmorcore/zizmor
+name: GitHub Actions security (zizmor)
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload-sarif needs this to publish results
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+
+      - name: Run zizmor
+        # Report only for now. The existing workflows still have findings to work
+        # through, so this uploads results to the Security tab instead of failing
+        # the build. Flip to a hard gate once they're cleared. No token is passed,
+        # so zizmor runs offline (skips the online-only audits) and avoids the API
+        # rate limits its docs warn about.
+        continue-on-error: true
+        run: uvx zizmor@1.25.2 --format=sarif . > results.sarif
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+        with:
+          sarif_file: results.sarif
+          category: zizmor


### PR DESCRIPTION
Adds [zizmor](https://github.com/zizmorcore/zizmor) static analysis over the GitHub Actions workflows, based on the one JupyterLab core runs. This answers the "do we have zizmor setup" question from the review on #996.

It's report-only for now: the existing workflows still have a handful of findings (a couple of unscoped app-token permissions, some checkouts missing `persist-credentials: false`, one template-injection), so instead of failing the build it uploads results to the Security tab via SARIF. A follow-up PR fixes those findings and flips this to a hard gate.

Runs offline (no token passed), so it skips the online-only audits and avoids the API rate limits the zizmor docs warn about.

Put this together with Claude Code, using JupyterLab's zizmor workflow as the base and running zizmor against our workflows locally to confirm it works.
