### PR TITLE
Make blocked navigation the default for views nobody claimed

### DIFF
--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -29,6 +29,7 @@ import {
   setupJlabCLICommandWithElevatedRights,
   waitForDuration
 } from './utils';
+import { installGlobalNavigationGuard } from './navigationguard';
 import { IServerFactory, JupyterServerFactory } from './server';
 import { connectAndGetServerInfo, IJupyterServerInfo } from './connect';
 import { UpdateDialog } from './updatedialog/updatedialog';
@@ -279,6 +280,7 @@ export class JupyterApplication implements IApplication, IDisposable {
     this._serverFactory.createFreeServer().catch(error => {
       console.error('Failed to create free server', error);
     });
+    installGlobalNavigationGuard();
     this._registerListeners();
 
     if (

--- a/src/main/connect.ts
+++ b/src/main/connect.ts
@@ -3,6 +3,7 @@
 
 import { BrowserWindow, Cookie } from 'electron';
 import { clearSession } from './utils';
+import { markGuarded } from './navigationguard';
 
 export let connectWindow: BrowserWindow;
 
@@ -55,6 +56,8 @@ export async function connectAndGetServerInfo(
     }
 
     const window = new BrowserWindow(browserOptions);
+    // this window exists to follow a login wherever the server sends it
+    markGuarded(window.webContents);
 
     const timeout = options?.timeout || 30000;
 

--- a/src/main/dialog/themedview.ts
+++ b/src/main/dialog/themedview.ts
@@ -5,6 +5,7 @@ import { WebContentsView } from 'electron';
 import * as fs from 'fs';
 import * as path from 'path';
 import { DarkThemeBGColor, LightThemeBGColor } from '../utils';
+import { guardAppOwnedView } from '../navigationguard';
 
 export class ThemedView {
   constructor(options: ThemedView.IOptions) {
@@ -14,6 +15,7 @@ export class ThemedView {
         preload: options.preload || path.join(__dirname, './preload.js')
       }
     });
+    guardAppOwnedView(this._view.webContents);
     this._view.setBackgroundColor(
       this._isDarkTheme ? DarkThemeBGColor : LightThemeBGColor
     );

--- a/src/main/dialog/themedwindow.ts
+++ b/src/main/dialog/themedwindow.ts
@@ -5,6 +5,7 @@ import { BrowserWindow } from 'electron';
 import * as fs from 'fs';
 import * as path from 'path';
 import { DarkThemeBGColor, LightThemeBGColor } from '../utils';
+import { guardAppOwnedView } from '../navigationguard';
 
 export class ThemedWindow {
   constructor(options: ThemedWindow.IOptions) {
@@ -26,6 +27,8 @@ export class ThemedWindow {
         preload: options.preload || path.join(__dirname, './preload.js')
       }
     });
+
+    guardAppOwnedView(this._window.webContents);
 
     // hide the traffic lights
     if (process.platform === 'darwin') {

--- a/src/main/labview/labview.ts
+++ b/src/main/labview/labview.ts
@@ -19,6 +19,7 @@ import {
   isSameServerOrigin,
   LightThemeBGColor
 } from '../utils';
+import { markGuarded } from '../navigationguard';
 import { SessionWindow } from '../sessionwindow/sessionwindow';
 import {
   CtrlWBehavior,
@@ -64,6 +65,8 @@ export class LabView implements IDisposable {
         partition
       }
     });
+    // this view decides per origin in _registerNavigationGuard
+    markGuarded(this._view.webContents);
 
     this._view.setBackgroundColor(
       options.isDarkTheme ? DarkThemeBGColor : LightThemeBGColor

--- a/src/main/navigationguard.ts
+++ b/src/main/navigationguard.ts
@@ -1,0 +1,86 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { app, shell, WebContents } from 'electron';
+import log from 'electron-log';
+
+// http/https for ordinary links, mailto for contact links
+const EXTERNAL_SCHEMES = ['https:', 'http:', 'mailto:'];
+
+const guarded = new WeakSet<WebContents>();
+
+/**
+ * Declare that this webContents carries its own navigation policy, so the
+ * application-wide guard leaves its navigations alone. The lab view decides per
+ * origin, and the server connection window has to follow a login wherever it
+ * goes.
+ */
+export function markGuarded(contents: WebContents): void {
+  guarded.add(contents);
+}
+
+export function openUrlInSystemBrowser(url: string): void {
+  try {
+    const { protocol, href } = new URL(url);
+    if (EXTERNAL_SCHEMES.includes(protocol)) {
+      shell.openExternal(href);
+    }
+  } catch {
+    // unparseable target, nothing safe to open
+  }
+}
+
+/**
+ * Pin a view that renders a bundled document. Those views are built from a
+ * data: URL and are never meant to navigate: keeping them on their own document
+ * means a link in content they render, the news feed on the welcome page for
+ * instance, cannot replace app chrome with a page from the network.
+ */
+export function guardAppOwnedView(contents: WebContents): void {
+  markGuarded(contents);
+
+  const sendToBrowser = (event: Electron.Event, url: string) => {
+    event.preventDefault();
+    openUrlInSystemBrowser(url);
+  };
+
+  contents.on('will-navigate', sendToBrowser);
+  contents.on('will-redirect', sendToBrowser);
+  contents.setWindowOpenHandler(({ url }) => {
+    openUrlInSystemBrowser(url);
+    return { action: 'deny' };
+  });
+}
+
+/**
+ * Deny navigation for any webContents nobody claimed. Views are added over
+ * time and the safe default is that a new one cannot be navigated away from its
+ * document until someone decides what its policy should be. The check runs when
+ * a navigation happens rather than when the webContents is created, because
+ * creation fires before the owner has had a chance to claim it.
+ */
+export function installGlobalNavigationGuard(): void {
+  app.on('web-contents-created', (_event, contents) => {
+    contents.on('will-attach-webview', event => {
+      event.preventDefault();
+    });
+
+    const denyUnclaimed = (event: Electron.Event, url: string) => {
+      if (guarded.has(contents)) {
+        return;
+      }
+      event.preventDefault();
+      log.warn(`Blocked navigation to ${url} in an unguarded view`);
+    };
+
+    contents.on('will-navigate', denyUnclaimed);
+    contents.on('will-redirect', denyUnclaimed);
+
+    // an owner that sets its own handler replaces this one, which is what
+    // claiming a view looks like for window creation
+    contents.setWindowOpenHandler(({ url }) => {
+      log.warn(`Blocked window opening ${url} from an unguarded view`);
+      return { action: 'deny' };
+    });
+  });
+}

--- a/src/main/sessionwindow/sessionwindow.ts
+++ b/src/main/sessionwindow/sessionwindow.ts
@@ -22,6 +22,7 @@ import {
   WorkspaceSettings
 } from '../config/settings';
 import { TitleBarView } from '../titlebarview/titlebarview';
+import { guardAppOwnedView } from '../navigationguard';
 import {
   DarkThemeBGColor,
   envPathForPythonPath,
@@ -133,6 +134,8 @@ export class SessionWindow implements IDisposable {
         devTools: false
       }
     });
+
+    guardAppOwnedView(this._window.webContents);
 
     this._window.setMenuBarVisibility(false);
     this._window.show();

--- a/src/main/titlebarview/titlebarview.ts
+++ b/src/main/titlebarview/titlebarview.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as ejs from 'ejs';
 import { DarkThemeBGColor, LightThemeBGColor } from '../utils';
+import { guardAppOwnedView } from '../navigationguard';
 import { EventTypeRenderer } from '../eventtypes';
 
 export class TitleBarView {
@@ -17,6 +18,8 @@ export class TitleBarView {
         devTools: process.env.NODE_ENV === 'development'
       }
     });
+
+    guardAppOwnedView(this._view.webContents);
 
     this._view.setBackgroundColor(
       this._isDarkTheme ? DarkThemeBGColor : LightThemeBGColor

--- a/src/main/welcomeview/welcomeview.ts
+++ b/src/main/welcomeview/welcomeview.ts
@@ -3,6 +3,7 @@
 
 import { net, WebContentsView } from 'electron';
 import { DarkThemeBGColor, getUserHomeDir, LightThemeBGColor } from '../utils';
+import { guardAppOwnedView } from '../navigationguard';
 import * as path from 'path';
 import * as fs from 'fs';
 import { parseNewsFeed } from './newsfeed';
@@ -30,6 +31,8 @@ export class WelcomeView {
         devTools: process.env.NODE_ENV === 'development'
       }
     });
+
+    guardAppOwnedView(this._view.webContents);
 
     this._view.setBackgroundColor(
       this._isDarkTheme ? DarkThemeBGColor : LightThemeBGColor

--- a/test/setup/electron-stub.ts
+++ b/test/setup/electron-stub.ts
@@ -10,6 +10,7 @@ import { join } from 'path';
 const userDataPath = join(tmpdir(), 'jlab-test-userdata');
 
 export const app = {
+  on: vi.fn(),
   getPath: vi.fn((name: string) => join(userDataPath, name)),
   getVersion: vi.fn(() => '4.4.7'),
   getName: vi.fn(() => 'JupyterLab'),

--- a/test/unit/navigationguard.test.ts
+++ b/test/unit/navigationguard.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { app, shell } from 'electron';
+import {
+  guardAppOwnedView,
+  installGlobalNavigationGuard,
+  markGuarded,
+  openUrlInSystemBrowser
+} from '../../src/main/navigationguard';
+
+interface IFakeContents {
+  on: (name: string, listener: (...args: any[]) => void) => void;
+  setWindowOpenHandler: (handler: (details: { url: string }) => any) => void;
+  emit: (name: string, ...args: any[]) => void;
+  openWindow: (url: string) => any;
+}
+
+function fakeContents(): IFakeContents {
+  const listeners = new Map<string, ((...args: any[]) => void)[]>();
+  let openHandler: (details: { url: string }) => any = () => undefined;
+
+  return {
+    on(name, listener) {
+      listeners.set(name, [...(listeners.get(name) ?? []), listener]);
+    },
+    setWindowOpenHandler(handler) {
+      openHandler = handler;
+    },
+    emit(name, ...args) {
+      (listeners.get(name) ?? []).forEach(listener => listener(...args));
+    },
+    openWindow(url) {
+      return openHandler({ url });
+    }
+  };
+}
+
+const navigationEvent = () => ({ preventDefault: vi.fn() });
+
+describe('openUrlInSystemBrowser', () => {
+  beforeEach(() => {
+    vi.mocked(shell.openExternal).mockClear();
+  });
+
+  it.each(['https://example.com/', 'http://example.com/', 'mailto:a@b.c'])(
+    'opens %s',
+    url => {
+      openUrlInSystemBrowser(url);
+
+      expect(shell.openExternal).toHaveBeenCalledOnce();
+    }
+  );
+
+  it.each(['file:///etc/passwd', 'javascript:alert(1)', 'not a url'])(
+    'leaves %s unopened',
+    url => {
+      openUrlInSystemBrowser(url);
+
+      expect(shell.openExternal).not.toHaveBeenCalled();
+    }
+  );
+});
+
+describe('guardAppOwnedView', () => {
+  beforeEach(() => {
+    vi.mocked(shell.openExternal).mockClear();
+  });
+
+  it('keeps the view on its own document and sends the link to the browser', () => {
+    const contents = fakeContents();
+    guardAppOwnedView(contents as any);
+    const event = navigationEvent();
+
+    contents.emit('will-navigate', event, 'https://example.com/');
+
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    expect(shell.openExternal).toHaveBeenCalledOnce();
+  });
+
+  it('guards a server-issued redirect the same way', () => {
+    const contents = fakeContents();
+    guardAppOwnedView(contents as any);
+    const event = navigationEvent();
+
+    contents.emit('will-redirect', event, 'https://example.com/');
+
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+  });
+
+  it('denies window creation and hands the target to the browser', () => {
+    const contents = fakeContents();
+    guardAppOwnedView(contents as any);
+
+    expect(contents.openWindow('https://example.com/')).toEqual({
+      action: 'deny'
+    });
+    expect(shell.openExternal).toHaveBeenCalledOnce();
+  });
+
+  it('prevents navigation without opening anything for an unsafe scheme', () => {
+    const contents = fakeContents();
+    guardAppOwnedView(contents as any);
+    const event = navigationEvent();
+
+    contents.emit('will-navigate', event, 'file:///etc/passwd');
+
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    expect(shell.openExternal).not.toHaveBeenCalled();
+  });
+});
+
+describe('installGlobalNavigationGuard', () => {
+  let created: (event: unknown, contents: any) => void;
+
+  beforeEach(() => {
+    vi.mocked(app.on).mockClear();
+    installGlobalNavigationGuard();
+    created = vi
+      .mocked(app.on)
+      .mock.calls.find(call => call[0] === 'web-contents-created')?.[1] as any;
+  });
+
+  it('registers itself for every webContents the app creates', () => {
+    expect(created).toBeTypeOf('function');
+  });
+
+  it('prevents navigation in a view nobody claimed', () => {
+    const contents = fakeContents();
+    created(null, contents);
+    const event = navigationEvent();
+
+    contents.emit('will-navigate', event, 'https://example.com/');
+
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+  });
+
+  it('leaves a claimed view to its own policy', () => {
+    const contents = fakeContents();
+    created(null, contents);
+    markGuarded(contents as any);
+    const event = navigationEvent();
+
+    contents.emit('will-navigate', event, 'https://example.com/');
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('denies window creation from a view nobody claimed', () => {
+    const contents = fakeContents();
+    created(null, contents);
+
+    expect(contents.openWindow('https://example.com/')).toEqual({
+      action: 'deny'
+    });
+  });
+
+  it('refuses to attach a webview even in a claimed view', () => {
+    const contents = fakeContents();
+    created(null, contents);
+    markGuarded(contents as any);
+    const event = navigationEvent();
+
+    contents.emit('will-attach-webview', event);
+
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
Closes #1088.

## What is wrong

Navigation control in this app is an exception rather than a policy. The lab view guards itself; everything else is open by default.

| surface | loads | guard before this PR |
| --- | --- | --- |
| welcome view | `data:text/html`, renders the remote news feed | none |
| title bar | `data:text/html` | none |
| themed window and themed view, which every dialog is built from | `data:text/html` | none |
| session window itself | container window | none |
| connect window | the remote server URL, navigates freely by design | none |
| lab view | server URL | yes |

None of the `data:` views is meant to navigate at all. The welcome view is the one that renders content derived from a remote feed, which is the surface GHSA-vrj4-r4fw-9rfh was about.

## What this does

- `installGlobalNavigationGuard()` denies `will-navigate`, `will-redirect` and window creation for any webContents that has not claimed a policy, and refuses `will-attach-webview` everywhere.
- the check runs at navigation time rather than at creation time. `web-contents-created` fires before a constructor can claim its own view, so deciding at creation would either lock out every view or trust every view.
- `guardAppOwnedView()` is what the bundled views claim: stay on this document, and hand a link the user follows to the system browser through the same `http`/`https`/`mailto` allowlist used elsewhere.
- the lab view and the connect window claim themselves with `markGuarded()` and keep the behaviour they have now, one deciding per origin and the other following a login wherever the server sends it.

A view added later inherits the deny rather than inheriting nothing, which is the actual point.

## Prior art

Doyensec's rule is named [`LIMIT_NAVIGATION_GLOBAL_CHECK`](https://github.com/doyensec/electronegativity/wiki/LIMIT_NAVIGATION_GLOBAL_CHECK), that is, limits at application level rather than per window, and Electron's checklist items 13 and 14 are written the same way. Reading how others do it: Signal denies window creation globally in `web-contents-created` and blocks webview attachment, VS Code calls `preventDefault()` on `will-navigate` for every webContents with an explicit exception for its integrated browser views, and Bitwarden guards `will-redirect` alongside `will-navigate`.

## Verified

Audited the bundled views before touching them, since denying navigation there could have broken something real: every anchor is `href="#"` (ten of them) or `href="javascript:void(0)"` (two), none navigates, and none of those views calls `window.open` or uses `target="_blank"`. Nothing legitimate is taken away.

Unit tests cover both sides of the claim check, the app-owned policy and the scheme allowlist, checked by mutation: making the fallback ignore claims fails the claimed-view test, dropping the allowlist fails three. Build, eslint, prettier and the full unit suite (484) pass, and the app starts with nothing logged as blocked. I smoke tested startup and the welcome view rather than opening every dialog one by one.

Independent of #1087 and #1092, and can land in any order relative to them.

Worked through this with Claude Code.
