### PR TITLE
Stop one flaky installer leg from cancelling the other three

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,9 @@ jobs:
       release_exists: ${{ steps.release-exists.outputs.result }}
       version: ${{ steps.package-info.outputs.version }}
     strategy:
+      # Each leg builds an independent installer, so a flake on one platform
+      # must not cancel the other three and throw away their artifacts.
+      fail-fast: false
       matrix:
         cfg:
         - { platform: linux-64, platform_name: Linux x64,  os: ubuntu-latest, build_platform: linux-64, conda_platform: linux-64 }


### PR DESCRIPTION
On #1077 the macOS x64 leg died in dmgbuild:

```
dmgbuild.core.DMGError: Unable to detach device cleanly:
hdiutil: couldn't eject "disk2" - Resource busy
```

Nothing to do with the change under review. The Windows leg was three minutes into `Create Application Server Installer` and got `##[error]The operation was canceled.` Linux and macOS arm64 had already finished, so the PR ended up red with two artifacts built, one flaked and one killed for no reason.

`strategy.fail-fast` [defaults to true](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstrategyfail-fast), which is right for a matrix of variants of one thing. This matrix is four independent installers sharing only the source tree, so a failure on one says nothing about the others, and cancelling them costs a full rerun to learn what a completed run would have shown for free.

The flake itself is upstream and long-standing: [electron-builder#4606](https://github.com/electron-userland/electron-builder/issues/4606), [#7137](https://github.com/electron-userland/electron-builder/issues/7137), [#9155](https://github.com/electron-userland/electron-builder/issues/9155), and [dmgbuild#26](https://github.com/dmgbuild/dmgbuild/issues/26) for the DiskArbitration timeouts behind it on hosted runners. dmgbuild already retries the detach internally, and `dmg-builder` invokes it as `dmgbuild -s <settings> <name> <path>` with no way to raise that count from our config, so there is nothing to tune here. A step level retry around the mac dist command is the remaining option and would be its own change. This one only stops the flake from spreading.

Noticed while looking at an unrelated CI failure with Claude Code. The upstream issues above are ones I opened and read, and the dmgbuild invocation is read out of `dmg-builder/out/dmgUtil.js` in this tree rather than recalled. I have not reproduced the flake deliberately; the run linked from #1077 is the only instance I have seen.
