### PR TITLE
Fix resize repaint gaps and initial view sizing

### DIFF
--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -1257,9 +1257,15 @@ export class JupyterApplication implements IApplication, IDisposable {
       )
       .then(async response => {
         try {
+          if (!response.ok) {
+            throw new Error(`Update check failed: ${response.status}`);
+          }
           const data = await response.text();
           const latestReleaseData = yaml.load(data);
           const latestVersion = (latestReleaseData as any).version;
+          if (!latestVersion || !semver.valid(latestVersion)) {
+            throw new Error('No valid version in update metadata');
+          }
           const currentVersion = app.getVersion();
           const newVersionAvailable =
             semver.compare(currentVersion, latestVersion) === -1;

--- a/src/main/dialog/themedwindow.ts
+++ b/src/main/dialog/themedwindow.ts
@@ -106,6 +106,7 @@ export class ThemedWindow {
             overflow-y: auto;
           }
           </style>
+          <!-- do not prepend the cjsInteropShim here: the toolkit is a UMD bundle that branches on typeof exports, so faking exports breaks every jp-* component -->
           <script type="module">${toolkitJsSrc}</script>
           <script type="module">${cjsInteropShim}${titlebarJsSrc}</script>
           <script>

--- a/src/main/sessionwindow/sessionwindow.ts
+++ b/src/main/sessionwindow/sessionwindow.ts
@@ -170,10 +170,11 @@ export class SessionWindow implements IDisposable {
   load() {
     const titleBarView = new TitleBarView({ isDarkTheme: this._isDarkTheme });
     this._window.contentView.addChildView(titleBarView.view);
+    const { width: contentWidth } = this._window.getContentBounds();
     titleBarView.view.setBounds({
       x: 0,
       y: 0,
-      width: DEFAULT_WIN_WIDTH,
+      width: contentWidth,
       height: titleBarHeight
     });
 
@@ -314,11 +315,15 @@ export class SessionWindow implements IDisposable {
       isDarkTheme: this._isDarkTheme
     });
     this._window.contentView.addChildView(welcomeView.view);
+    const {
+      width: contentWidth,
+      height: contentHeight
+    } = this._window.getContentBounds();
     welcomeView.view.setBounds({
       x: 0,
       y: titleBarHeight,
-      width: DEFAULT_WIN_WIDTH,
-      height: DEFAULT_WIN_HEIGHT
+      width: contentWidth,
+      height: contentHeight - titleBarHeight
     });
 
     welcomeView.load();
@@ -1248,6 +1253,7 @@ export class SessionWindow implements IDisposable {
       };
       invalidate(this._titleBarView?.view?.webContents);
       invalidate(this.contentView?.webContents);
+      invalidate(this._progressView?.view?.view?.webContents);
       invalidate(this._envSelectPopup?.view?.view?.webContents);
     }, 200);
   }

--- a/src/main/sessionwindow/sessionwindow.ts
+++ b/src/main/sessionwindow/sessionwindow.ts
@@ -170,13 +170,7 @@ export class SessionWindow implements IDisposable {
   load() {
     const titleBarView = new TitleBarView({ isDarkTheme: this._isDarkTheme });
     this._window.contentView.addChildView(titleBarView.view);
-    const { width: contentWidth } = this._window.getContentBounds();
-    titleBarView.view.setBounds({
-      x: 0,
-      y: 0,
-      width: contentWidth,
-      height: titleBarHeight
-    });
+    titleBarView.view.setBounds(this._titleBarBounds());
 
     this._window.on('focus', () => {
       titleBarView.activate();
@@ -1218,16 +1212,23 @@ export class SessionWindow implements IDisposable {
     }, 300);
   }
 
-  private _resizeViews() {
-    const { width, height } = this._window.getContentBounds();
-    // add padding to allow resizing around title bar
+  // Title bar bounds, shared by load() and _resizeViews() so the first paint
+  // matches every later resize. Non-macOS insets by 1px so the frame stays
+  // grabbable for resizing around the title bar.
+  private _titleBarBounds(): Electron.Rectangle {
+    const { width } = this._window.getContentBounds();
     const padding = process.platform === 'darwin' ? 0 : 1;
-    this._titleBarView.view.setBounds({
+    return {
       x: padding,
       y: padding,
       width: width - 2 * padding,
       height: titleBarHeight - padding
-    });
+    };
+  }
+
+  private _resizeViews() {
+    const { width, height } = this._window.getContentBounds();
+    this._titleBarView.view.setBounds(this._titleBarBounds());
     const contentRect: Electron.Rectangle = {
       x: 0,
       y: titleBarHeight,

--- a/test/setup/electron-stub.ts
+++ b/test/setup/electron-stub.ts
@@ -55,6 +55,8 @@ export const BrowserWindow = vi.fn().mockImplementation(() => ({
 
 export const shell = { openExternal: vi.fn(), openPath: vi.fn() };
 
+export const net = { fetch: vi.fn() };
+
 export const nativeTheme = { shouldUseDarkColors: false };
 
 export const screen = {

--- a/test/unit/app-checkforupdates.test.ts
+++ b/test/unit/app-checkforupdates.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { net } from '../setup/electron-stub';
 import { JupyterApplication } from '../../src/main/app';
 

--- a/test/unit/app-checkforupdates.test.ts
+++ b/test/unit/app-checkforupdates.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { net } from '../setup/electron-stub';
+import { JupyterApplication } from '../../src/main/app';
+
+// checkForUpdates is a method on the large JupyterApplication class whose
+// constructor wires up the whole main process, so we exercise the method on a
+// prototype-only instance and stub the two collaborators it reaches: the
+// electron `net.fetch` boundary and the private _showUpdateDialog sink.
+function makeApp(): {
+  app: JupyterApplication;
+  showUpdateDialog: ReturnType<typeof vi.fn>;
+} {
+  const app = Object.create(JupyterApplication.prototype) as JupyterApplication;
+  const showUpdateDialog = vi.fn();
+  ((app as unknown) as {
+    _showUpdateDialog: unknown;
+  })._showUpdateDialog = showUpdateDialog;
+  return { app, showUpdateDialog };
+}
+
+describe('JupyterApplication.checkForUpdates', () => {
+  beforeEach(() => {
+    (net.fetch as ReturnType<typeof vi.fn>).mockReset();
+  });
+
+  it('does not read the body when the release feed responds non-ok', async () => {
+    const { app, showUpdateDialog } = makeApp();
+    const text = vi.fn(() => Promise.resolve('<html>not yaml</html>'));
+    (net.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 503,
+      text
+    });
+
+    app.checkForUpdates('always');
+
+    await vi.waitFor(() => expect(showUpdateDialog).toHaveBeenCalled());
+    expect(text).not.toHaveBeenCalled();
+    expect(showUpdateDialog).toHaveBeenCalledWith('error');
+    expect(showUpdateDialog).not.toHaveBeenCalledWith('updates-available');
+  });
+});

--- a/test/unit/sessionwindow-titlebar-bounds.test.ts
+++ b/test/unit/sessionwindow-titlebar-bounds.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { SessionWindow } from '../../src/main/sessionwindow/sessionwindow';
+
+// _titleBarBounds is the single source of truth shared by load() and
+// _resizeViews(); if the two ever diverge again the first paint gaps by a pixel
+// on non-macOS. Drive it directly without the heavy constructor.
+const realPlatform = process.platform;
+function setPlatform(p: string): void {
+  Object.defineProperty(process, 'platform', { value: p, configurable: true });
+}
+
+function windowWith(width: number): any {
+  const win = Object.create(SessionWindow.prototype);
+  win._window = { getContentBounds: () => ({ width, height: 600 }) };
+  return win;
+}
+
+describe('SessionWindow._titleBarBounds', () => {
+  afterEach(() => setPlatform(realPlatform));
+
+  it('spans the full content width with no inset on macOS', () => {
+    setPlatform('darwin');
+    expect(windowWith(800)._titleBarBounds()).toEqual({
+      x: 0,
+      y: 0,
+      width: 800,
+      height: 29
+    });
+  });
+
+  it('insets by one pixel on non-macOS so the frame stays grabbable', () => {
+    setPlatform('linux');
+    expect(windowWith(800)._titleBarBounds()).toEqual({
+      x: 1,
+      y: 1,
+      width: 798,
+      height: 28
+    });
+  });
+});


### PR DESCRIPTION
References #1035.

Four small, independent fixes from that issue:

- Progress view repaint on resize: the post-resize invalidate block in `sessionwindow.ts` repainted the title bar, content view and env-select popup but skipped the progress view, even though it is re-bounded on every resize just above. On the platforms that rely on the explicit `invalidate` that left it stale until the next paint. It now gets invalidated with the rest.
- Initial view sizing: the title bar and welcome view were laid out from the compile-time `DEFAULT_WIN_*` constants at load time, so a session restored larger or maximized rendered mis-sized for a frame. Both now read the live size from `this._window.getContentBounds()`, mirroring what `_resizeViews` already does.
- Update check response status: `checkForUpdates` in `app.ts` parsed the release feed body with no status check, so a 5xx or an HTML error page could flow straight into `yaml.load`. It now throws on a non-ok response before reading the body, and guards that the parsed version is valid semver before comparing. The existing try/catch routes both to the error dialog on the `always` path, so a bad response fails cleanly instead of being compared against garbage.
- Toolkit shim note: a one-line comment by the dialog toolkit script warning that the CommonJS interop shim used on the next line must not be applied to it, since the toolkit is a UMD bundle that branches on `typeof exports` and faking exports there breaks every jp-* component.

I intentionally left the blank-flash item (F7) out of this PR. It lives in `_restartServerInPythonEnvironment`, which the env-switch PR is already changing, and confirming the fix needs a running build. It is better handled as a follow-up once that lands, to avoid a conflict.

Tests: added a focused unit test that a non-ok update response never reaches the body parse. It fails before the status check and passes after. The rest are visual or comment-only changes, so I did not add setBounds-argument assertions that would just restate the code.

I built and verified this with Claude Code: `tsc --noEmit` clean, the full unit suite green (450 tests), and prettier clean on the changed files.
