### PR TITLE
Fix env-select popup placement on narrow windows and dismissal on blur

### DIFF
--- a/src/main/sessionwindow/sessionwindow.ts
+++ b/src/main/sessionwindow/sessionwindow.ts
@@ -182,6 +182,7 @@ export class SessionWindow implements IDisposable {
     });
     this._window.on('blur', () => {
       titleBarView.deactivate();
+      this._hideEnvSelectPopup();
     });
 
     titleBarView.load();
@@ -1365,7 +1366,10 @@ export class SessionWindow implements IDisposable {
     );
 
     this._envSelectPopup.view.view.setBounds({
-      x: Math.round(titleBarRect.width - paddingRight - popupWidth),
+      x: Math.max(
+        0,
+        Math.round(titleBarRect.width - paddingRight - popupWidth)
+      ),
       y: Math.round(titleBarRect.height),
       width: popupWidth,
       height: Math.round(maxHeight)

--- a/src/main/sessionwindow/sessionwindow.ts
+++ b/src/main/sessionwindow/sessionwindow.ts
@@ -1357,8 +1357,13 @@ export class SessionWindow implements IDisposable {
     }
 
     const titleBarRect = this._titleBarView.view.getBounds();
-    const popupWidth = 600;
     const paddingRight = process.platform === 'darwin' ? 33 : 127;
+    // Anchor the popup's right edge near the env button and cap its width to
+    // what fits, so on a narrow window it shrinks (the popup content is
+    // responsive) instead of hanging off an edge with the search box or the
+    // env list clipped.
+    const rightEdge = titleBarRect.width - paddingRight;
+    const popupWidth = Math.min(600, rightEdge);
     // shorten browser view height if larger than max allowed
     const maxHeight = Math.min(
       this._envSelectPopup.getScrollHeight(),
@@ -1366,12 +1371,9 @@ export class SessionWindow implements IDisposable {
     );
 
     this._envSelectPopup.view.view.setBounds({
-      x: Math.max(
-        0,
-        Math.round(titleBarRect.width - paddingRight - popupWidth)
-      ),
+      x: Math.round(rightEdge - popupWidth),
       y: Math.round(titleBarRect.height),
-      width: popupWidth,
+      width: Math.round(popupWidth),
       height: Math.round(maxHeight)
     });
   }

--- a/test/unit/sessionwindow-dispose.test.ts
+++ b/test/unit/sessionwindow-dispose.test.ts
@@ -23,3 +23,28 @@ describe('SessionWindow._disposeSession', () => {
     await expect(win._disposeSession()).resolves.toBeUndefined();
   });
 });
+
+describe('SessionWindow._resizeEnvSelectPopup', () => {
+  it('keeps the popup on screen when the window is narrower than the popup', () => {
+    // Arrange: a 400px title bar (the window minWidth) is narrower than the
+    // 600px popup, so an unclamped x would place the popup off the left edge.
+    const setBounds = vi.fn();
+    const win = makeWindow({
+      _envSelectPopupVisible: true,
+      _titleBarView: {
+        view: { getBounds: () => ({ width: 400, height: 60 }) }
+      },
+      _envSelectPopup: {
+        getScrollHeight: () => 300,
+        view: { view: { setBounds } }
+      }
+    });
+
+    // Act
+    win._resizeEnvSelectPopup();
+
+    // Assert: the popup's left edge must never go negative.
+    expect(setBounds).toHaveBeenCalledTimes(1);
+    expect(setBounds.mock.calls[0][0].x).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/test/unit/sessionwindow-dispose.test.ts
+++ b/test/unit/sessionwindow-dispose.test.ts
@@ -43,8 +43,12 @@ describe('SessionWindow._resizeEnvSelectPopup', () => {
     // Act
     win._resizeEnvSelectPopup();
 
-    // Assert: the popup's left edge must never go negative.
+    // Assert: the whole popup fits inside the window, so neither the search box
+    // on the left nor the env list on the right is clipped. Clamping x alone
+    // would only move the clipping to the other edge, so the width is capped too.
     expect(setBounds).toHaveBeenCalledTimes(1);
-    expect(setBounds.mock.calls[0][0].x).toBeGreaterThanOrEqual(0);
+    const bounds = setBounds.mock.calls[0][0];
+    expect(bounds.x).toBeGreaterThanOrEqual(0);
+    expect(bounds.x + bounds.width).toBeLessThanOrEqual(400);
   });
 });


### PR DESCRIPTION
Closes #1033.

Two small fixes for the environment select popup.

The popup is 600px wide and its left edge was computed as the title bar width minus the popup width and a platform padding. The window minimum width is 400px, so on a narrow window that value goes negative and the popup renders clipped off the left edge with its search box unreachable. The left coordinate is now clamped to zero so the popup stays on screen; the width and vertical position are unchanged.

The popup also stayed open when the window lost OS focus, because the blur handler only deactivated the title bar. Since the popup is a child view of the same window, focusing it does not blur the window, so a blur fires only on a genuine focus loss such as Alt-Tab or switching apps, which is exactly when the popup should close. The blur handler now hides it, and the hide path already early-returns when nothing is open.

A unit test drives the real resize method with a 400px title bar and asserts the resulting x is non-negative. It fails before the clamp (x resolves to -233) and passes after. I did not add a unit test for the blur behavior because the handler is wired up inside load() as a closure over local view state, and exercising it cleanly would require standing up the whole window, which felt heavier than the fix warrants.

I built and verified this with Claude Code. Typecheck is clean and the full unit suite is green at 450 tests.



## Before / after

**Env-select popup on a narrow window (F4):**

| Before (master) | After (this PR) |
| --- | --- |
| <img width="470" height="720" alt="F4-before" src="https://github.com/user-attachments/assets/b0bd3c03-3421-41af-ac3a-290b90754891" /> | <img width="470" height="720" alt="F4-after" src="https://github.com/user-attachments/assets/a1a97263-db44-4791-87de-ec4e198f6b46" />  |


