### PR TITLE
Snap on stable cannot launch: refresh electron-builder past the .tar.7z extraction bug

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -197,18 +197,12 @@ jobs:
           command -v unsquashfs >/dev/null || sudo apt-get install -y --no-install-recommends squashfs-tools
           rm -rf snap-check
           unsquashfs -q -d snap-check dist/JupyterLab.snap command.sh
-          unsquashfs -l dist/JupyterLab.snap > snap-contents.txt
-          status=0
-          # whatever the launcher execs has to be in the image: the 4.6.2-1 snap
-          # shipped the template as a tarball and died on a missing script
-          for target in $(grep -oE '\$SNAP/[A-Za-z0-9._/-]+' snap-check/command.sh | sort -u); do
-            entry="squashfs-root/${target#\$SNAP/}"
-            if ! grep -qx "$entry" snap-contents.txt; then
-              echo "::error::command.sh execs $target but it is not in the snap"
-              status=1
-            fi
-          done
-          exit $status
+          unsquashfs -l dist/JupyterLab.snap | sort > snap-contents.txt
+          # 4.6.2-1 shipped the template as a tarball, so the launcher died on a
+          # missing script: whatever command.sh execs has to be in the image
+          grep -oE '\$SNAP/[^" ]+' snap-check/command.sh | sed 's|\$SNAP|squashfs-root|' | sort -u > snap-needs.txt
+          comm -23 snap-needs.txt snap-contents.txt | tee snap-missing.txt
+          [ ! -s snap-missing.txt ]
 
       - name: Upload Snap Installer
         if: matrix.cfg.platform == 'linux-64'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -194,21 +194,21 @@ jobs:
       - name: Verify the snap can actually launch
         if: matrix.cfg.platform == 'linux-64'
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends squashfs-tools
+          command -v unsquashfs >/dev/null || sudo apt-get install -y --no-install-recommends squashfs-tools
+          rm -rf snap-check
+          unsquashfs -q -d snap-check dist/JupyterLab.snap command.sh
           unsquashfs -l dist/JupyterLab.snap > snap-contents.txt
-          missing=0
-          for script in desktop-init.sh desktop-common.sh desktop-gnome-specific.sh; do
-            if ! grep -qx "squashfs-root/$script" snap-contents.txt; then
-              echo "::error::$script is missing from the snap; command.sh execs it, so the app cannot start"
-              missing=1
+          status=0
+          # whatever the launcher execs has to be in the image: the 4.6.2-1 snap
+          # shipped the template as a tarball and died on a missing script
+          for target in $(grep -oE '\$SNAP/[A-Za-z0-9._/-]+' snap-check/command.sh | sort -u); do
+            entry="squashfs-root/${target#\$SNAP/}"
+            if ! grep -qx "$entry" snap-contents.txt; then
+              echo "::error::command.sh execs $target but it is not in the snap"
+              status=1
             fi
           done
-          if grep -qE '^squashfs-root/snap-template-.*\.tar$' snap-contents.txt; then
-            echo "::error::the snap template was packed as a tarball instead of being extracted"
-            missing=1
-          fi
-          exit $missing
+          exit $status
 
       - name: Upload Snap Installer
         if: matrix.cfg.platform == 'linux-64'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -191,19 +191,6 @@ jobs:
           path: |
             dist/JupyterLab.rpm
       
-      - name: Verify the snap can actually launch
-        if: matrix.cfg.platform == 'linux-64'
-        run: |
-          command -v unsquashfs >/dev/null || sudo apt-get install -y --no-install-recommends squashfs-tools
-          rm -rf snap-check
-          unsquashfs -q -d snap-check dist/JupyterLab.snap command.sh
-          unsquashfs -l dist/JupyterLab.snap | sort > snap-contents.txt
-          # 4.6.2-1 shipped the template as a tarball, so the launcher died on a
-          # missing script: whatever command.sh execs has to be in the image
-          grep -oE '\$SNAP/[^" ]+' snap-check/command.sh | sed 's|\$SNAP|squashfs-root|' | sort -u > snap-needs.txt
-          comm -23 snap-needs.txt snap-contents.txt | tee snap-missing.txt
-          [ ! -s snap-missing.txt ]
-
       - name: Upload Snap Installer
         if: matrix.cfg.platform == 'linux-64'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -212,6 +199,28 @@ jobs:
           name: snap-installer
           path: |
             dist/JupyterLab.snap
+
+      - name: Verify the snap can actually launch
+        if: matrix.cfg.platform == 'linux-64'
+        run: |
+          command -v unsquashfs >/dev/null || { sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends squashfs-tools; }
+          # 4.6.2-1 shipped the template as a tarball and died on a missing script
+          unsquashfs -q -d "$RUNNER_TEMP/snap-check" dist/JupyterLab.snap command.sh
+          unsquashfs -l -d squashfs-root dist/JupyterLab.snap | sort > "$RUNNER_TEMP/snap-have.txt"
+          grep -oE '\$SNAP/[A-Za-z0-9._/-]+' "$RUNNER_TEMP/snap-check/command.sh" | sed 's|\$SNAP|squashfs-root|' | sort -u > "$RUNNER_TEMP/snap-need.txt"
+          if [ ! -s "$RUNNER_TEMP/snap-need.txt" ]; then
+            echo "::error::no \$SNAP path was read out of command.sh, so this check would pass without verifying anything"
+            exit 1
+          fi
+          missing="$(comm -23 "$RUNNER_TEMP/snap-need.txt" "$RUNNER_TEMP/snap-have.txt")"
+          if [ -n "$missing" ]; then
+            echo "::error::command.sh execs paths that are not in the snap: $missing"
+            exit 1
+          fi
+          if grep -qE '^squashfs-root/snap-template-.*\.tar$' "$RUNNER_TEMP/snap-have.txt"; then
+            echo "::error::the snap template was packed as a tarball instead of being extracted"
+            exit 1
+          fi
 
       - name: Upload macOS x64 Installer
         if: matrix.cfg.platform == 'osx-64'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -191,6 +191,25 @@ jobs:
           path: |
             dist/JupyterLab.rpm
       
+      - name: Verify the snap can actually launch
+        if: matrix.cfg.platform == 'linux-64'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends squashfs-tools
+          unsquashfs -l dist/JupyterLab.snap > snap-contents.txt
+          missing=0
+          for script in desktop-init.sh desktop-common.sh desktop-gnome-specific.sh; do
+            if ! grep -qx "squashfs-root/$script" snap-contents.txt; then
+              echo "::error::$script is missing from the snap; command.sh execs it, so the app cannot start"
+              missing=1
+            fi
+          done
+          if grep -qE '^squashfs-root/snap-template-.*\.tar$' snap-contents.txt; then
+            echo "::error::the snap template was packed as a tarball instead of being extracted"
+            missing=1
+          fi
+          exit $missing
+
       - name: Upload Snap Installer
         if: matrix.cfg.platform == 'linux-64'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
     "@types/yargs": "^17.0.35",
     "@vitest/coverage-v8": "^4.1.9",
     "electron": "^42.4.0",
-    "electron-builder": "^26.15.3",
+    "electron-builder": "^26.15.7",
     "electron-playwright-helpers": "^2.1.0",
     "eslint": "^10.5.0",
     "eslint-config-prettier": "^10.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1111,10 +1111,10 @@ anynum@^1.0.1:
   resolved "https://registry.yarnpkg.com/anynum/-/anynum-1.0.1.tgz#2aac00e08dfad3726c1d462e60dbc2f831659a44"
   integrity sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==
 
-app-builder-lib@26.15.3:
-  version "26.15.3"
-  resolved "https://registry.yarnpkg.com/app-builder-lib/-/app-builder-lib-26.15.3.tgz#0fa6c965e307bb6d86226407c750a45b3fd6b1bf"
-  integrity sha512-2VnyWkqsP5v5XbBhL3tD5Syx8iNPBYsoU7kY4S2fz7wg8Rj/nztWKCUzGKaFRTv0Xwf3/H058CR1Kvtd/3lRow==
+app-builder-lib@26.15.7:
+  version "26.15.7"
+  resolved "https://registry.yarnpkg.com/app-builder-lib/-/app-builder-lib-26.15.7.tgz#70c7fcafef9aa458e9e3179bdbfbb867f1b37a51"
+  integrity sha512-C7APoYISPExUmrEntNhDpz9Tccb4uWuEDfLaC0WPPc7/pwzz0WZGznCz/ycPfkkzw6tKOalceD8g6TgHmVz1QA==
   dependencies:
     "@electron/asar" "3.4.1"
     "@electron/fuses" "^1.8.0"
@@ -1632,12 +1632,12 @@ dir-compare@^4.2.0:
     minimatch "^3.0.5"
     p-limit "^3.1.0 "
 
-dmg-builder@26.15.3:
-  version "26.15.3"
-  resolved "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-26.15.3.tgz#d884362e223551ee0dbc96bbb7187b42905378f8"
-  integrity sha512-O3zJUFUYHJKgzPqioHxfxzBzlSC1eXCSr79gMSBKBP5AgjjpmrydMsMLotEg9fAJF36vdUncb+4ndRNxoPdlSQ==
+dmg-builder@26.15.7:
+  version "26.15.7"
+  resolved "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-26.15.7.tgz#cb16f9ef213c1e7779f61e48c758bc7e8e9f8b9a"
+  integrity sha512-rfo1YyAWO0L3cZLKCqKQiLYbW6ZXebRUfK0kWp4oXxO7dDFLrf7alRkWImNuXvZVQhs6Idzy++cwOk8I+xPDhw==
   dependencies:
-    app-builder-lib "26.15.3"
+    app-builder-lib "26.15.7"
     builder-util "26.15.3"
     fs-extra "^10.1.0"
     js-yaml "^4.1.0"
@@ -1689,17 +1689,17 @@ ejs@^6.0.1:
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-6.0.1.tgz#88ea8ce00335c3575d7c3602dd76e84b0bd60f43"
   integrity sha512-UaaM14yby8U3k02ihS1Bmj5Kz2d7CCQM1scxpgs4Mhkq8F1wR2gl3+Ts4h5Ne4Mnt7M9m4Dw7jsuMr3+xO4vZA==
 
-electron-builder@^26.15.3:
-  version "26.15.3"
-  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-26.15.3.tgz#0e82828f6829c0b2596338365209170ac0acbcd5"
-  integrity sha512-a1KM5heqS3gQCZzizXEI8RjJy3QVogULPdeSknt76uLDpBIW/HDGsMg/XgP0riP6PI9COsRvFITKKGDqA8fJxA==
+electron-builder@^26.15.7:
+  version "26.15.7"
+  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-26.15.7.tgz#e697e616ca972e207d8d44383bd858b10c45a78e"
+  integrity sha512-DBpaNzxsPs1BvEblzFoNriSbzsBqDCy/gseIngeEhYzQG1IxfB7Hvc2tBBVmpWE2BTQGP9J1RrAvDT+Vc/uAxg==
   dependencies:
-    app-builder-lib "26.15.3"
+    app-builder-lib "26.15.7"
     builder-util "26.15.3"
     builder-util-runtime "9.7.0"
     chalk "^4.1.2"
     ci-info "^4.2.0"
-    dmg-builder "26.15.3"
+    dmg-builder "26.15.7"
     fs-extra "^10.1.0"
     lazy-val "^1.0.5"
     simple-update-notifier "2.0.0"


### PR DESCRIPTION
Fixes #1085. The snap on the store cannot launch, so this one is time sensitive.

## What is wrong

The 4.6.2-1 snap has the template tarball sitting at its root instead of the files inside it:

```
squashfs-root/command.sh
squashfs-root/jupyterlab-desktop
squashfs-root/snap-template-electron-4.0-2-amd64.tar     <- never unpacked
```

`command.sh` starts with `exec "$SNAP/desktop-init.sh" ...`, and that script is one of the three inside the tarball, so every launch ends at:

```
/snap/jupyterlab-desktop/35/command.sh: line 2:
/snap/jupyterlab-desktop/35/desktop-init.sh: No such file or directory
```

The Snap Store API reports revision 35 (4.6.2-1) on both `stable` and `candidate` for amd64, released 2026-07-22. `edge` still has revision 31 (4.2.5-1), which works. The deb, rpm and the other platforms are unaffected; this is specific to the snap template path.

## Cause

`extractArchive` in app-builder-lib branched on extension and, for a `.tar.7z` artifact, stripped only the outer 7z layer, leaving the inner tar untouched. The snap template is published as `snap-template-electron-4.0-2-amd64.tar.7z`, so `mksquashfs` packed the tar verbatim. That is [electron-userland/electron-builder#10002](https://github.com/electron-userland/electron-builder/issues/10002), which affects 26.15.0 through 26.15.6 and is fixed in 26.15.7 (2026-07-18). Our lockfile resolved 26.15.3 even though `^26.15.3` already allowed the fix four days before we built the release.

## This PR

- refreshes electron-builder to 26.15.7. Diff is one line of package.json and the lockfile entries for electron-builder, app-builder-lib and dmg-builder.
- adds a five line step: the `$SNAP/...` paths `command.sh` execs, minus the paths present in the image, has to be empty. It reads the requirement off the launcher rather than hardcoding filenames, so a build that stops using the template path, or an upstream rename, does not fail a correct release.

  Canonical's advice for this is `snap install --dangerous` plus [review-tools](https://snapcraft.io/review-tools) in CI. Neither fits: review-tools checks store requirements rather than whether the launcher's own dependencies are in the image, and installing and running the app needs snapd and a display on the runner, which trades this failure for flakier ones. A set difference over the file list is the smallest thing that catches the class.

The second half matters as much as the first. This workflow runs on pull requests too, so the check would have failed on the PR that introduced the breakage rather than after it reached the store, and the snap is the one artifact nothing ever looks inside. The upstream fix also renames the toolset cache directory for `.tar.7z`, so a poisoned cache on a builder cannot survive the upgrade.

## What still needs doing after this lands

A rebuilt snap has to be published and promoted, since revision 35 stays on stable until a new revision replaces it. That is a maintainer action, I cannot trigger it.

## Verified

Unpacked the released artifact and confirmed the missing scripts and the stray tarball, queried the Snap Store for the published revisions, and checked that the `.tar.7z` branch is present in 26.15.7 and absent in 26.15.3 through 26.15.6. Build and the unit suite pass on the refreshed lockfile.

The check itself I ran both ways against the released 4.6.2-1 snap: it names the three missing scripts and exits 1, and with those entries present it exits 0. What I could not do is build a snap on macOS, so its first run against a freshly built artifact happens in CI here.

Worked through this with Claude Code, and the artifact inspection and version bisect are mine.
