### PR TITLE
Fix dialog title bars and env-switch crash from the Electron 42 / TS6 migration

### DIFF
--- a/src/main/dialog/themedwindow.ts
+++ b/src/main/dialog/themedwindow.ts
@@ -66,6 +66,8 @@ export class ThemedWindow {
     const titlebarJsSrc = fs.readFileSync(
       path.join(__dirname, './dialogtitlebar.js')
     );
+    // ponytail: dialogtitlebar.js emits CommonJS (tsconfig nodenext); define exports so its customElements.define runs when injected as an inline module. Proper fix in Phase 4: bundle for web / drop data: URLs.
+    const cjsInteropShim = 'var exports={},module={exports};';
 
     const pageSource = `
       <html>
@@ -105,7 +107,7 @@ export class ThemedWindow {
           }
           </style>
           <script type="module">${toolkitJsSrc}</script>
-          <script type="module">${titlebarJsSrc}</script>
+          <script type="module">${cjsInteropShim}${titlebarJsSrc}</script>
           <script>
             document.addEventListener("DOMContentLoaded", () => {
               const platform = "${process.platform}";

--- a/src/main/sessionwindow/sessionwindow.ts
+++ b/src/main/sessionwindow/sessionwindow.ts
@@ -187,6 +187,17 @@ export class SessionWindow implements IDisposable {
     titleBarView.load();
     this._titleBarView = titleBarView;
 
+    // transfer focus to the current labView. Registered once on the persistent
+    // window and titlebar webContents (they outlive every labView); dereferencing
+    // this._labView freshly means an env switch that recreates the labView cannot
+    // leave a stale, disposed webContents behind, nor accumulate a handler per switch.
+    this._window.webContents.on('focus', () => {
+      this._labView?.view?.webContents?.focus();
+    });
+    this._titleBarView.view.webContents.on('focus', () => {
+      this._labView?.view?.webContents?.focus();
+    });
+
     if (this._contentViewType === ContentViewType.Lab) {
       if (this._sessionConfig.isRemote) {
         this._createSessionForRemoteUrl(
@@ -362,13 +373,6 @@ export class SessionWindow implements IDisposable {
     });
     this._window.contentView.addChildView(labView.view);
 
-    // transfer focus to labView
-    this._window.webContents.on('focus', () => {
-      labView.view.webContents.focus();
-    });
-    this._titleBarView.view.webContents.on('focus', () => {
-      labView.view.webContents.focus();
-    });
     labView.view.webContents.on('did-finish-load', () => {
       labView.view.webContents.focus();
     });
@@ -1237,11 +1241,14 @@ export class SessionWindow implements IDisposable {
     // TODO: on linux, electron 22 does not repaint properly after resize
     // check if fixed in newer versions
     setTimeout(() => {
-      this._titleBarView.view.webContents.invalidate();
-      this.contentView?.webContents.invalidate();
-      if (this._envSelectPopup) {
-        this._envSelectPopup.view.view.webContents.invalidate();
-      }
+      const invalidate = (webContents?: Electron.WebContents) => {
+        if (webContents && !webContents.isDestroyed()) {
+          webContents.invalidate();
+        }
+      };
+      invalidate(this._titleBarView?.view?.webContents);
+      invalidate(this.contentView?.webContents);
+      invalidate(this._envSelectPopup?.view?.view?.webContents);
     }, 200);
   }
 

--- a/test/e2e/dialog-titlebar.test.ts
+++ b/test/e2e/dialog-titlebar.test.ts
@@ -1,0 +1,83 @@
+import { expect, test } from '@playwright/test';
+import { cleanup, launchApp, pageByTitle } from './helpers';
+
+// The ThemedWindow dialogs (About, Settings, Manage environments, ...) draw
+// their title bar, window title and close button through the
+// <jlab-dialog-titlebar> custom element. That element is compiled by the
+// project's tsc and injected as an inline script into a data: URL page. When
+// tsc emits CommonJS (tsconfig `module: nodenext`) the script references
+// `exports`, throws `exports is not defined` as an ES module, and aborts before
+// customElements.define runs, so every dialog silently loses its title bar and
+// close button. This pins that the element registers and renders its content.
+test('a ThemedWindow dialog renders its custom title bar and close button', async () => {
+  const { app, userDataDir, jupyterDir } = await launchApp();
+  try {
+    // Arrange: the welcome window is the renderer that opens the dialog.
+    const welcome = await pageByTitle(app, /welcome/i);
+    await welcome.waitForLoadState('domcontentloaded');
+
+    // Act: open the Manage Python environments dialog through the same IPC the
+    // UI uses.
+    await welcome.evaluate(() =>
+      ((window as unknown) as {
+        electronAPI: { sendMessageToMain: (message: string) => void };
+      }).electronAPI.sendMessageToMain('show-manage-python-environments-dialog')
+    );
+
+    // Find the dialog window by the presence of the <jlab-dialog-titlebar>
+    // element itself (every ThemedWindow embeds it, registered or not), not by
+    // URL text: a seeded env also opens an env-select popup whose body contains
+    // the label "Manage Python environments", and matching on that grabbed the
+    // wrong window. The element is absent from that popup.
+    const deadline = Date.now() + 20_000;
+    let dialog;
+    while (!dialog && Date.now() < deadline) {
+      for (const page of app.windows()) {
+        const isDialog = await page
+          .evaluate(() => !!document.querySelector('jlab-dialog-titlebar'))
+          .catch(() => false);
+        if (isDialog) {
+          dialog = page;
+          break;
+        }
+      }
+      if (!dialog) {
+        await new Promise(resolve => setTimeout(resolve, 200));
+      }
+    }
+    if (!dialog) {
+      throw new Error('Manage Python environments dialog window never opened');
+    }
+    await dialog.waitForLoadState('load');
+    // Wait for the custom element to register; swallow the timeout so a
+    // regression (the element never defines) still reaches the assertion below
+    // and fails with a clear message rather than an opaque timeout.
+    await dialog
+      .waitForFunction(
+        () => !!customElements.get('jlab-dialog-titlebar'),
+        undefined,
+        {
+          timeout: 10_000
+        }
+      )
+      .catch(() => undefined);
+
+    // Assert: the custom element registered (the regression signal) and drew
+    // both the window title and the close button inside its shadow root.
+    const rendered = await dialog.evaluate(() => {
+      const el = document.querySelector('jlab-dialog-titlebar');
+      const shadow = el?.shadowRoot;
+      return {
+        defined: !!customElements.get('jlab-dialog-titlebar'),
+        title: shadow?.querySelector('.dialog-title')?.textContent ?? null,
+        hasCloseButton: !!shadow?.querySelector('.close-button')
+      };
+    });
+    expect(rendered.defined).toBe(true);
+    expect(rendered.title).toBe('Manage Python environments');
+    expect(rendered.hasCloseButton).toBe(true);
+  } finally {
+    await app.close();
+    cleanup(userDataDir, jupyterDir);
+  }
+});


### PR DESCRIPTION
Fixes both dialog and session window regressions from #1021. Both come from the Electron 42 (#988) and TypeScript 6 (#978) migrations, not from anything in JupyterLab.

### Dialog title bars (all ThemedWindow dialogs)

`dialogtitlebar.ts` is injected into a `data:` URL page as an inline module, but tsconfig `module: nodenext` emits it as CommonJS, so `exports is not defined` throws before `customElements.define` runs and the element never registers. The first commit defines the CommonJS globals ahead of the injected script so it registers again. This is the surgical fix. Moving these dialogs off the `data:` URL to `loadFile` or a privileged scheme, which also lets a real CSP apply, is the proper follow up and I have it noted for a later PR.

### Env switch crash and listener leak

The window and titlebar `focus` handlers closed over a stale `labView`; after an env switch its `webContents` is undefined under `WebContentsView` and the handler threw `Cannot read properties of undefined (reading 'focus')`. The second commit registers the two handlers once and reads the current `this._labView`, which also stops them accumulating on the persistent emitters, and guards the post-resize `invalidate()` against a closed `webContents`.

### Testing

Added `test/e2e/dialog-titlebar.test.ts`, which opens a dialog and asserts the title bar custom element registers and renders its close button. I confirmed it fails on the pre-fix build and passes after. The full e2e suite is green (11 of 11) including the session window tests, and type-check and build are clean.

Closes #1021

I put this together and traced it with Claude Code, and verified everything against the running app and the local e2e suite before opening this.
