### PR TITLE
Drop the isDevMode comment about the check it replaced

### DIFF
--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -28,8 +28,6 @@ export interface ISaveOptions {
 }
 
 export function isDevMode(): boolean {
-  // require.main is undefined under ESM and when the app runs against an
-  // Electron binary from the system rather than the bundled one (#786)
   return !app.isPackaged;
 }
 

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -418,8 +418,6 @@ describe('getJlabCLICommandTargetPath', () => {
   });
 });
 
-// #786: the app is in dev mode when it is unpackaged, which also covers being
-// run against an Electron binary from the system rather than the bundled one
 describe('isDevMode', () => {
   afterEach(() => {
     (app as any).isPackaged = false;

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -418,6 +418,8 @@ describe('getJlabCLICommandTargetPath', () => {
   });
 });
 
+// #786: the app is in dev mode when it is unpackaged, which also covers being
+// run against an Electron binary from the system rather than the bundled one
 describe('isDevMode', () => {
   afterEach(() => {
     (app as any).isPackaged = false;


### PR DESCRIPTION
## References

- Follow-up to the review comment on #1097, which merged eleven minutes after it was left

## Code changes

`git log -L` on the hunk shows the comment was added by the same commit that removed `require.main.filename.indexOf('app.asar')`, so it explains why a check that is no longer in the file was the wrong one. The two cases it names, ESM and a system Electron binary, are what the tests either side of it already pin.

## User-facing changes

None.

## Backwards-incompatible changes

None.

## Manual testing

Not applicable; comment only, no emitted code changes.

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **YES**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Claude Code, Opus 5
