### PR TITLE
ci: build the osx-64 installer on a native Intel runner

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,8 +36,9 @@ jobs:
         - { platform: linux-64, platform_name: Linux x64,  os: ubuntu-latest, build_platform: linux-64, conda_platform: linux-64 }
         # Native Intel runner: macos-latest is arm64, and packing the osx-64
         # env there runs its x86_64 Python under Rosetta, which aborts conda
-        # pack intermittently (#1018). macos-15-intel is the last x86_64 image.
-        - { platform: osx-64, platform_name: macOS x64, os: macos-15-intel, build_platform: osx-64, conda_platform: osx-64 }
+        # pack intermittently (#1018). macos-26-intel is the newest x86_64
+        # image (GitHub offers no macos-latest-intel; -latest is arm64 only).
+        - { platform: osx-64, platform_name: macOS x64, os: macos-26-intel, build_platform: osx-64, conda_platform: osx-64 }
         - { platform: osx-arm64, platform_name: macOS arm64, os: macos-latest, build_platform: osx-64, conda_platform: osx-arm64 }
         - { platform: win-64, platform_name: Windows x64, os: windows-latest, build_platform: win-64, conda_platform: win-64 }
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,10 @@ jobs:
       matrix:
         cfg:
         - { platform: linux-64, platform_name: Linux x64,  os: ubuntu-latest, build_platform: linux-64, conda_platform: linux-64 }
-        - { platform: osx-64, platform_name: macOS x64, os: macos-latest, build_platform: osx-64, conda_platform: osx-64 }
+        # Native Intel runner: macos-latest is arm64, and packing the osx-64
+        # env there runs its x86_64 Python under Rosetta, which aborts conda
+        # pack intermittently (#1018). macos-15-intel is the last x86_64 image.
+        - { platform: osx-64, platform_name: macOS x64, os: macos-15-intel, build_platform: osx-64, conda_platform: osx-64 }
         - { platform: osx-arm64, platform_name: macOS arm64, os: macos-latest, build_platform: osx-64, conda_platform: osx-arm64 }
         - { platform: win-64, platform_name: Windows x64, os: windows-latest, build_platform: win-64, conda_platform: win-64 }
 


### PR DESCRIPTION
Closes #1018.

The `macOS x64 installer` job fails intermittently at `conda pack` with `rosetta error: unable to mmap __TEXT` and `Abort trap: 6` (exit 134). `macos-latest` is arm64 now, so the `osx-64` leg installs an x86_64 conda environment and `conda pack` runs that environment's x86_64 Python under Rosetta on the arm64 host, which is where the abort comes from. The `osx-arm64` leg is not affected because its environment is native.

This pins just the `osx-64` row to `macos-26-intel`, the newest x86_64 image GitHub offers. There is no `macos-latest-intel` label (the `-latest` alias stays arm64), and `macos-26-intel` is newer than `macos-15-intel`, so it tracks macOS 26 like the arm64 legs and has the longest runway. The build then runs natively with no emulation. Nothing else in the matrix changes.

Worth noting x86_64 macOS runners retire in Fall 2027, so the osx-64 installer will need a longer term plan around then (cross-arch pack, or dropping the Intel build), but that is separate from unblocking CI now.

I traced the failing run and checked the available Intel labels and their support window with Claude Code before writing this.
