### PR TITLE
Fix flaky signing of mac assets and update release docs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -129,7 +129,22 @@ jobs:
           security import certificate.p12 -k build.keychain -P $CSC_KEY_PASSWORD -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $ENV_INSTALLER_KEYCHAIN_PASS build.keychain
           echo "Signing env binaries"
-          while read line; do /usr/bin/codesign --force --options=runtime --deep -s "Developer ID Application" ./env_installer/jlab_server_extracted/"$line" -v; done < ./env_installer/sign-${{ matrix.cfg.platform }}.txt
+          # Signing with --options=runtime contacts Apple's timestamp service
+          # for every file; under thousands of sequential requests it
+          # intermittently fails, so retry each file with backoff.
+          while read line; do
+            for attempt in 1 2 3 4 5; do
+              if /usr/bin/codesign --force --options=runtime --deep -s "Developer ID Application" ./env_installer/jlab_server_extracted/"$line" -v; then
+                break
+              elif [ "$attempt" -eq 5 ]; then
+                echo "Failed to sign $line after $attempt attempts"
+                exit 1
+              else
+                echo "Signing $line failed (attempt $attempt), retrying..."
+                sleep $((attempt * 10))
+              fi
+            done
+          done < ./env_installer/sign-${{ matrix.cfg.platform }}.txt
           rm certificate.p12
           security delete-keychain build.keychain
 

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -14,11 +14,22 @@ jobs:
   publish:
     # Action can only be run on windows
     runs-on: windows-latest
+    # The winget environment holds the credentials of the dedicated
+    # jupyterlab-winget-bot machine account (WINGET_USER variable and
+    # WINGET_TOKEN secret). The submission PR to microsoft/winget-pkgs is
+    # opened from that account's fork of winget-pkgs, which is why this needs
+    # a classic PAT (public_repo scope) instead of a GitHub App token: an app
+    # token cannot open PRs on repos the app is not installed on.
+    # The token expires and MUST be regenerated every 9 months on the bot
+    # account, then updated in the winget environment.
+    environment: winget
+    # generous: the release asset it downloads and hashes is large
+    timeout-minutes: 30
     steps:
       - uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
 # https://github.com/vedantmgoyal9/winget-releaser
         with:
           identifier: ProjectJupyter.JupyterLab
           token: ${{ secrets.WINGET_TOKEN }}
-          fork-user: mbektas
+          fork-user: ${{ vars.WINGET_USER }}
           release-tag: ${{ inputs.version }}

--- a/Release.md
+++ b/Release.md
@@ -63,4 +63,6 @@ Releases are driven by manually dispatched GitHub Actions workflows. They must b
 
 7. After publishing, dispatch the [`Publish to WinGet`](https://github.com/jupyterlab/jupyterlab-desktop/actions/workflows/winget.yml) workflow with the release tag (for example `v3.1.12-3`) as the version input to submit the Windows installer to the WinGet package registry.
 
+   The submission PR to [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) is opened from the fork owned by the dedicated `jupyterlab-winget-bot` machine account. The account name and its classic PAT (`public_repo` scope) are configured in the `winget` environment as the `WINGET_USER` variable and `WINGET_TOKEN` secret. The token expires and needs to be regenerated on the bot account every 9 months, then updated in the environment.
+
 8. Promote the snap from `latest/candidate` to `latest/stable`. This is a manual step: CI only publishes to the candidate channel. Open the [Releases page of the snap listing](https://snapcraft.io/jupyterlab-desktop/releases) in the Snapcraft UI and promote the candidate revision to stable.

--- a/Release.md
+++ b/Release.md
@@ -16,7 +16,7 @@ yarn check_version_match
 
 ## Updating the bundled JupyterLab
 
-Updating to a new JupyterLab release is automated by the [`Check for new JupyterLab releases`](.github/workflows/sync_lab_release.yml) workflow. It runs daily (and can be dispatched manually from the Actions tab), and when a new JupyterLab release is found it:
+Updating to a new JupyterLab release is automated by the [`Check for new JupyterLab releases`](https://github.com/jupyterlab/jupyterlab-desktop/actions/workflows/sync_lab_release.yml) workflow. It runs daily (and can be dispatched manually from the Actions tab), and when a new JupyterLab release is found it:
 
 1. Bumps the application version to `<new-jlab-version>-1` using [tbump](https://github.com/your-tools/tbump)
 2. Updates the conda lock files (`yarn update_conda_lock`)
@@ -51,14 +51,16 @@ Releases are driven by manually dispatched GitHub Actions workflows. They must b
 
    If the version in `package.json` has not been released yet, there is nothing to bump.
 
-2. Dispatch the [`Create Pre-release`](.github/workflows/prerelease.yml) workflow. It creates a GitHub release of type `pre-release` with tag `v<version>` (for example `v3.1.12-3`), unless a release with that tag already exists. Edit the release description to add the release notes; they can be refined at any time before publishing. The release needs to stay as `pre-release` for GitHub Actions to be able to attach installers to it.
+2. Dispatch the [`Create Pre-release`](https://github.com/jupyterlab/jupyterlab-desktop/actions/workflows/prerelease.yml) workflow. It creates a GitHub release of type `pre-release` with tag `v<version>` (for example `v3.1.12-3`), unless a release with that tag already exists. Edit the release description to add the release notes; they can be refined at any time before publishing. The release needs to stay as `pre-release` for GitHub Actions to be able to attach installers to it.
 
-3. Dispatch the [`Create Release PR`](.github/workflows/releasepr.yml) workflow. It verifies that the pre-release exists, then creates a `release-v<version>` branch with a placeholder commit and opens a `Release v<version>` PR.
+3. Dispatch the [`Create Release PR`](https://github.com/jupyterlab/jupyterlab-desktop/actions/workflows/releasepr.yml) workflow. It verifies that the pre-release exists, then creates a `release-v<version>` branch with a placeholder commit and opens a `Release v<version>` PR.
 
-4. The [`Publish`](.github/workflows/publish.yml) workflow runs on the PR (and on any push to `master`). When it finds a draft or pre-release with a tag matching the version in `package.json`, it builds signed installers for each platform (Linux, macOS, Windows) and uploads them as assets to that release. New runs overwrite the existing installer assets.
+4. The [`Publish`](https://github.com/jupyterlab/jupyterlab-desktop/actions/workflows/publish.yml) workflow runs on the PR (and on any push to `master`). When it finds a draft or pre-release with a tag matching the version in `package.json`, it builds signed installers for each platform (Linux, macOS, Windows) and uploads them as assets to that release. New runs overwrite the existing installer assets. Release builds also publish the snap installer to the `latest/candidate` channel in the Snap Store.
 
 5. Make sure that application is building, installing and running properly by following the [distribution build instructions](dev.md#building-for-distribution) locally, or by testing the installers attached to the pre-release.
 
 6. Once all the changes are complete, installers are uploaded and the release notes are ready, merge the release PR and publish the release.
 
-7. After publishing, dispatch the [`Publish to WinGet`](.github/workflows/winget.yml) workflow with the release tag (for example `v3.1.12-3`) as the version input to submit the Windows installer to the WinGet package registry.
+7. After publishing, dispatch the [`Publish to WinGet`](https://github.com/jupyterlab/jupyterlab-desktop/actions/workflows/winget.yml) workflow with the release tag (for example `v3.1.12-3`) as the version input to submit the Windows installer to the WinGet package registry.
+
+8. Promote the snap from `latest/candidate` to `latest/stable`. This is a manual step: CI only publishes to the candidate channel. Open the [Releases page of the snap listing](https://snapcraft.io/jupyterlab-desktop/releases) in the Snapcraft UI and promote the candidate revision to stable.


### PR DESCRIPTION
- [x] Addresses transient failure seen in https://github.com/jupyterlab/jupyterlab-desktop/pull/1068
- [x] Mentions snapcraft manual release promotion process
- [x] Updates winget credentials/fork and documents it