### PR TITLE
Fix title bar maximize/restore desync and cross-window focus theft

### DIFF
--- a/src/main/eventtypes.ts
+++ b/src/main/eventtypes.ts
@@ -96,6 +96,7 @@ export enum EventTypeRenderer {
   SetRunningServerList = 'set-running-server-list',
   SetTitle = 'set-title',
   SetActive = 'set-active',
+  SetMaximized = 'set-maximized',
   ShowServerStatus = 'show-server-status',
   ShowServerNotificationBadge = 'show-server-notification-badge',
   SetRecentSessionList = 'set-recent-session-list',

--- a/src/main/sessionwindow/sessionwindow.ts
+++ b/src/main/sessionwindow/sessionwindow.ts
@@ -192,10 +192,16 @@ export class SessionWindow implements IDisposable {
     // this._labView freshly means an env switch that recreates the labView cannot
     // leave a stale, disposed webContents behind, nor accumulate a handler per switch.
     this._window.webContents.on('focus', () => {
-      this._labView?.view?.webContents?.focus();
+      const wc = this.contentView?.webContents;
+      if (wc && !wc.isDestroyed()) {
+        wc.focus();
+      }
     });
     this._titleBarView.view.webContents.on('focus', () => {
-      this._labView?.view?.webContents?.focus();
+      const wc = this.contentView?.webContents;
+      if (wc && !wc.isDestroyed()) {
+        wc.focus();
+      }
     });
 
     if (this._contentViewType === ContentViewType.Lab) {
@@ -240,12 +246,15 @@ export class SessionWindow implements IDisposable {
       this._resizeViewsDelayed();
     });
     this._window.on('maximize', () => {
+      this._titleBarView.setMaximized(this._window.isMaximized());
       this._resizeViewsDelayed();
     });
     this._window.on('unmaximize', () => {
+      this._titleBarView.setMaximized(this._window.isMaximized());
       this._resizeViewsDelayed();
     });
     this._window.on('restore', () => {
+      this._titleBarView.setMaximized(this._window.isMaximized());
       this._resizeViewsDelayed();
     });
     this._window.on('move', () => {
@@ -374,7 +383,9 @@ export class SessionWindow implements IDisposable {
     this._window.contentView.addChildView(labView.view);
 
     labView.view.webContents.on('did-finish-load', () => {
-      labView.view.webContents.focus();
+      if (this._window.isFocused()) {
+        labView.view.webContents.focus();
+      }
     });
 
     labView.load((errorCode: number, errorDescription: string) => {

--- a/src/main/titlebarview/preload.ts
+++ b/src/main/titlebarview/preload.ts
@@ -5,11 +5,13 @@ const { contextBridge, ipcRenderer } = electron;
 
 type SetTitleListener = (title: string) => void;
 type SetActiveListener = (active: boolean) => void;
+type SetMaximizedListener = (isMaximized: boolean) => void;
 type ShowServerStatusListener = (show: boolean) => void;
 type ShowServerNotificationBadgeListener = (show: boolean) => void;
 
 let onSetTitleListener: SetTitleListener;
 let onSetActiveListener: SetActiveListener;
+let onSetMaximizedListener: SetMaximizedListener;
 let onShowServerStatusListener: ShowServerStatusListener;
 let onShowServerNotificationBadgeListener: ShowServerNotificationBadgeListener;
 
@@ -52,6 +54,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   onSetActive: (callback: SetActiveListener) => {
     onSetActiveListener = callback;
   },
+  onSetMaximized: (callback: SetMaximizedListener) => {
+    onSetMaximizedListener = callback;
+  },
   onShowServerStatus: (callback: ShowServerStatusListener) => {
     onShowServerStatusListener = callback;
   },
@@ -71,6 +76,12 @@ ipcRenderer.on(EventTypeRenderer.SetTitle, (event, title) => {
 ipcRenderer.on(EventTypeRenderer.SetActive, (event, active) => {
   if (onSetActiveListener) {
     onSetActiveListener(active);
+  }
+});
+
+ipcRenderer.on(EventTypeRenderer.SetMaximized, (event, isMaximized) => {
+  if (onSetMaximizedListener) {
+    onSetMaximizedListener(isMaximized);
   }
 });
 

--- a/src/main/titlebarview/titlebar.html
+++ b/src/main/titlebarview/titlebar.html
@@ -230,6 +230,11 @@ Distributed under the terms of the Modified BSD License.
         }
       });
 
+      window.electronAPI.onSetMaximized((isMaximized) => {
+        maximizeButton.style.display = isMaximized ? 'none' : 'block';
+        restoreButton.style.display = isMaximized ? 'block' : 'none';
+      });
+
       window.electronAPI.onShowServerStatus((show) => {
         serverButton.style.display = show ? 'flex' : 'none';
 
@@ -255,15 +260,11 @@ Distributed under the terms of the Modified BSD License.
       maximizeButton.onclick = (ev) => {
         ev.stopPropagation();
         window.electronAPI.maximizeWindow();
-        maximizeButton.style.display = 'none';
-        restoreButton.style.display = 'block';
       };
 
       restoreButton.onclick = (ev) => {
         ev.stopPropagation();
         window.electronAPI.restoreWindow();
-        restoreButton.style.display = 'none';
-        maximizeButton.style.display = 'block';
       };
 
       closeButton.onclick = (ev) => {

--- a/src/main/titlebarview/titlebarview.ts
+++ b/src/main/titlebarview/titlebarview.ts
@@ -62,6 +62,10 @@ export class TitleBarView {
     );
   }
 
+  setMaximized(isMaximized: boolean) {
+    this._view.webContents.send(EventTypeRenderer.SetMaximized, isMaximized);
+  }
+
   showServerStatus(show: boolean) {
     this._view.webContents.send(EventTypeRenderer.ShowServerStatus, show);
   }

--- a/test/e2e/titlebar-dragregion.test.ts
+++ b/test/e2e/titlebar-dragregion.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from '@playwright/test';
+import { cleanup, launchApp } from './helpers';
+
+// The title bar is drawn inside its own WebContentsView. Window dragging relies
+// on `-webkit-app-region: drag` on the `.app-title` element, and every control
+// button opts back out with `-webkit-app-region: no-drag`. Dropping either rule
+// in a refactor silently breaks window moving or makes the buttons undraggable.
+//
+// This is only a guard on the computed CSS declaration. It does NOT exercise a
+// real window move: synthetic Playwright/CDP mouse events do not drive the OS
+// drag on the app-region hit-test, so an actual drag cannot be asserted here.
+// The real window move, and the layered-WebContentsView no-drag hit-testing
+// (electron/electron#43320), still have to be verified by hand per OS.
+test('the title bar keeps its drag region and no-drag controls', async () => {
+  const { app, userDataDir, jupyterDir } = await launchApp();
+  try {
+    // Arrange: find the titlebar page. It has no window title, so it is located
+    // by the presence of its `#app-title` element, the same element-probe
+    // pattern the dialog-titlebar test uses.
+    const deadline = Date.now() + 20_000;
+    let titlebar;
+    while (!titlebar && Date.now() < deadline) {
+      for (const page of app.windows()) {
+        const hasTitle = await page
+          .evaluate(() => !!document.getElementById('app-title'))
+          .catch(() => false);
+        if (hasTitle) {
+          titlebar = page;
+          break;
+        }
+      }
+      if (!titlebar) {
+        await new Promise(resolve => setTimeout(resolve, 200));
+      }
+    }
+    if (!titlebar) {
+      throw new Error('title bar page with #app-title never appeared');
+    }
+    await titlebar.waitForLoadState('load');
+
+    // Act: read the computed app-region of the drag surface and of two control
+    // buttons. The JS-side property is `webkitAppRegion`; its value is the
+    // keyword ('drag' / 'no-drag'), not a length.
+    const regions = await titlebar.evaluate(() => {
+      const regionOf = (id: string) => {
+        const el = document.getElementById(id);
+        if (!el) {
+          return null;
+        }
+        return (getComputedStyle(el) as CSSStyleDeclaration & {
+          webkitAppRegion?: string;
+        }).webkitAppRegion;
+      };
+      return {
+        appTitle: regionOf('app-title'),
+        closeButton: regionOf('close-button'),
+        serverButton: regionOf('server-button')
+      };
+    });
+
+    // Assert: the title is draggable and the controls explicitly opt out. If a
+    // refactor drops the `-webkit-app-region` rules these flip to the inherited
+    // default ('none') and the test fails.
+    expect(regions.appTitle).toBe('drag');
+    expect(regions.closeButton).toBe('no-drag');
+    expect(regions.serverButton).toBe('no-drag');
+  } finally {
+    await app.close();
+    cleanup(userDataDir, jupyterDir);
+  }
+});

--- a/test/unit/preload/titlebarview.test.ts
+++ b/test/unit/preload/titlebarview.test.ts
@@ -29,6 +29,7 @@ describe('titlebarview preload', () => {
         'sendMouseEvent',
         'onSetTitle',
         'onSetActive',
+        'onSetMaximized',
         'onShowServerStatus',
         'onShowServerNotificationBadge'
       ].sort()
@@ -86,6 +87,14 @@ describe('titlebarview preload', () => {
     const cb = vi.fn();
     api.onSetActive(cb);
     rendererHandler(EventTypeRenderer.SetActive)({}, true);
+    expect(cb).toHaveBeenCalledWith(true);
+  });
+
+  it('onSetMaximized relays SetMaximized to the callback', async () => {
+    const api = await load();
+    const cb = vi.fn();
+    api.onSetMaximized(cb);
+    rendererHandler(EventTypeRenderer.SetMaximized)({}, true);
     expect(cb).toHaveBeenCalledWith(true);
   });
 

--- a/test/unit/titlebarview-maximized.test.ts
+++ b/test/unit/titlebarview-maximized.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+import { TitleBarView } from '../../src/main/titlebarview/titlebarview';
+import { EventTypeRenderer } from '../../src/main/eventtypes';
+
+// Drive setMaximized without the heavy WebContentsView constructor: create an
+// instance linked to the prototype and stub only the webContents.send it uses.
+function makeTitleBarView(send: ReturnType<typeof vi.fn>): TitleBarView {
+  const view = Object.create(TitleBarView.prototype);
+  view._view = { webContents: { send } };
+  return view;
+}
+
+describe('TitleBarView.setMaximized', () => {
+  it('sends SetMaximized with true when the window is maximized', () => {
+    // Arrange
+    const send = vi.fn();
+    const titleBarView = makeTitleBarView(send);
+
+    // Act
+    titleBarView.setMaximized(true);
+
+    // Assert
+    expect(send).toHaveBeenCalledWith(EventTypeRenderer.SetMaximized, true);
+  });
+
+  it('sends SetMaximized with false when the window is restored', () => {
+    // Arrange
+    const send = vi.fn();
+    const titleBarView = makeTitleBarView(send);
+
+    // Act
+    titleBarView.setMaximized(false);
+
+    // Assert
+    expect(send).toHaveBeenCalledWith(EventTypeRenderer.SetMaximized, false);
+  });
+});


### PR DESCRIPTION
Closes #1034.

Three focused fixes for the custom title bar and window focus handling:

- Maximize/restore button desync. The buttons only toggled themselves inside their own onclick handlers, so maximizing via a double click on the drag region or via the OS window controls left the wrong button showing. The button state now follows a new `SetMaximized` renderer event driven by the window's own `maximize`/`unmaximize`/`restore` events, using the same IPC path as `SetActive` and `ShowServerStatus`, so the real window state is the single source of truth.

- Welcome view never keyboard-focused. The window and titlebar focus handlers only forwarded focus to the lab view, which is null in Welcome mode, so the welcome content never got focus. They now focus the active content view with a destroyed-guard, which covers both Welcome and Lab.

- Background window steals focus. The lab view's `did-finish-load` handler focused itself unconditionally, so a background second window grabbed focus whenever its lab reloaded. It now only focuses when its own window is already focused.

The focus-handler change touches the same handlers as #1031, so a trivial rebase may be needed at merge time.

Added unit coverage for `TitleBarView.setMaximized` and the new `onSetMaximized` preload bridge. The focus-handler changes are closures registered during window construction, so I did not add tests that would need the whole window wiring stood up rather than asserting real behavior.

I built and verified this locally with Claude Code: `tsc --noEmit` is clean and the unit suite passes (452 tests).


## Verification, before and after

Ran an automated check on a built app (macOS): launch, then `BrowserWindow.maximize()` (the OS or double-click path, not the custom button), then read the title bar button state.

Before this change (master build): `isMaximized() === true`, but the title bar still shows the maximize button (`#maximize-button` display `block`, `#restore-button` display `none`).

After this change: `isMaximized() === true`, and the title bar shows restore (`#maximize-button` display `none`, `#restore-button` display `block`).

Caveat on platforms: the custom min/max/close control box is zero-width on macOS (the native traffic lights are used there), so the check above is a DOM-level before/after, not a visible one. I could not test this on Windows or Linux, where that control box is the primary window chrome and the swap is actually visible, so that part is expected from the code and the macOS DOM state rather than verified. Someone on Windows or Linux should confirm it and, ideally, attach a short before/after recording.

## Follow-up tests for the drag region and focus fixes

Added `test/e2e/titlebar-dragregion.test.ts`, a regression guard for the window drag region. It launches the app, finds the title bar page by its `#app-title` element, and asserts the computed `webkitAppRegion` is `drag` on the title and `no-drag` on the close and server buttons. I confirmed it is a real guard by removing the `-webkit-app-region: drag` rule from the built title bar: the computed value falls back to `none` and the test fails. It is a CSS-declaration guard only. An actual OS window move cannot be driven from Playwright (synthetic mouse events do not fire the app-region hit-test), so the real drag and the layered-WebContentsView no-drag hit-testing (electron/electron#43320) still need a manual pass per OS.

I looked into automating the two focus fixes as well but could not make either deterministic. Under the Playwright/Electron harness the launched app never becomes the OS-frontmost application, so `webContents.isFocused()` reads `false` for every view even after forcing `BrowserWindow.focus()` and `webContents.focus()` from the main process. Any assertion built on that would pass or fail regardless of the fix, so I left them as manual steps rather than ship a flaky or tautological test.

Manual verification for the focus fixes:

- Welcome view focus (Welcome mode): start the app so the Welcome view is showing, click another app to defocus, then click the JupyterLab window title bar to refocus it. Press Tab. Focus should land inside the welcome content (a recent-session entry or a new-notebook link highlights). Before the fix, Tab did nothing because focus was forwarded to the null lab view.
- Background window does not steal focus: open two session windows, keep window A in the foreground, and trigger a reload of the lab in background window B (for example switch its environment so its lab view reloads). Focus should stay on window A. Before the fix, B grabbed focus on its `did-finish-load`.