### PR TITLE
Run the unit suite on macOS and Windows too

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# These run as Unix shell scripts wherever they end up, so they keep LF even
+# when checked out on Windows. linux_after_install.sh becomes the postinst of
+# the deb and rpm, where a CRLF shebang is read as an interpreter named
+# "/bin/bash\r" and the install fails.
+*.sh text eol=lf
+electron-builder-scripts/snap-hooks/* text eol=lf

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,8 +14,16 @@ permissions:
 
 jobs:
   test:
-    name: 'Unit tests'
-    runs-on: ubuntu-latest
+    # One leg per OS, the way jupyterlab splits linuxtests / macostests /
+    # windowstests. The suite mocks electron, so no binary is needed and the
+    # cost is a runner each; what it buys is the filesystem behaviour that only
+    # differs by platform, which the config tests reach directly.
+    name: 'Unit tests (${{ matrix.os }})'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     permissions:
       contents: read
@@ -26,7 +34,12 @@ jobs:
           node-version: '24.x'
           cache: 'yarn'
       - run: yarn install --frozen-lockfile
-      - run: yarn test:coverage
+      # Coverage thresholds only need enforcing once; the other legs are here
+      # for the behaviour, not the numbers.
+      - if: matrix.os == 'ubuntu-latest'
+        run: yarn test:coverage
+      - if: matrix.os != 'ubuntu-latest'
+        run: yarn test:unit
 
   publish:
     needs: test

--- a/test/unit/appdata.test.ts
+++ b/test/unit/appdata.test.ts
@@ -83,7 +83,9 @@ describe('ApplicationData.read', () => {
     );
     appData.read();
     expect(appData.condaPath).toContain('conda');
-    expect(appData.condaPath).toContain('/opt/conda');
+    // the derived path keeps the root it migrated from, whichever slash the
+    // host joins it with
+    expect(appData.condaPath.replace(/\\/g, '/')).toContain('/opt/conda');
   });
 
   it('reads recentRemoteURLs list', () => {

--- a/test/unit/appdata.test.ts
+++ b/test/unit/appdata.test.ts
@@ -83,8 +83,7 @@ describe('ApplicationData.read', () => {
     );
     appData.read();
     expect(appData.condaPath).toContain('conda');
-    // the derived path keeps the root it migrated from, whichever slash the
-    // host joins it with
+    // the derived path keeps the root it migrated from, whichever slash the host joins it with
     expect(appData.condaPath.replace(/\\/g, '/')).toContain('/opt/conda');
   });
 

--- a/test/unit/cli-spawn.test.ts
+++ b/test/unit/cli-spawn.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'fs';
 import { execFileSync, spawn } from 'child_process';
 
@@ -97,7 +97,15 @@ beforeEach(() => {
 });
 
 describe('launchCLIinEnvironment', () => {
+  const originalPlatform = process.platform;
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
   it('spawns bash with the generated activate script and cleans it up on close', async () => {
+    // pinned: the Windows branch spawns cmd and waits five seconds before it
+    // unlinks, so on that runner this hit the timeout rather than the assertion
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
     mockSpawn.mockReturnValue(makeChild(0));
     const result = await launchCLIinEnvironment('/envs/a');
     expect(mockSpawn).toHaveBeenCalledWith(

--- a/test/unit/cli-spawn.test.ts
+++ b/test/unit/cli-spawn.test.ts
@@ -103,8 +103,7 @@ describe('launchCLIinEnvironment', () => {
   });
 
   it('spawns bash with the generated activate script and cleans it up on close', async () => {
-    // pinned: the Windows branch spawns cmd and waits five seconds before it
-    // unlinks, so on that runner this hit the timeout rather than the assertion
+    // pinned: the Windows branch spawns cmd and waits five seconds before it unlinks, so on that runner this hit the timeout rather than the assertion
     Object.defineProperty(process, 'platform', { value: 'darwin' });
     mockSpawn.mockReturnValue(makeChild(0));
     const result = await launchCLIinEnvironment('/envs/a');

--- a/test/unit/env-spawn.test.ts
+++ b/test/unit/env-spawn.test.ts
@@ -93,7 +93,14 @@ beforeEach(() => {
 });
 
 describe('runCommandInEnvironment', () => {
+  const original = process.platform;
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: original });
+  });
+
   it('spawns bash with -c and the env script and resolves true on exit code 0', async () => {
+    // pinned, or the Windows leg of the matrix takes the cmd branch below
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
     mockSpawn.mockReturnValue(makeChild({ code: 0 }));
     const result = await env.runCommandInEnvironment(
       '/envs/a',

--- a/test/unit/navigationguard.test.ts
+++ b/test/unit/navigationguard.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { readdirSync, readFileSync, statSync } from 'fs';
-import { join, relative } from 'path';
+import { join, relative, sep } from 'path';
 import { app, shell } from 'electron';
 import {
   guardAppOwnedView,
@@ -290,7 +290,11 @@ describe('every surface that claims navigation also declares a popup policy', ()
       );
     });
 
-    expect(callers.map(file => relative(root, file)).sort()).toEqual([
+    const named = callers.map(file =>
+      relative(root, file).split(sep).join('/')
+    );
+
+    expect(named.sort()).toEqual([
       'authwindow/authwindow.ts',
       'connect.ts',
       'labview/labview.ts'

--- a/test/unit/sessionconfig.test.ts
+++ b/test/unit/sessionconfig.test.ts
@@ -343,8 +343,10 @@ describe('SessionConfig.createFromArgs', () => {
   });
 
   it('excludes pythonPath when it does not exist', () => {
+    // the arg is resolved before it reaches here, so on Windows it arrives as
+    // C:\valid\dir and a forward-slash match would find nothing
     mockFs.existsSync = vi.fn((p: fs.PathLike) => {
-      return p.toString().includes('valid/dir');
+      return p.toString().replace(/\\/g, '/').includes('valid/dir');
     });
     const result = SessionConfig.createFromArgs({
       _: [],

--- a/test/unit/sessionconfig.test.ts
+++ b/test/unit/sessionconfig.test.ts
@@ -343,8 +343,7 @@ describe('SessionConfig.createFromArgs', () => {
   });
 
   it('excludes pythonPath when it does not exist', () => {
-    // the arg is resolved before it reaches here, so on Windows it arrives as
-    // C:\valid\dir and a forward-slash match would find nothing
+    // the arg is resolved before it reaches here, so on Windows it arrives as C:\valid\dir and a forward-slash match would find nothing
     mockFs.existsSync = vi.fn((p: fs.PathLike) => {
       return p.toString().replace(/\\/g, '/').includes('valid/dir');
     });

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -81,10 +81,7 @@ import * as net from 'net';
 
 const mockFs = vi.mocked(fs);
 
-// Stubbing process.platform does not restage path: it binds win32 or posix at
-// import, from the real host. So a function that branches on the platform runs
-// the branch the test asked for, and joins it with the host's separator. These
-// assertions are about layout, not about which slash, so they compare in one.
+// Stubbing process.platform does not restage path: it binds win32 or posix at import, from the real host. So a function that branches on the platform runs the branch the test asked for, and joins it with the host's separator. These assertions are about layout, not about which slash, so they compare in one.
 const toSlash = (p: string) => p.split(path.sep).join('/');
 
 // Reset the fs stubs to fresh no-op fns before every test so a value set in
@@ -207,8 +204,7 @@ describe('condaSourcePathForEnvPath', () => {
 
   it('returns conda.sh path on posix', () => {
     Object.defineProperty(process, 'platform', { value: 'darwin' });
-    // undefined is this function's Windows answer, and the empty string it
-    // becomes here fails the comparison rather than typing as a string
+    // undefined is this function's Windows answer, and the empty string it becomes here fails the comparison rather than typing as a string
     expect(toSlash(condaSourcePathForEnvPath('/env') ?? '')).toBe(
       '/env/etc/profile.d/conda.sh'
     );

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -81,6 +81,12 @@ import * as net from 'net';
 
 const mockFs = vi.mocked(fs);
 
+// Stubbing process.platform does not restage path: it binds win32 or posix at
+// import, from the real host. So a function that branches on the platform runs
+// the branch the test asked for, and joins it with the host's separator. These
+// assertions are about layout, not about which slash, so they compare in one.
+const toSlash = (p: string) => p.split(path.sep).join('/');
+
 // Reset the fs stubs to fresh no-op fns before every test so a value set in
 // one test cannot leak into a later one that does not set it.
 beforeEach(() => {
@@ -133,7 +139,7 @@ describe('pythonPathForEnvPath', () => {
   it('returns bin/python on posix', () => {
     Object.defineProperty(process, 'platform', { value: 'darwin' });
     mockFs.existsSync = vi.fn(() => false);
-    expect(pythonPathForEnvPath('/env')).toBe('/env/bin/python');
+    expect(toSlash(pythonPathForEnvPath('/env'))).toBe('/env/bin/python');
   });
 
   it('returns python.exe in root for conda on windows', () => {
@@ -161,7 +167,7 @@ describe('envPathForPythonPath', () => {
   it('returns parent of bin/ on posix', () => {
     Object.defineProperty(process, 'platform', { value: 'darwin' });
     const result = envPathForPythonPath('/env/bin/python');
-    expect(result).toContain('/env');
+    expect(toSlash(result)).toContain('/env');
   });
 
   it('returns parent of Scripts/ on windows', () => {
@@ -187,7 +193,7 @@ describe('activatePathForEnvPath', () => {
 
   it('returns bin/activate on posix', () => {
     Object.defineProperty(process, 'platform', { value: 'darwin' });
-    expect(activatePathForEnvPath('/env')).toBe('/env/bin/activate');
+    expect(toSlash(activatePathForEnvPath('/env'))).toBe('/env/bin/activate');
   });
 });
 
@@ -200,7 +206,7 @@ describe('condaSourcePathForEnvPath', () => {
 
   it('returns conda.sh path on posix', () => {
     Object.defineProperty(process, 'platform', { value: 'darwin' });
-    expect(condaSourcePathForEnvPath('/env')).toBe(
+    expect(toSlash(condaSourcePathForEnvPath('/env'))).toBe(
       '/env/etc/profile.d/conda.sh'
     );
   });
@@ -213,7 +219,7 @@ describe('condaSourcePathForEnvPath', () => {
 
 describe('jupyterEnvInstallInfoPathForEnvPath', () => {
   it('returns .jupyter/env.json path', () => {
-    expect(jupyterEnvInstallInfoPathForEnvPath('/env')).toBe(
+    expect(toSlash(jupyterEnvInstallInfoPathForEnvPath('/env'))).toBe(
       '/env/.jupyter/env.json'
     );
   });
@@ -368,7 +374,7 @@ describe('getLogFilePath', () => {
 
   it('returns path under Library/Logs on darwin', () => {
     Object.defineProperty(process, 'platform', { value: 'darwin' });
-    expect(getLogFilePath()).toContain('Library/Logs');
+    expect(toSlash(getLogFilePath())).toContain('Library/Logs');
   });
 
   it('returns path under .config on linux', () => {
@@ -737,7 +743,7 @@ describe('createTempFile', () => {
   it('returns path inside the temp dir', () => {
     const result = createTempFile('run.sh');
     expect(result).toContain('run.sh');
-    expect(result).toContain('/tmp/jlab_desktop_abc');
+    expect(toSlash(result)).toContain('/tmp/jlab_desktop_abc');
   });
 
   it('uses defaults when called with no args', () => {

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -167,7 +167,8 @@ describe('envPathForPythonPath', () => {
   it('returns parent of bin/ on posix', () => {
     Object.defineProperty(process, 'platform', { value: 'darwin' });
     const result = envPathForPythonPath('/env/bin/python');
-    expect(toSlash(result)).toContain('/env');
+    // exact, because 'contains /env' is also true of the argument it was given
+    expect(toSlash(result)).toBe('/env/');
   });
 
   it('returns parent of Scripts/ on windows', () => {
@@ -206,7 +207,9 @@ describe('condaSourcePathForEnvPath', () => {
 
   it('returns conda.sh path on posix', () => {
     Object.defineProperty(process, 'platform', { value: 'darwin' });
-    expect(toSlash(condaSourcePathForEnvPath('/env'))).toBe(
+    // undefined is this function's Windows answer, and the empty string it
+    // becomes here fails the comparison rather than typing as a string
+    expect(toSlash(condaSourcePathForEnvPath('/env') ?? '')).toBe(
       '/env/etc/profile.d/conda.sh'
     );
   });


### PR DESCRIPTION
## References

- Part of #1049
- The `.gitattributes` here would also have prevented the CRLF postinst behind #870

## Code changes

The unit job ran on `ubuntu-latest` only. It now runs on macOS and Windows too. The first Windows run had thirteen tests red, which is why the fixes are in this PR and not a follow-up: a matrix nobody can merge is worth nothing.

Twelve are tests, failing the same way. The suite stubs `process.platform` to reach a branch, but `path` binds `win32` or `posix` when it is imported, from the real host. So the function takes the branch the test asked for and joins the result the host's way, and `/env/bin/python` meets `\env\bin\python`. The file already knew, next to one of them:

```ts
// path.join uses host OS separator — just verify it doesn't include Scripts
```

Where the assertion is about layout it now folds separators before comparing (`toSlash` is the identity on the two legs that were already green). Where it is about which program gets spawned, the platform is pinned instead. Two were also weak and got exact: `envPathForPythonPath` was checked with `toContain('/env')`, true of its own argument.

The thirteenth is real. `electron-builder-scripts/linux_after_install.sh` becomes the `postinst` of the deb and rpm, and the Windows runner checked it out with CRLF. A CRLF shebang fails with `bad interpreter: /bin/bash^M: no such file or directory`; with `.gitattributes` in place the same checkout writes LF, so the attribute is what does it. Five files pinned. No tracked file has CRLF today, so nothing is renormalised.

Coverage thresholds stay enforced once, on ubuntu.

## User-facing changes

None.

## Backwards-incompatible changes

None. `publish` is `needs: test`, so a Windows-only failure now blocks the installers and therefore a release, where before only ubuntu could. That is the point, and it is a new way to be held up.

## Manual testing

The Windows leg is the testing: thirteen red to green across two runs on this PR. Legs cost ubuntu 25s, macOS 41s, Windows 1m05s against a 10 minute cap.

Locally on macOS: full suite, `tsc --noEmit`, eslint, prettier. The two strengthened assertions were mutation-checked, since those could have been weakened rather than fixed.

Not done: nothing here runs the app on Windows. The e2e matrix is still ubuntu and macOS, which is #1113.

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **<!-- YES or NO -->**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Claude Code, Opus 5
