### PR TITLE
Keep the config keys this build has no setting for

### DIFF
--- a/src/main/cli.ts
+++ b/src/main/cli.ts
@@ -1028,6 +1028,7 @@ function handleConfigSetCommand(argv: any) {
     return;
   }
 
+  let saved: boolean;
   if (projectPath) {
     const setting = userSettings.settings[key];
     if (!setting.wsOverridable) {
@@ -1037,10 +1038,18 @@ function handleConfigSetCommand(argv: any) {
 
     const wsSettings = new WorkspaceSettings(projectPath);
     wsSettings.setValue(key as SettingType, value);
-    wsSettings.save();
+    saved = wsSettings.save();
   } else {
     userSettings.setValue(key as SettingType, value);
-    userSettings.save();
+    saved = userSettings.save();
+  }
+
+  // save now declines when the file is there and could not be read, so printing success without asking would tell somebody their setting landed while the file was left untouched
+  if (!saved) {
+    console.error(
+      `Could not write the settings file, so "${key}" was not saved. The log names the file and why.`
+    );
+    return;
   }
 
   console.log(

--- a/src/main/cli.ts
+++ b/src/main/cli.ts
@@ -982,7 +982,7 @@ function handleConfigListCommand(argv: any) {
   console.log(listLines.join('\n'));
 }
 
-function handleConfigSetCommand(argv: any) {
+export function handleConfigSetCommand(argv: any) {
   const parseSetting = (): { key: string; value: string } => {
     if (argv._.length !== 3) {
       console.error(`Invalid setting. Use "set <settingKey> <value>" format.`);
@@ -1059,7 +1059,7 @@ function handleConfigSetCommand(argv: any) {
   );
 }
 
-function handleConfigUnsetCommand(argv: any) {
+export function handleConfigUnsetCommand(argv: any) {
   const parseKey = (): string => {
     if (argv._.length !== 2) {
       console.error(`Invalid setting. Use "unset <settingKey>" format.`);
@@ -1082,6 +1082,7 @@ function handleConfigUnsetCommand(argv: any) {
     return;
   }
 
+  let saved: boolean;
   if (projectPath) {
     const setting = userSettings.settings[key];
     if (!setting.wsOverridable) {
@@ -1091,10 +1092,18 @@ function handleConfigUnsetCommand(argv: any) {
 
     const wsSettings = new WorkspaceSettings(projectPath);
     wsSettings.unsetValue(key as SettingType);
-    wsSettings.save();
+    saved = wsSettings.save();
   } else {
     userSettings.unsetValue(key as SettingType);
-    userSettings.save();
+    saved = userSettings.save();
+  }
+
+  // the same refusal `set` already reports: a reset announced over a file that was left untouched is the one shape automation cannot tell from success, and the guard was written on one side only
+  if (!saved) {
+    console.error(
+      `Could not write the settings file, so "${key}" was not reset. The log names the file and why.`
+    );
+    return;
   }
 
   console.log(

--- a/src/main/config/settings.ts
+++ b/src/main/config/settings.ts
@@ -213,17 +213,19 @@ export class UserSettings {
     const data = fs.readFileSync(userSettingsPath);
     const jsonData = JSON.parse(data.toString());
 
-    for (let key in SettingType) {
-      if (key in jsonData) {
-        const setting = this._settings[key];
-        setting.value = jsonData[key];
+    this._unclaimed = {};
+    for (const key of Object.keys(jsonData)) {
+      if (key in SettingType) {
+        this._settings[key].value = jsonData[key];
+      } else {
+        this._unclaimed[key] = jsonData[key];
       }
     }
   }
 
   save() {
     const userSettingsPath = UserSettings.getUserSettingsPath();
-    const userSettings: { [key: string]: any } = {};
+    const userSettings: { [key: string]: any } = { ...this._unclaimed };
 
     for (let key in SettingType) {
       const setting = this._settings[key];
@@ -241,6 +243,9 @@ export class UserSettings {
     );
   }
 
+  // what the file held and this build had no setting for. Kept because save
+  // rebuilds the file, so a key left out of it is a key deleted from disk.
+  protected _unclaimed: { [key: string]: any } = {};
   protected _settings: { [key: string]: Setting<any> };
 }
 
@@ -278,6 +283,7 @@ export class WorkspaceSettings extends UserSettings {
 
   unsetValue(setting: SettingType) {
     delete this._wsSettings[setting];
+    delete this._wsUnclaimed[setting];
   }
 
   read() {
@@ -292,13 +298,15 @@ export class WorkspaceSettings extends UserSettings {
     const data = fs.readFileSync(wsSettingsPath);
     const jsonData = JSON.parse(data.toString());
 
-    for (let key in SettingType) {
-      if (key in jsonData) {
-        const userSetting = this._settings[key];
-        if (userSetting.wsOverridable) {
-          this._wsSettings[key] = Object.assign({}, userSetting);
-          this._wsSettings[key].value = jsonData[key];
-        }
+    this._wsUnclaimed = {};
+    for (const key of Object.keys(jsonData)) {
+      const userSetting = key in SettingType ? this._settings[key] : undefined;
+      if (userSetting?.wsOverridable) {
+        this._wsSettings[key] = Object.assign({}, userSetting);
+        this._wsSettings[key].value = jsonData[key];
+      } else {
+        // not overridable by a project, or not a setting this build knows
+        this._wsUnclaimed[key] = jsonData[key];
       }
     }
   }
@@ -307,7 +315,7 @@ export class WorkspaceSettings extends UserSettings {
     const wsSettingsPath = WorkspaceSettings.getWorkspaceSettingsPath(
       this._workingDirectory
     );
-    const wsSettings: { [key: string]: any } = {};
+    const wsSettings: { [key: string]: any } = { ...this._wsUnclaimed };
 
     // uiMode needs special handling, it needs to be saved even if same as global default.
     // this is due to automatically setting uiMode to Zen for default for opening single file
@@ -348,6 +356,7 @@ export class WorkspaceSettings extends UserSettings {
     return path.join(workingDirectory, '.jupyter', 'desktop-settings.json');
   }
 
+  private _wsUnclaimed: { [key: string]: any } = {};
   private _workingDirectory: string;
   private _wsSettings: { [key: string]: Setting<any> } = {};
 }

--- a/src/main/config/settings.ts
+++ b/src/main/config/settings.ts
@@ -136,6 +136,25 @@ export namespace Setting {
   }
 }
 
+/**
+ * What the file holds right now, or nothing when it is absent or unusable.
+ * save merges over this rather than rebuilding, so a read that fails here
+ * costs the keys this build does not know rather than corrupting the ones it
+ * does; #1115 replaces this with the shared reader.
+ */
+function readJsonFileOrEmpty(filePath: string): { [key: string]: any } {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(filePath).toString());
+    return parsed !== null &&
+      typeof parsed === 'object' &&
+      !Array.isArray(parsed)
+      ? parsed
+      : {};
+  } catch {
+    return {};
+  }
+}
+
 export class UserSettings {
   constructor(readSettings: boolean = true) {
     this._settings = {
@@ -199,10 +218,15 @@ export class UserSettings {
 
   setValue(setting: SettingType, value: any) {
     this._settings[setting].value = value;
+    this._unset.delete(setting);
   }
 
   unsetValue(setting: SettingType) {
     this._settings[setting].setToDefault();
+    // the only thing that takes a key out of the file. A value that merely
+    // equals its default is indistinguishable from one nobody ever set, so
+    // save cannot use that to decide a deletion
+    this._unset.add(setting);
   }
 
   read() {
@@ -213,28 +237,51 @@ export class UserSettings {
     const data = fs.readFileSync(userSettingsPath);
     const jsonData = JSON.parse(data.toString());
 
-    this._unclaimed = {};
-    for (const key of Object.keys(jsonData)) {
-      if (key in SettingType) {
+    for (let key in SettingType) {
+      if (key in jsonData) {
         this._settings[key].value = jsonData[key];
-      } else {
-        this._unclaimed[key] = jsonData[key];
       }
     }
   }
 
   save() {
     const userSettingsPath = UserSettings.getUserSettingsPath();
-    const userSettings: { [key: string]: any } = { ...this._unclaimed };
+    const userSettings = this._merged(
+      readJsonFileOrEmpty(userSettingsPath),
+      key => {
+        const setting = this._settings[key];
+        return { write: setting.differentThanDefault, value: setting.value };
+      }
+    );
+
+    fs.writeFileSync(userSettingsPath, JSON.stringify(userSettings, null, 2));
+  }
+
+  /**
+   * The file as it is on disk, with this object's settings written over it.
+   * Rebuilding from the settings alone deletes every key the build has no
+   * setting for, and every value the read declined to take.
+   */
+  protected _merged(
+    onDisk: { [key: string]: any },
+    valueFor: (key: string) => { write: boolean; value?: any }
+  ): { [key: string]: any } {
+    // spread defines rather than assigns, so a __proto__ key out of the file
+    // stays an own property instead of reaching Object.prototype
+    const merged = { ...onDisk };
 
     for (let key in SettingType) {
-      const setting = this._settings[key];
-      if (setting.differentThanDefault) {
-        userSettings[key] = setting.value;
+      if (this._unset.has(key)) {
+        delete merged[key];
+        continue;
+      }
+      const decision = valueFor(key);
+      if (decision.write) {
+        merged[key] = decision.value;
       }
     }
 
-    fs.writeFileSync(userSettingsPath, JSON.stringify(userSettings, null, 2));
+    return merged;
   }
 
   get resolvedWorkingDirectory(): string {
@@ -243,9 +290,7 @@ export class UserSettings {
     );
   }
 
-  // what the file held and this build had no setting for. Kept because save
-  // rebuilds the file, so a key left out of it is a key deleted from disk.
-  protected _unclaimed: { [key: string]: any } = {};
+  protected _unset = new Set<string>();
   protected _settings: { [key: string]: Setting<any> };
 }
 
@@ -283,7 +328,7 @@ export class WorkspaceSettings extends UserSettings {
 
   unsetValue(setting: SettingType) {
     delete this._wsSettings[setting];
-    delete this._wsUnclaimed[setting];
+    this._unset.add(setting);
   }
 
   read() {
@@ -298,15 +343,13 @@ export class WorkspaceSettings extends UserSettings {
     const data = fs.readFileSync(wsSettingsPath);
     const jsonData = JSON.parse(data.toString());
 
-    this._wsUnclaimed = {};
-    for (const key of Object.keys(jsonData)) {
-      const userSetting = key in SettingType ? this._settings[key] : undefined;
-      if (userSetting?.wsOverridable) {
-        this._wsSettings[key] = Object.assign({}, userSetting);
-        this._wsSettings[key].value = jsonData[key];
-      } else {
-        // not overridable by a project, or not a setting this build knows
-        this._wsUnclaimed[key] = jsonData[key];
+    for (let key in SettingType) {
+      if (key in jsonData) {
+        const userSetting = this._settings[key];
+        if (userSetting.wsOverridable) {
+          this._wsSettings[key] = Object.assign({}, userSetting);
+          this._wsSettings[key].value = jsonData[key];
+        }
       }
     }
   }
@@ -315,21 +358,20 @@ export class WorkspaceSettings extends UserSettings {
     const wsSettingsPath = WorkspaceSettings.getWorkspaceSettingsPath(
       this._workingDirectory
     );
-    const wsSettings: { [key: string]: any } = { ...this._wsUnclaimed };
-
     // uiMode needs special handling, it needs to be saved even if same as global default.
     // this is due to automatically setting uiMode to Zen for default for opening single file
-    for (let key in SettingType) {
-      const setting = this._wsSettings[key];
-      if (
-        setting &&
-        this._settings[key].wsOverridable &&
-        (key === SettingType.uiMode ||
-          this._isDifferentThanUserSetting(key as SettingType))
-      ) {
-        wsSettings[key] = setting.value;
+    const wsSettings = this._merged(
+      readJsonFileOrEmpty(wsSettingsPath),
+      key => {
+        const setting = this._wsSettings[key];
+        const write =
+          !!setting &&
+          this._settings[key].wsOverridable &&
+          (key === SettingType.uiMode ||
+            this._isDifferentThanUserSetting(key as SettingType));
+        return { write, value: setting?.value };
       }
-    }
+    );
 
     // Write when there is something to persist, or when a previous file needs
     // to be cleared. mkdir is unconditional: recursive mode is a no-op when the
@@ -356,7 +398,6 @@ export class WorkspaceSettings extends UserSettings {
     return path.join(workingDirectory, '.jupyter', 'desktop-settings.json');
   }
 
-  private _wsUnclaimed: { [key: string]: any } = {};
   private _workingDirectory: string;
   private _wsSettings: { [key: string]: Setting<any> } = {};
 }

--- a/src/main/config/settings.ts
+++ b/src/main/config/settings.ts
@@ -137,10 +137,7 @@ export namespace Setting {
 }
 
 /**
- * What the file holds right now, or nothing when it is absent or unusable.
- * save merges over this rather than rebuilding, so a read that fails here
- * costs the keys this build does not know rather than corrupting the ones it
- * does; #1115 replaces this with the shared reader.
+ * What the file holds right now, or nothing when it is absent or unusable. save merges over this rather than rebuilding, so a read that fails here costs the keys this build does not know rather than corrupting the ones it does; #1115 replaces this with the shared reader.
  */
 function readJsonFileOrEmpty(filePath: string): { [key: string]: any } {
   try {
@@ -250,8 +247,7 @@ export class UserSettings {
       readJsonFileOrEmpty(userSettingsPath),
       key => {
         const setting = this._settings[key];
-        // every key of SettingType is one this build owns, so one matching
-        // its default does not belong in the file, whatever the file holds
+        // every key of SettingType is one this build owns, so one matching its default does not belong in the file, whatever the file holds
         return setting.differentThanDefault
           ? { kind: 'write', value: setting.value }
           : { kind: 'delete' };
@@ -262,16 +258,13 @@ export class UserSettings {
   }
 
   /**
-   * The file as it is on disk, with this object's settings written over it.
-   * Rebuilding from the settings alone deletes every key the build has no
-   * setting for, and every value the read declined to take.
+   * The file as it is on disk, with this object's settings written over it. Rebuilding from the settings alone deletes every key the build has no setting for, and every value the read declined to take.
    */
   protected _merged(
     onDisk: { [key: string]: any },
     decide: (key: string) => SettingDecision
   ): { [key: string]: any } {
-    // spread defines rather than assigns, so a __proto__ key out of the file
-    // stays an own property instead of reaching Object.prototype
+    // spread defines rather than assigns, so a __proto__ key out of the file stays an own property instead of reaching Object.prototype
     const merged = { ...onDisk };
 
     for (let key in SettingType) {
@@ -363,8 +356,7 @@ export class WorkspaceSettings extends UserSettings {
     const wsSettings = this._merged(
       readJsonFileOrEmpty(wsSettingsPath),
       key => {
-        // a key a project cannot override is not this file's to remove, even
-        // though it does nothing here
+        // a key a project cannot override is not this file's to remove, even though it does nothing here
         if (!this._settings[key].wsOverridable) {
           return { kind: 'leave' };
         }
@@ -376,8 +368,7 @@ export class WorkspaceSettings extends UserSettings {
         ) {
           return { kind: 'write', value: setting.value };
         }
-        // unsetValue takes it out of _wsSettings, and an override matching the
-        // global value is not an override any more
+        // unsetValue takes it out of _wsSettings, and an override matching the global value is not an override any more
         return { kind: 'delete' };
       }
     );

--- a/src/main/config/settings.ts
+++ b/src/main/config/settings.ts
@@ -155,6 +155,11 @@ function readJsonFileOrEmpty(filePath: string): { [key: string]: any } {
   }
 }
 
+type SettingDecision =
+  | { kind: 'write'; value: any }
+  | { kind: 'delete' }
+  | { kind: 'leave' };
+
 export class UserSettings {
   constructor(readSettings: boolean = true) {
     this._settings = {
@@ -218,15 +223,10 @@ export class UserSettings {
 
   setValue(setting: SettingType, value: any) {
     this._settings[setting].value = value;
-    this._unset.delete(setting);
   }
 
   unsetValue(setting: SettingType) {
     this._settings[setting].setToDefault();
-    // the only thing that takes a key out of the file. A value that merely
-    // equals its default is indistinguishable from one nobody ever set, so
-    // save cannot use that to decide a deletion
-    this._unset.add(setting);
   }
 
   read() {
@@ -250,7 +250,11 @@ export class UserSettings {
       readJsonFileOrEmpty(userSettingsPath),
       key => {
         const setting = this._settings[key];
-        return { write: setting.differentThanDefault, value: setting.value };
+        // every key of SettingType is one this build owns, so one matching
+        // its default does not belong in the file, whatever the file holds
+        return setting.differentThanDefault
+          ? { kind: 'write', value: setting.value }
+          : { kind: 'delete' };
       }
     );
 
@@ -264,20 +268,18 @@ export class UserSettings {
    */
   protected _merged(
     onDisk: { [key: string]: any },
-    valueFor: (key: string) => { write: boolean; value?: any }
+    decide: (key: string) => SettingDecision
   ): { [key: string]: any } {
     // spread defines rather than assigns, so a __proto__ key out of the file
     // stays an own property instead of reaching Object.prototype
     const merged = { ...onDisk };
 
     for (let key in SettingType) {
-      if (this._unset.has(key)) {
-        delete merged[key];
-        continue;
-      }
-      const decision = valueFor(key);
-      if (decision.write) {
+      const decision = decide(key);
+      if (decision.kind === 'write') {
         merged[key] = decision.value;
+      } else if (decision.kind === 'delete') {
+        delete merged[key];
       }
     }
 
@@ -290,7 +292,6 @@ export class UserSettings {
     );
   }
 
-  protected _unset = new Set<string>();
   protected _settings: { [key: string]: Setting<any> };
 }
 
@@ -328,7 +329,6 @@ export class WorkspaceSettings extends UserSettings {
 
   unsetValue(setting: SettingType) {
     delete this._wsSettings[setting];
-    this._unset.add(setting);
   }
 
   read() {
@@ -363,13 +363,22 @@ export class WorkspaceSettings extends UserSettings {
     const wsSettings = this._merged(
       readJsonFileOrEmpty(wsSettingsPath),
       key => {
+        // a key a project cannot override is not this file's to remove, even
+        // though it does nothing here
+        if (!this._settings[key].wsOverridable) {
+          return { kind: 'leave' };
+        }
         const setting = this._wsSettings[key];
-        const write =
-          !!setting &&
-          this._settings[key].wsOverridable &&
+        if (
+          setting &&
           (key === SettingType.uiMode ||
-            this._isDifferentThanUserSetting(key as SettingType));
-        return { write, value: setting?.value };
+            this._isDifferentThanUserSetting(key as SettingType))
+        ) {
+          return { kind: 'write', value: setting.value };
+        }
+        // unsetValue takes it out of _wsSettings, and an override matching the
+        // global value is not an override any more
+        return { kind: 'delete' };
       }
     );
 

--- a/src/main/config/settings.ts
+++ b/src/main/config/settings.ts
@@ -148,9 +148,9 @@ function reportRejected(filePath: string): { [key: string]: any } {
   reportOnce(
     filePath,
     'shape',
-    `${filePath} holds no JSON object, so keys this build does not know may be dropped from it`
+    `${filePath} holds no JSON object, so the file is left alone until it is repaired`
   );
-  return {};
+  return undefined;
 }
 
 /**
@@ -181,7 +181,9 @@ export function resetUnreadableReports(): void {
 /**
  * What the file holds right now, or nothing when it is absent or unusable. save merges over this rather than rebuilding, so a read that fails here costs the keys this build does not know rather than corrupting the ones it does; #1115 replaces this with the shared reader.
  */
-function readJsonFileOrEmpty(filePath: string): { [key: string]: any } {
+function readJsonFileOrEmpty(
+  filePath: string
+): { [key: string]: any } | undefined {
   try {
     const parsed = JSON.parse(fs.readFileSync(filePath).toString());
     if (
@@ -206,18 +208,18 @@ function readJsonFileOrEmpty(filePath: string): { [key: string]: any } {
       reportOnce(
         filePath,
         'malformed',
-        `${filePath} is not valid JSON, so keys this build does not know may be dropped from it`,
+        `${filePath} is not valid JSON, so the file is left alone until it is repaired`,
         error
       );
-      return {};
+      return undefined;
     }
     reportOnce(
       filePath,
       'unreadable',
-      `Could not read ${filePath}, so keys this build does not know may be dropped from it`,
+      `Could not read ${filePath}, so the file is left alone until it is repaired`,
       error
     );
-    return {};
+    return undefined;
   }
 }
 
@@ -312,16 +314,18 @@ export class UserSettings {
 
   save() {
     const userSettingsPath = UserSettings.getUserSettingsPath();
-    const userSettings = this._merged(
-      readJsonFileOrEmpty(userSettingsPath),
-      key => {
-        const setting = this._settings[key];
-        // every key of SettingType is one this build owns, so one matching its default does not belong in the file, whatever the file holds
-        return setting.differentThanDefault
-          ? { kind: 'write', value: setting.value }
-          : { kind: 'delete' };
-      }
-    );
+    const onDisk = readJsonFileOrEmpty(userSettingsPath);
+    // Absent is `{}` and merging over nothing is right for it. Undefined means the file is there and we could not read it, and writing anyway is the loss this merge exists to prevent: measured on darwin, a settings.json at mode 0200 gives EACCES on the read and OK on the write, because writeFileSync opens O_WRONLY and never reads. A read failure does not imply a write failure.
+    if (onDisk === undefined) {
+      return;
+    }
+    const userSettings = this._merged(onDisk, key => {
+      const setting = this._settings[key];
+      // every key of SettingType is one this build owns, so one matching its default does not belong in the file, whatever the file holds
+      return setting.differentThanDefault
+        ? { kind: 'write', value: setting.value }
+        : { kind: 'delete' };
+    });
 
     fs.writeFileSync(userSettingsPath, JSON.stringify(userSettings, null, 2));
   }
@@ -422,25 +426,27 @@ export class WorkspaceSettings extends UserSettings {
     );
     // uiMode needs special handling, it needs to be saved even if same as global default.
     // this is due to automatically setting uiMode to Zen for default for opening single file
-    const wsSettings = this._merged(
-      readJsonFileOrEmpty(wsSettingsPath),
-      key => {
-        // a key a project cannot override is not this file's to remove, even though it does nothing here
-        if (!this._settings[key].wsOverridable) {
-          return { kind: 'leave' };
-        }
-        const setting = this._wsSettings[key];
-        if (
-          setting &&
-          (key === SettingType.uiMode ||
-            this._isDifferentThanUserSetting(key as SettingType))
-        ) {
-          return { kind: 'write', value: setting.value };
-        }
-        // unsetValue takes it out of _wsSettings, and an override matching the global value is not an override any more
-        return { kind: 'delete' };
+    const onDisk = readJsonFileOrEmpty(wsSettingsPath);
+    // same as the user file above: there and unreadable means leave it alone
+    if (onDisk === undefined) {
+      return;
+    }
+    const wsSettings = this._merged(onDisk, key => {
+      // a key a project cannot override is not this file's to remove, even though it does nothing here
+      if (!this._settings[key].wsOverridable) {
+        return { kind: 'leave' };
       }
-    );
+      const setting = this._wsSettings[key];
+      if (
+        setting &&
+        (key === SettingType.uiMode ||
+          this._isDifferentThanUserSetting(key as SettingType))
+      ) {
+        return { kind: 'write', value: setting.value };
+      }
+      // unsetValue takes it out of _wsSettings, and an override matching the global value is not an override any more
+      return { kind: 'delete' };
+    });
 
     // Write when there is something to persist, or when a previous file needs
     // to be cleared. mkdir is unconditional: recursive mode is a no-op when the

--- a/src/main/config/settings.ts
+++ b/src/main/config/settings.ts
@@ -140,6 +140,17 @@ export namespace Setting {
 // Reported once per path per run. Eighteen call sites reach save(), so a condition that persists — an antivirus pass holding the file, a permission that stayed wrong — would otherwise put the same line in the log on every settings change, which is the reason this repository already gives for leaving the directory flush at debug.
 const reportedUnreadable = new Set<string>();
 
+/** Say once per path that the file was there and unusable, and give back the empty object the caller merges over. */
+function reportRejected(filePath: string): { [key: string]: any } {
+  if (!reportedUnreadable.has(filePath)) {
+    reportedUnreadable.add(filePath);
+    log.error(
+      `${filePath} holds no JSON object, so keys this build does not know may be dropped from it`
+    );
+  }
+  return {};
+}
+
 /** Only for tests: the set above outlives them otherwise, and the second one to run reads as silent because the first already reported. */
 export function resetUnreadableReports(): void {
   reportedUnreadable.clear();
@@ -151,11 +162,13 @@ export function resetUnreadableReports(): void {
 function readJsonFileOrEmpty(filePath: string): { [key: string]: any } {
   try {
     const parsed = JSON.parse(fs.readFileSync(filePath).toString());
+    // a later break in the same run has to be able to say so, or a support log collected that evening shows the first one and not the current state
+    reportedUnreadable.delete(filePath);
     return parsed !== null &&
       typeof parsed === 'object' &&
       !Array.isArray(parsed)
       ? parsed
-      : {};
+      : reportRejected(filePath);
   } catch (error) {
     // Absent is the ordinary case and merging over nothing is right for it. Anything else means the file is there and we could not read it, and merging over {} would delete every key this build does not know, which is the loss this merge exists to prevent. The case that actually reaches the write is the parse failure: `userSettings` is constructed once at import, so a user who follows troubleshoot.md and hand-edits settings.json while the app runs, leaving a trailing comma, gets the SyntaxError caught here and will-quit rewrites the file without their edit. An EBUSY or EACCES would fail the writeFileSync below as well, so those throw rather than lose quietly. Say so; the shared reader in #1115 refuses the write outright, which is the better answer and is not this branch's to add.
     if (

--- a/src/main/config/settings.ts
+++ b/src/main/config/settings.ts
@@ -144,7 +144,7 @@ const reportedUnreadable = new Map<
 >();
 
 /** Say once per path that the file was there and unusable, and give back the empty object the caller merges over. */
-function reportRejected(filePath: string): { [key: string]: any } {
+function reportRejected(filePath: string): undefined {
   reportOnce(
     filePath,
     'shape',
@@ -197,7 +197,7 @@ function readJsonFileOrEmpty(
     reportedUnreadable.delete(filePath);
     return parsed;
   } catch (error) {
-    // Absent is the ordinary case and merging over nothing is right for it. Anything else means the file is there and we could not read it, and merging over {} would delete every key this build does not know, which is the loss this merge exists to prevent. The case that actually reaches the write is the parse failure: `userSettings` is constructed once at import, so a user who follows troubleshoot.md and hand-edits settings.json while the app runs, leaving a trailing comma, gets the SyntaxError caught here and will-quit rewrites the file without their edit. An EBUSY or EACCES would fail the writeFileSync below as well, so those throw rather than lose quietly. Say so; the shared reader in #1115 refuses the write outright, which is the better answer and is not this branch's to add.
+    // Absent is the ordinary case and merging over nothing is right for it. Anything else means the file is there and we could not read it, and merging over {} would delete every key this build does not know, which is the loss this merge exists to prevent. The case that actually reaches the write is the parse failure: `userSettings` is constructed once at import, so a user who follows troubleshoot.md and hand-edits settings.json while the app runs, leaving a trailing comma, gets the SyntaxError caught here and will-quit rewrites the file without their edit. Measured on darwin: a settings.json at mode 0200 gives EACCES on the read and OK on the write, because writeFileSync opens O_WRONLY and never reads, so a read failure does not imply a write failure and the loss lands. The file is left alone instead, which is what #1115's shared reader will do through a different route.
     if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
       // gone rather than broken, so whatever was reported about it no longer describes anything
       reportedUnreadable.delete(filePath);
@@ -312,12 +312,12 @@ export class UserSettings {
     }
   }
 
-  save() {
+  save(): boolean {
     const userSettingsPath = UserSettings.getUserSettingsPath();
     const onDisk = readJsonFileOrEmpty(userSettingsPath);
     // Absent is `{}` and merging over nothing is right for it. Undefined means the file is there and we could not read it, and writing anyway is the loss this merge exists to prevent: measured on darwin, a settings.json at mode 0200 gives EACCES on the read and OK on the write, because writeFileSync opens O_WRONLY and never reads. A read failure does not imply a write failure.
     if (onDisk === undefined) {
-      return;
+      return false;
     }
     const userSettings = this._merged(onDisk, key => {
       const setting = this._settings[key];
@@ -328,6 +328,7 @@ export class UserSettings {
     });
 
     fs.writeFileSync(userSettingsPath, JSON.stringify(userSettings, null, 2));
+    return true;
   }
 
   /**
@@ -420,7 +421,7 @@ export class WorkspaceSettings extends UserSettings {
     }
   }
 
-  save() {
+  save(): boolean {
     const wsSettingsPath = WorkspaceSettings.getWorkspaceSettingsPath(
       this._workingDirectory
     );
@@ -429,7 +430,7 @@ export class WorkspaceSettings extends UserSettings {
     const onDisk = readJsonFileOrEmpty(wsSettingsPath);
     // same as the user file above: there and unreadable means leave it alone
     if (onDisk === undefined) {
-      return;
+      return false;
     }
     const wsSettings = this._merged(onDisk, key => {
       // a key a project cannot override is not this file's to remove, even though it does nothing here
@@ -455,6 +456,8 @@ export class WorkspaceSettings extends UserSettings {
       fs.mkdirSync(path.dirname(wsSettingsPath), { recursive: true });
       fs.writeFileSync(wsSettingsPath, JSON.stringify(wsSettings, null, 2));
     }
+    // true also when there was nothing to write and no file to clear, which is not a failure. #1114 carries the case where a caller reads that as a value having been persisted.
+    return true;
   }
 
   private _isDifferentThanUserSetting(setting: SettingType): boolean {

--- a/src/main/config/settings.ts
+++ b/src/main/config/settings.ts
@@ -137,6 +137,14 @@ export namespace Setting {
   }
 }
 
+// Reported once per path per run. Eighteen call sites reach save(), so a condition that persists — an antivirus pass holding the file, a permission that stayed wrong — would otherwise put the same line in the log on every settings change, which is the reason this repository already gives for leaving the directory flush at debug.
+const reportedUnreadable = new Set<string>();
+
+/** Only for tests: the set above outlives them otherwise, and the second one to run reads as silent because the first already reported. */
+export function resetUnreadableReports(): void {
+  reportedUnreadable.clear();
+}
+
 /**
  * What the file holds right now, or nothing when it is absent or unusable. save merges over this rather than rebuilding, so a read that fails here costs the keys this build does not know rather than corrupting the ones it does; #1115 replaces this with the shared reader.
  */
@@ -150,7 +158,11 @@ function readJsonFileOrEmpty(filePath: string): { [key: string]: any } {
       : {};
   } catch (error) {
     // Absent is the ordinary case and merging over nothing is right for it. Anything else means the file is there and we could not read it this once — EBUSY while an antivirus or backup pass holds it on Windows, EACCES after a permission change, EMFILE under descriptor pressure — and merging over {} would delete every key this build does not know, which is the loss this merge exists to prevent, silently and with the write reporting success. Say so; the shared reader in #1115 refuses the write outright, which is the better answer and is not this branch's to add.
-    if ((error as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+    if (
+      (error as NodeJS.ErrnoException)?.code !== 'ENOENT' &&
+      !reportedUnreadable.has(filePath)
+    ) {
+      reportedUnreadable.add(filePath);
       log.error(
         `Could not read ${filePath}, so keys this build does not know may be dropped from it`,
         error

--- a/src/main/config/settings.ts
+++ b/src/main/config/settings.ts
@@ -3,6 +3,7 @@
 
 import * as path from 'path';
 import * as fs from 'fs';
+import log from 'electron-log';
 import { getUserDataDir, getUserHomeDir } from '../utils';
 
 export const DEFAULT_WIN_WIDTH = 1024;
@@ -147,7 +148,14 @@ function readJsonFileOrEmpty(filePath: string): { [key: string]: any } {
       !Array.isArray(parsed)
       ? parsed
       : {};
-  } catch {
+  } catch (error) {
+    // Absent is the ordinary case and merging over nothing is right for it. Anything else means the file is there and we could not read it this once — EBUSY while an antivirus or backup pass holds it on Windows, EACCES after a permission change, EMFILE under descriptor pressure — and merging over {} would delete every key this build does not know, which is the loss this merge exists to prevent, silently and with the write reporting success. Say so; the shared reader in #1115 refuses the write outright, which is the better answer and is not this branch's to add.
+    if ((error as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+      log.error(
+        `Could not read ${filePath}, so keys this build does not know may be dropped from it`,
+        error
+      );
+    }
     return {};
   }
 }

--- a/src/main/config/settings.ts
+++ b/src/main/config/settings.ts
@@ -138,7 +138,10 @@ export namespace Setting {
 }
 
 // Reported once per path per run. Eighteen call sites reach save(), so a condition that persists, an antivirus pass holding the file, a permission that stayed wrong, would otherwise put the same line in the log on every settings change, which is the reason this repository already gives for leaving the directory flush at debug.
-const reportedUnreadable = new Map<string, 'unreadable' | 'shape'>();
+const reportedUnreadable = new Map<
+  string,
+  'unreadable' | 'malformed' | 'shape'
+>();
 
 /** Say once per path that the file was there and unusable, and give back the empty object the caller merges over. */
 function reportRejected(filePath: string): { [key: string]: any } {
@@ -155,7 +158,7 @@ function reportRejected(filePath: string): { [key: string]: any } {
  */
 function reportOnce(
   filePath: string,
-  kind: 'unreadable' | 'shape',
+  kind: 'unreadable' | 'malformed' | 'shape',
   message: string,
   error?: unknown
 ): void {
@@ -196,6 +199,16 @@ function readJsonFileOrEmpty(filePath: string): { [key: string]: any } {
     if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
       // gone rather than broken, so whatever was reported about it no longer describes anything
       reportedUnreadable.delete(filePath);
+      return {};
+    }
+    // A SyntaxError is the case this function's comment names as the one that reaches the write, and it is the one a reader can fix. Saying "could not read" about it sends them to look at permissions instead of at the trailing comma they just typed. Its own kind rather than reusing 'unreadable', or by the dedup's own rule a file that goes EACCES and then malformed would stay silent on the second break.
+    if (error instanceof SyntaxError) {
+      reportOnce(
+        filePath,
+        'malformed',
+        `${filePath} is not valid JSON, so keys this build does not know may be dropped from it`,
+        error
+      );
       return {};
     }
     reportOnce(

--- a/src/main/config/settings.ts
+++ b/src/main/config/settings.ts
@@ -138,17 +138,36 @@ export namespace Setting {
 }
 
 // Reported once per path per run. Eighteen call sites reach save(), so a condition that persists, an antivirus pass holding the file, a permission that stayed wrong, would otherwise put the same line in the log on every settings change, which is the reason this repository already gives for leaving the directory flush at debug.
-const reportedUnreadable = new Set<string>();
+const reportedUnreadable = new Map<string, 'unreadable' | 'shape'>();
 
 /** Say once per path that the file was there and unusable, and give back the empty object the caller merges over. */
 function reportRejected(filePath: string): { [key: string]: any } {
-  if (!reportedUnreadable.has(filePath)) {
-    reportedUnreadable.add(filePath);
-    log.error(
-      `${filePath} holds no JSON object, so keys this build does not know may be dropped from it`
-    );
-  }
+  reportOnce(
+    filePath,
+    'shape',
+    `${filePath} holds no JSON object, so keys this build does not know may be dropped from it`
+  );
   return {};
+}
+
+/**
+ * Say it once per path, and again when the file breaks a different way. Keyed by kind rather than by path alone: a file that fails to parse and then comes back as an array is two different things to repair, and remembering only that "this path was reported" left the second one silent with the first one's wording standing in a support log.
+ */
+function reportOnce(
+  filePath: string,
+  kind: 'unreadable' | 'shape',
+  message: string,
+  error?: unknown
+): void {
+  if (reportedUnreadable.get(filePath) === kind) {
+    return;
+  }
+  reportedUnreadable.set(filePath, kind);
+  if (error === undefined) {
+    log.error(message);
+  } else {
+    log.error(message, error);
+  }
 }
 
 /** Only for tests: the set above outlives them otherwise, and the second one to run reads as silent because the first already reported. */
@@ -174,16 +193,17 @@ function readJsonFileOrEmpty(filePath: string): { [key: string]: any } {
     return parsed;
   } catch (error) {
     // Absent is the ordinary case and merging over nothing is right for it. Anything else means the file is there and we could not read it, and merging over {} would delete every key this build does not know, which is the loss this merge exists to prevent. The case that actually reaches the write is the parse failure: `userSettings` is constructed once at import, so a user who follows troubleshoot.md and hand-edits settings.json while the app runs, leaving a trailing comma, gets the SyntaxError caught here and will-quit rewrites the file without their edit. An EBUSY or EACCES would fail the writeFileSync below as well, so those throw rather than lose quietly. Say so; the shared reader in #1115 refuses the write outright, which is the better answer and is not this branch's to add.
-    if (
-      (error as NodeJS.ErrnoException)?.code !== 'ENOENT' &&
-      !reportedUnreadable.has(filePath)
-    ) {
-      reportedUnreadable.add(filePath);
-      log.error(
-        `Could not read ${filePath}, so keys this build does not know may be dropped from it`,
-        error
-      );
+    if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
+      // gone rather than broken, so whatever was reported about it no longer describes anything
+      reportedUnreadable.delete(filePath);
+      return {};
     }
+    reportOnce(
+      filePath,
+      'unreadable',
+      `Could not read ${filePath}, so keys this build does not know may be dropped from it`,
+      error
+    );
     return {};
   }
 }

--- a/src/main/config/settings.ts
+++ b/src/main/config/settings.ts
@@ -157,7 +157,7 @@ function readJsonFileOrEmpty(filePath: string): { [key: string]: any } {
       ? parsed
       : {};
   } catch (error) {
-    // Absent is the ordinary case and merging over nothing is right for it. Anything else means the file is there and we could not read it this once — EBUSY while an antivirus or backup pass holds it on Windows, EACCES after a permission change, EMFILE under descriptor pressure — and merging over {} would delete every key this build does not know, which is the loss this merge exists to prevent, silently and with the write reporting success. Say so; the shared reader in #1115 refuses the write outright, which is the better answer and is not this branch's to add.
+    // Absent is the ordinary case and merging over nothing is right for it. Anything else means the file is there and we could not read it, and merging over {} would delete every key this build does not know, which is the loss this merge exists to prevent. The case that actually reaches the write is the parse failure: `userSettings` is constructed once at import, so a user who follows troubleshoot.md and hand-edits settings.json while the app runs, leaving a trailing comma, gets the SyntaxError caught here and will-quit rewrites the file without their edit. An EBUSY or EACCES would fail the writeFileSync below as well, so those throw rather than lose quietly. Say so; the shared reader in #1115 refuses the write outright, which is the better answer and is not this branch's to add.
     if (
       (error as NodeJS.ErrnoException)?.code !== 'ENOENT' &&
       !reportedUnreadable.has(filePath)

--- a/src/main/config/settings.ts
+++ b/src/main/config/settings.ts
@@ -314,7 +314,7 @@ export class UserSettings {
   }
 
   /**
-   * The file as it is on disk, with this object's settings written over it. Rebuilding from the settings alone deletes every key the build has no setting for, and every value the read declined to take.
+   * The file as it is on disk, with this object's settings written over it. Rebuilding from the settings alone deletes every key the build has no setting for. It does not preserve a value the read declined to take: a key this build owns is written or deleted by the decision below, and `UserSettings.save` deletes any that equals its default, which is what a declining read leaves behind. Keeping those is #1116's question, not this one's.
    */
   protected _merged(
     onDisk: { [key: string]: any },

--- a/src/main/config/settings.ts
+++ b/src/main/config/settings.ts
@@ -143,7 +143,7 @@ const reportedUnreadable = new Map<
   'unreadable' | 'malformed' | 'shape'
 >();
 
-/** Say once per path that the file was there and unusable, and give back the empty object the caller merges over. */
+/** Say once per path that the file was there and unusable, and give back the sentinel that tells the caller to leave the file alone rather than merge over it. */
 function reportRejected(filePath: string): undefined {
   reportOnce(
     filePath,
@@ -425,8 +425,6 @@ export class WorkspaceSettings extends UserSettings {
     const wsSettingsPath = WorkspaceSettings.getWorkspaceSettingsPath(
       this._workingDirectory
     );
-    // uiMode needs special handling, it needs to be saved even if same as global default.
-    // this is due to automatically setting uiMode to Zen for default for opening single file
     const onDisk = readJsonFileOrEmpty(wsSettingsPath);
     // same as the user file above: there and unreadable means leave it alone
     if (onDisk === undefined) {
@@ -440,6 +438,7 @@ export class WorkspaceSettings extends UserSettings {
       const setting = this._wsSettings[key];
       if (
         setting &&
+        // uiMode is saved even when it matches the global default, because opening a single file sets it to Zen automatically and a project that matched by coincidence would lose the override
         (key === SettingType.uiMode ||
           this._isDifferentThanUserSetting(key as SettingType))
       ) {

--- a/src/main/config/settings.ts
+++ b/src/main/config/settings.ts
@@ -303,6 +303,7 @@ export class UserSettings {
       return;
     }
     const data = fs.readFileSync(userSettingsPath);
+    // Unguarded on purpose, and worth saying because the reader above makes it look otherwise: this branch protects the *write*, not the read. `userSettings` is constructed at module import, so a settings.json edited into invalid JSON while the app is closed throws here before app.whenReady and the app does not start at all. Only the mid-run edit reaches readJsonFileOrEmpty's catch and gets the file left alone. Guarding this one is #1115, which replaces both call sites with a shared reader.
     const jsonData = JSON.parse(data.toString());
 
     for (let key in SettingType) {

--- a/src/main/config/settings.ts
+++ b/src/main/config/settings.ts
@@ -137,7 +137,7 @@ export namespace Setting {
   }
 }
 
-// Reported once per path per run. Eighteen call sites reach save(), so a condition that persists — an antivirus pass holding the file, a permission that stayed wrong — would otherwise put the same line in the log on every settings change, which is the reason this repository already gives for leaving the directory flush at debug.
+// Reported once per path per run. Eighteen call sites reach save(), so a condition that persists, an antivirus pass holding the file, a permission that stayed wrong, would otherwise put the same line in the log on every settings change, which is the reason this repository already gives for leaving the directory flush at debug.
 const reportedUnreadable = new Set<string>();
 
 /** Say once per path that the file was there and unusable, and give back the empty object the caller merges over. */
@@ -162,13 +162,16 @@ export function resetUnreadableReports(): void {
 function readJsonFileOrEmpty(filePath: string): { [key: string]: any } {
   try {
     const parsed = JSON.parse(fs.readFileSync(filePath).toString());
-    // a later break in the same run has to be able to say so, or a support log collected that evening shows the first one and not the current state
+    if (
+      parsed === null ||
+      typeof parsed !== 'object' ||
+      Array.isArray(parsed)
+    ) {
+      return reportRejected(filePath);
+    }
+    // Only here, on a read that actually produced an object. Clearing it before the shape check undid the dedup for a file that parses and is not an object, which then logged on every save while a parse failure logged once. A later break in the same run still has to say so, or a support log collected that evening shows the first one rather than the current state.
     reportedUnreadable.delete(filePath);
-    return parsed !== null &&
-      typeof parsed === 'object' &&
-      !Array.isArray(parsed)
-      ? parsed
-      : reportRejected(filePath);
+    return parsed;
   } catch (error) {
     // Absent is the ordinary case and merging over nothing is right for it. Anything else means the file is there and we could not read it, and merging over {} would delete every key this build does not know, which is the loss this merge exists to prevent. The case that actually reaches the write is the parse failure: `userSettings` is constructed once at import, so a user who follows troubleshoot.md and hand-edits settings.json while the app runs, leaving a trailing comma, gets the SyntaxError caught here and will-quit rewrites the file without their edit. An EBUSY or EACCES would fail the writeFileSync below as well, so those throw rather than lose quietly. Say so; the shared reader in #1115 refuses the write outright, which is the better answer and is not this branch's to add.
     if (

--- a/test/unit/cli-handlers.test.ts
+++ b/test/unit/cli-handlers.test.ts
@@ -361,9 +361,7 @@ describe('handleEnvActivateCommand', () => {
   });
 });
 
-// Neither refusal had a test: the handlers were not exported, so mutating either guard away left
-// the whole suite green. `set` got its guard three rounds before `unset` did, and the gap between
-// them is the shape this branch already carries a note about, a guard written on one side only.
+// Neither refusal had a test: the handlers were not exported, so mutating either guard away left the whole suite green. `set` got its guard three rounds before `unset` did, and the gap between them is the shape this branch already carries a note about, a guard written on one side only.
 describe('a config command that could not write says so', () => {
   let exit: ReturnType<typeof vi.spyOn>;
   beforeEach(() => {

--- a/test/unit/cli-handlers.test.ts
+++ b/test/unit/cli-handlers.test.ts
@@ -32,21 +32,42 @@ vi.mock('../../src/main/config/appdata', () => ({
   },
   ApplicationData: { getSingleton: vi.fn() }
 }));
+// Hoisted, because a vi.mock factory runs above every const. Hard-coding save to one value leaves the other branch unreachable and the suite green whichever way it goes.
+const cfg = vi.hoisted(() => ({ saveResult: true }));
+
 vi.mock('../../src/main/config/settings', () => ({
   userSettings: {
     getValue: vi.fn(() => ''),
     setValue: vi.fn(),
-    save: vi.fn()
+    unsetValue: vi.fn(),
+    save: vi.fn(() => cfg.saveResult),
+    // the config handlers read this to decide whether a key may be overridden per project
+    settings: { theme: { wsOverridable: true } }
   },
   SettingType: {
     pythonPath: 'pythonPath',
     pythonEnvsPath: 'pythonEnvsPath',
     condaPath: 'condaPath',
     condaChannels: 'condaChannels',
-    systemPythonPath: 'systemPythonPath'
+    systemPythonPath: 'systemPythonPath',
+    theme: 'theme'
   },
   UserSettings: vi.fn(),
-  WorkspaceSettings: vi.fn()
+  // an arrow function cannot be used with `new`, and a bare vi.fn() builds an object with none of the methods the handler calls
+  WorkspaceSettings: Object.assign(
+    vi.fn().mockImplementation(function () {
+      return {
+        setValue: vi.fn(),
+        unsetValue: vi.fn(),
+        save: vi.fn(() => cfg.saveResult)
+      };
+    } as any),
+    {
+      getWorkspaceSettingsPath: vi.fn(
+        (dir: string) => `${dir}/.jupyter/desktop-settings.json`
+      )
+    }
+  )
 }));
 vi.mock('../../src/main/utils', () => ({
   getBundledPythonPath: vi.fn(() => '/bundled/python'),
@@ -90,6 +111,8 @@ vi.mock('../../src/main/registry', () => ({ Registry: vi.fn() }));
 
 import {
   addUserSetEnvironment,
+  handleConfigSetCommand,
+  handleConfigUnsetCommand,
   handleEnvActivateCommand,
   handleEnvSetCondaChannelsCommand,
   handleEnvSetCondaPathCommand,
@@ -336,4 +359,46 @@ describe('handleEnvActivateCommand', () => {
     errorSpy.mockRestore();
     logSpy.mockRestore();
   });
+});
+
+// Neither refusal had a test: the handlers were not exported, so mutating either guard away left
+// the whole suite green. `set` got its guard three rounds before `unset` did, and the gap between
+// them is the shape this branch already carries a note about, a guard written on one side only.
+describe('a config command that could not write says so', () => {
+  let exit: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    cfg.saveResult = false;
+    exit = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined) as any);
+  });
+  afterEach(() => {
+    cfg.saveResult = true;
+    exit.mockRestore();
+  });
+
+  for (const [name, run] of [
+    ['set', () => handleConfigSetCommand({ _: ['set', 'theme', 'dark'] })],
+    ['unset', () => handleConfigUnsetCommand({ _: ['unset', 'theme'] })]
+  ] as const) {
+    it(`${name} does not claim success over a refused write`, () => {
+      const err = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => undefined);
+      const out = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+      try {
+        run();
+
+        expect(err).toHaveBeenCalledWith(
+          expect.stringContaining('Could not write the settings file')
+        );
+        const said = out.mock.calls.map(c => String(c[0])).join('\n');
+        expect(said).not.toContain('successfully');
+      } finally {
+        err.mockRestore();
+        out.mockRestore();
+      }
+    });
+  }
 });

--- a/test/unit/settings.test.ts
+++ b/test/unit/settings.test.ts
@@ -249,6 +249,26 @@ describe('UserSettings', () => {
     expect(written).toEqual({});
   });
 
+  it('drops a key whose value is back to the default', () => {
+    // merging over the file means the on-disk value survives unless something
+    // takes it out, and a setting that no longer differs is one of those
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.readFileSync = vi.fn(() =>
+      Buffer.from(JSON.stringify({ showNewsFeed: false }))
+    ) as any;
+    mockFs.writeFileSync = vi.fn();
+
+    const us = new UserSettings(true);
+    us.setValue(SettingType.showNewsFeed, true); // true is the default
+
+    us.save();
+
+    const written = JSON.parse(
+      (mockFs.writeFileSync as any).mock.calls[0][1] as string
+    );
+    expect('showNewsFeed' in written).toBe(false);
+  });
+
   it('writes back a key it has no setting for', () => {
     // save merges over the file rather than rebuilding it, or a settings.json
     // written by a newer build loses whatever this one does not recognise, and

--- a/test/unit/settings.test.ts
+++ b/test/unit/settings.test.ts
@@ -190,4 +190,23 @@ describe('UserSettings', () => {
     expect(written).toHaveProperty('theme', ThemeType.Light);
     expect(written).not.toHaveProperty('logLevel');
   });
+
+  it('writes back a key it has no setting for', () => {
+    // save rebuilds the file, so a key left out of it is a key deleted from
+    // disk: a settings.json written by a newer build loses whatever this one
+    // does not recognise, and troubleshoot.md sends people to edit this by hand
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.readFileSync = vi.fn(() =>
+      Buffer.from(JSON.stringify({ futureSetting: 42, theme: 'dark' }))
+    ) as any;
+    mockFs.writeFileSync = vi.fn();
+
+    const us = new UserSettings(true);
+    us.save();
+
+    const written = JSON.parse(
+      (mockFs.writeFileSync as any).mock.calls[0][1] as string
+    );
+    expect(written).toEqual({ futureSetting: 42, theme: 'dark' });
+  });
 });

--- a/test/unit/settings.test.ts
+++ b/test/unit/settings.test.ts
@@ -9,8 +9,7 @@ vi.mock('fs', async () => {
     lstatSync: vi.fn(),
     mkdirSync: vi.fn(),
     writeFileSync: vi.fn(),
-    // a vi.fn() with no implementation returns undefined, and the reader calls
-    // .toString() on it: throw what fs throws for a missing file instead
+    // a vi.fn() with no implementation returns undefined, and the reader calls .toString() on it: throw what fs throws for a missing file instead
     readFileSync: vi.fn(() => {
       throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
     })
@@ -35,8 +34,7 @@ import {
 
 const mockFs = vi.mocked(fs);
 
-// save() reads the file before merging over it, so a stub left set by one test
-// would feed the next one whatever the previous body returned
+// save() reads the file before merging over it, so a stub left set by one test would feed the next one whatever the previous body returned
 beforeEach(() => {
   vi.clearAllMocks();
   mockFs.existsSync = vi.fn();
@@ -210,9 +208,7 @@ describe('UserSettings', () => {
   });
 
   it('does not let a __proto__ key out of the file reach Object.prototype', () => {
-    // read walks SettingType rather than the file, so nothing out of the file
-    // ever indexes _settings. Walking the file instead resolved '__proto__' to
-    // Object.prototype and assigned onto it, at module import.
+    // read walks SettingType rather than the file, so nothing out of the file ever indexes _settings. Walking the file instead resolved '__proto__' to Object.prototype and assigned onto it, at module import.
     mockFs.existsSync = vi.fn(() => true);
     mockFs.readFileSync = vi.fn(() =>
       Buffer.from('{"__proto__":{"pwned":1},"theme":"dark"}')
@@ -250,8 +246,7 @@ describe('UserSettings', () => {
   });
 
   it('drops a key whose value is back to the default', () => {
-    // merging over the file means the on-disk value survives unless something
-    // takes it out, and a setting that no longer differs is one of those
+    // merging over the file means the on-disk value survives unless something takes it out, and a setting that no longer differs is one of those
     mockFs.existsSync = vi.fn(() => true);
     mockFs.readFileSync = vi.fn(() =>
       Buffer.from(JSON.stringify({ showNewsFeed: false }))
@@ -270,9 +265,7 @@ describe('UserSettings', () => {
   });
 
   it('writes back a key it has no setting for', () => {
-    // save merges over the file rather than rebuilding it, or a settings.json
-    // written by a newer build loses whatever this one does not recognise, and
-    // troubleshoot.md sends people to edit this file by hand
+    // save merges over the file rather than rebuilding it, or a settings.json written by a newer build loses whatever this one does not recognise, and troubleshoot.md sends people to edit this file by hand
     mockFs.existsSync = vi.fn(() => true);
     mockFs.readFileSync = vi.fn(() =>
       Buffer.from(JSON.stringify({ futureSetting: 42, theme: 'dark' }))

--- a/test/unit/settings.test.ts
+++ b/test/unit/settings.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'fs';
 
 vi.mock('fs', async () => {
@@ -8,7 +8,12 @@ vi.mock('fs', async () => {
     existsSync: vi.fn(),
     lstatSync: vi.fn(),
     mkdirSync: vi.fn(),
-    writeFileSync: vi.fn()
+    writeFileSync: vi.fn(),
+    // a vi.fn() with no implementation returns undefined, and the reader calls
+    // .toString() on it: throw what fs throws for a missing file instead
+    readFileSync: vi.fn(() => {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    })
   };
 });
 
@@ -29,6 +34,19 @@ import {
 } from '../../src/main/config/settings';
 
 const mockFs = vi.mocked(fs);
+
+// save() reads the file before merging over it, so a stub left set by one test
+// would feed the next one whatever the previous body returned
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFs.existsSync = vi.fn();
+  mockFs.lstatSync = vi.fn();
+  mockFs.mkdirSync = vi.fn();
+  mockFs.writeFileSync = vi.fn();
+  mockFs.readFileSync = vi.fn(() => {
+    throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+  }) as any;
+});
 
 describe('constants', () => {
   it('DEFAULT_WIN_WIDTH is 1024', () => expect(DEFAULT_WIN_WIDTH).toBe(1024));
@@ -191,10 +209,50 @@ describe('UserSettings', () => {
     expect(written).not.toHaveProperty('logLevel');
   });
 
+  it('does not let a __proto__ key out of the file reach Object.prototype', () => {
+    // read walks SettingType rather than the file, so nothing out of the file
+    // ever indexes _settings. Walking the file instead resolved '__proto__' to
+    // Object.prototype and assigned onto it, at module import.
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.readFileSync = vi.fn(() =>
+      Buffer.from('{"__proto__":{"pwned":1},"theme":"dark"}')
+    ) as any;
+    mockFs.writeFileSync = vi.fn();
+
+    try {
+      const us = new UserSettings(true);
+      us.save();
+
+      expect(({} as any).value).toBeUndefined();
+      expect(({} as any).pwned).toBeUndefined();
+      // and it is still written back, rather than dropped
+      const written = (mockFs.writeFileSync as any).mock.calls[0][1] as string;
+      expect(written).toContain('__proto__');
+    } finally {
+      delete (Object.prototype as any).value;
+      delete (Object.prototype as any).pwned;
+    }
+  });
+
+  it('takes nothing from a file whose top level is not an object', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.readFileSync = vi.fn(() => Buffer.from('[1,2,3]')) as any;
+    mockFs.writeFileSync = vi.fn();
+
+    const us = new UserSettings(true);
+    us.save();
+
+    // spreading an array would have written {"0":1,"1":2,"2":3}
+    const written = JSON.parse(
+      (mockFs.writeFileSync as any).mock.calls[0][1] as string
+    );
+    expect(written).toEqual({});
+  });
+
   it('writes back a key it has no setting for', () => {
-    // save rebuilds the file, so a key left out of it is a key deleted from
-    // disk: a settings.json written by a newer build loses whatever this one
-    // does not recognise, and troubleshoot.md sends people to edit this by hand
+    // save merges over the file rather than rebuilding it, or a settings.json
+    // written by a newer build loses whatever this one does not recognise, and
+    // troubleshoot.md sends people to edit this file by hand
     mockFs.existsSync = vi.fn(() => true);
     mockFs.readFileSync = vi.fn(() =>
       Buffer.from(JSON.stringify({ futureSetting: 42, theme: 'dark' }))

--- a/test/unit/settings.test.ts
+++ b/test/unit/settings.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'fs';
+import log from 'electron-log';
 
 vi.mock('fs', async () => {
   const actual = await vi.importActual<typeof import('fs')>('fs');
@@ -219,6 +220,7 @@ describe('UserSettings', () => {
       const us = new UserSettings(true);
       us.save();
 
+      // These two are for the merge, not for the read: swapping `{ ...onDisk }` for `Object.assign({}, onDisk)` is what makes them fire, since assign sets where spread defines. Measured: with the read walking the file instead of the enum, the test still goes red with both of them deleted, and the assertion below is what catches that one.
       expect(({} as any).value).toBeUndefined();
       expect(({} as any).pwned).toBeUndefined();
       // and it is still written back, rather than dropped
@@ -253,7 +255,42 @@ describe('UserSettings', () => {
     expect(({} as any).c).toBeUndefined();
   });
 
-  it('takes nothing from a file whose top level is not an object', () => {
+  // The catch used to swallow both cases the same way, and merging over {} deletes every key this build does not know: the loss this merge exists to prevent, with the write reporting success.
+  it('says so when the file is there and could not be read', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    let reads = 0;
+    mockFs.readFileSync = vi.fn(() => {
+      // readable at construction, unreadable by the time save re-reads it
+      if (reads++ === 0) {
+        return Buffer.from('{"futureSetting":42,"theme":"dark"}');
+      }
+      throw Object.assign(new Error('EBUSY'), { code: 'EBUSY' });
+    }) as any;
+    mockFs.writeFileSync = vi.fn();
+
+    const us = new UserSettings(true);
+    us.save();
+
+    expect(log.error).toHaveBeenCalledWith(
+      expect.stringContaining('may be dropped'),
+      expect.anything()
+    );
+  });
+
+  it('says nothing when the file is simply absent', () => {
+    mockFs.existsSync = vi.fn(() => false);
+    mockFs.readFileSync = vi.fn(() => {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    }) as any;
+    mockFs.writeFileSync = vi.fn();
+
+    new UserSettings(true).save();
+
+    expect(log.error).not.toHaveBeenCalled();
+  });
+
+  // `[1,2,3]` is the only non-object shape that survives read(): null, a number and a string all throw out of `key in jsonData`, and that throw is #1115's to catch, not this branch's.
+  it('takes nothing from an array at the top level', () => {
     mockFs.existsSync = vi.fn(() => true);
     mockFs.readFileSync = vi.fn(() => Buffer.from('[1,2,3]')) as any;
     mockFs.writeFileSync = vi.fn();

--- a/test/unit/settings.test.ts
+++ b/test/unit/settings.test.ts
@@ -221,10 +221,12 @@ describe('UserSettings', () => {
       const us = new UserSettings(true);
       us.save();
 
-      // These two are for the merge, not for the read: swapping `{ ...onDisk }` for `Object.assign({}, onDisk)` is what makes them fire, since assign sets where spread defines. Measured: with the read walking the file instead of the enum, the test still goes red with both of them deleted, and the assertion below is what catches that one.
+      // Measured one assertion at a time against both mutations, because the first attempt at this comment asserted the opposite and was wrong. Against `read` walking the file instead of the enum, all three fire. Against the merge, `{ ...onDisk }` swapped for `Object.assign({}, onDisk)`, only the round-trip below fires: assign invokes the `__proto__` setter on `merged`, which retargets that object's own prototype and never touches `Object.prototype`, so neither probe sees it.
+      //
+      // These two are the pollution probes, and they are what a future change that writes onto the prototype would trip.
       expect(({} as any).value).toBeUndefined();
       expect(({} as any).pwned).toBeUndefined();
-      // and it is still written back, rather than dropped
+      // This one is the merge guard, and the only assertion here that catches the spread being swapped for assign. It reads as the redundant one next to two prototype checks, which is exactly why it says so.
       const written = (mockFs.writeFileSync as any).mock.calls[0][1] as string;
       expect(written).toContain('__proto__');
     } finally {

--- a/test/unit/settings.test.ts
+++ b/test/unit/settings.test.ts
@@ -444,6 +444,20 @@ describe('UserSettings', () => {
     expect(breakages(['{"a":1}', 'EBUSY', '{"theme":"dark",}'])).toBe(2);
   });
 
+  // The boolean exists so a caller can tell; without it `jlab config set` printed success over a write that was declined.
+  it('reports the refusal to its caller', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    let n = 0;
+    mockFs.readFileSync = vi.fn(() =>
+      Buffer.from(n++ === 0 ? '{"a":1}' : '[1,2,3]')
+    ) as any;
+    mockFs.writeFileSync = vi.fn();
+
+    const us = new UserSettings(true);
+
+    expect(us.save()).toBe(false);
+  });
+
   it('says nothing when the file is simply absent', () => {
     mockFs.existsSync = vi.fn(() => false);
     mockFs.readFileSync = vi.fn(() => {

--- a/test/unit/settings.test.ts
+++ b/test/unit/settings.test.ts
@@ -323,7 +323,23 @@ describe('UserSettings', () => {
     expect(vi.mocked(log.error).mock.calls).toHaveLength(2);
   });
 
-  // Rejected for its shape rather than for a parse failure, and it wipes the file the same way, so it cannot be the one case that says nothing.
+  // Rejected for its shape rather than for a parse failure, and it wipes the file the same way, so it cannot be the one case that says nothing. `new UserSettings(false)` skips read(), so save() reaches the guard with shapes that read() would have thrown on first. Both arms are deletable with every other test still green without these.
+  it.each([
+    ['null', 'null'],
+    ['a number', '42'],
+    ['a string', '"x"']
+  ])('reports a top level that is %s', (_name, raw) => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.readFileSync = vi.fn(() => Buffer.from(raw)) as any;
+    mockFs.writeFileSync = vi.fn();
+
+    new UserSettings(false).save();
+
+    expect(log.error).toHaveBeenCalledWith(
+      expect.stringContaining('holds no JSON object')
+    );
+  });
+
   it('says so when the top level is not an object', () => {
     mockFs.existsSync = vi.fn(() => true);
     mockFs.readFileSync = vi.fn(() => Buffer.from('[1,2,3]')) as any;
@@ -348,6 +364,26 @@ describe('UserSettings', () => {
     us.save();
 
     expect(vi.mocked(log.error).mock.calls).toHaveLength(1);
+  });
+
+  // The whole point of merging rather than rebuilding: what this object holds wins over what the file holds for a key this build owns. Untested until now, and a mutation that only writes a key absent from the file left every test in this suite green.
+  it('writes its own value over the one already in the file', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.readFileSync = vi.fn(() =>
+      Buffer.from('{"theme":"light","futureSetting":42}')
+    ) as any;
+    mockFs.writeFileSync = vi.fn();
+
+    const us = new UserSettings(true);
+    us.setValue(SettingType.theme, ThemeType.Dark);
+    us.save();
+
+    const written = JSON.parse(
+      (mockFs.writeFileSync as any).mock.calls[0][1] as string
+    );
+    expect(written.theme).toBe(ThemeType.Dark);
+    // and the key it does not own is still there, which is the other half
+    expect(written.futureSetting).toBe(42);
   });
 
   // Two breakages of the same file are two different things to repair, and the mark used to remember only that the path had been reported, so the second stayed silent with the first one's wording standing in the log. The repaired-and-broke-again test above does not cover this: it puts a valid object between the two, which clears the mark for the wrong reason.

--- a/test/unit/settings.test.ts
+++ b/test/unit/settings.test.ts
@@ -22,6 +22,7 @@ import {
   DEFAULT_WIN_HEIGHT,
   DEFAULT_WIN_WIDTH,
   LogLevel,
+  resetUnreadableReports,
   resolveWorkingDirectory,
   serverLaunchArgsDefault,
   serverLaunchArgsFixed,
@@ -256,6 +257,11 @@ describe('UserSettings', () => {
   });
 
   // The catch used to swallow both cases the same way, and merging over {} deletes every key this build does not know: the loss this merge exists to prevent, with the write reporting success.
+  beforeEach(() => {
+    // module state, so without this the second unreadable case reads as silent because the first already reported
+    resetUnreadableReports();
+  });
+
   it('says so when the file is there and could not be read', () => {
     mockFs.existsSync = vi.fn(() => true);
     let reads = 0;
@@ -275,6 +281,26 @@ describe('UserSettings', () => {
       expect.stringContaining('may be dropped'),
       expect.anything()
     );
+  });
+
+  // Eighteen call sites reach save(), so a condition that persists would otherwise put the same line in the log on every settings change.
+  it('reports an unreadable file once, not on every save', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    let reads = 0;
+    mockFs.readFileSync = vi.fn(() => {
+      if (reads++ === 0) {
+        return Buffer.from('{"futureSetting":42}');
+      }
+      throw Object.assign(new Error('EBUSY'), { code: 'EBUSY' });
+    }) as any;
+    mockFs.writeFileSync = vi.fn();
+
+    const us = new UserSettings(true);
+    us.save();
+    us.save();
+    us.save();
+
+    expect(vi.mocked(log.error).mock.calls).toHaveLength(1);
   });
 
   it('says nothing when the file is simply absent', () => {

--- a/test/unit/settings.test.ts
+++ b/test/unit/settings.test.ts
@@ -221,9 +221,13 @@ describe('UserSettings', () => {
       const us = new UserSettings(true);
       us.save();
 
-      // Measured one assertion at a time against both mutations, because the first attempt at this comment asserted the opposite and was wrong. Against `read` walking the file instead of the enum, all three fire. Against the merge, `{ ...onDisk }` swapped for `Object.assign({}, onDisk)`, only the round-trip below fires: assign invokes the `__proto__` setter on `merged`, which retargets that object's own prototype and never touches `Object.prototype`, so neither probe sees it.
+      // What each of these is worth, measured rather than assumed, after two earlier versions of this comment got it wrong.
       //
-      // These two are the pollution probes, and they are what a future change that writes onto the prototype would trip.
+      // Against `read` walking the file instead of the enum: no assertion fires at all. The test dies first with `TypeError: Invalid property descriptor`, out of the assignment itself. The mutation is caught, by the throw, and leaving only one assertion in place does not tell you which one caught it — it tells you the throw happened before it.
+      //
+      // Against the merge, `{ ...onDisk }` swapped for `Object.assign({}, onDisk)`: only the round-trip below fires. Assign invokes the `__proto__` setter on `merged`, which retargets that object's own prototype and never touches `Object.prototype`, so neither probe can see it.
+      //
+      // So these two catch neither named mutation. They stay as the pollution invariant, which is what a future change that writes onto `Object.prototype` would trip, and the comment says so rather than claiming a guard they do not provide.
       expect(({} as any).value).toBeUndefined();
       expect(({} as any).pwned).toBeUndefined();
       // This one is the merge guard, and the only assertion here that catches the spread being swapped for assign. It reads as the redundant one next to two prototype checks, which is exactly why it says so.
@@ -254,8 +258,6 @@ describe('UserSettings', () => {
     );
     expect(written.constructor).toBe('c');
     expect(written.toString).toBe('t');
-    // and nothing leaked onto the prototype on the way
-    expect(({} as any).c).toBeUndefined();
   });
 
   // The catch used to swallow both cases the same way, and merging over {} deletes every key this build does not know: the loss this merge exists to prevent, with the write reporting success.
@@ -303,6 +305,35 @@ describe('UserSettings', () => {
     us.save();
 
     expect(vi.mocked(log.error).mock.calls).toHaveLength(1);
+  });
+
+  // One-shot for the whole process would show a support log the first breakage and not the current state: repaired at noon and broken again at three has to say so twice.
+  it('says so again after the file was repaired and broke again', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    const shapes = ['{"a":1}', 'nope', '{"a":1}', 'nope'];
+    let n = 0;
+    mockFs.readFileSync = vi.fn(() => Buffer.from(shapes[n++] ?? '{}')) as any;
+    mockFs.writeFileSync = vi.fn();
+
+    const us = new UserSettings(true);
+    us.save();
+    us.save();
+    us.save();
+
+    expect(vi.mocked(log.error).mock.calls).toHaveLength(2);
+  });
+
+  // Rejected for its shape rather than for a parse failure, and it wipes the file the same way, so it cannot be the one case that says nothing.
+  it('says so when the top level is not an object', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.readFileSync = vi.fn(() => Buffer.from('[1,2,3]')) as any;
+    mockFs.writeFileSync = vi.fn();
+
+    new UserSettings(true).save();
+
+    expect(log.error).toHaveBeenCalledWith(
+      expect.stringContaining('holds no JSON object')
+    );
   });
 
   it('says nothing when the file is simply absent', () => {

--- a/test/unit/settings.test.ts
+++ b/test/unit/settings.test.ts
@@ -223,7 +223,7 @@ describe('UserSettings', () => {
 
       // What each of these is worth, measured rather than assumed, after two earlier versions of this comment got it wrong.
       //
-      // Against `read` walking the file instead of the enum: no assertion fires at all. The test dies first with `TypeError: Invalid property descriptor`, out of the assignment itself. The mutation is caught, by the throw, and leaving only one assertion in place does not tell you which one caught it — it tells you the throw happened before it.
+      // Against `read` walking the file instead of the enum: no assertion fires at all. The test dies first with `TypeError: Invalid property descriptor`, out of the assignment itself. The mutation is caught, by the throw, and leaving only one assertion in place does not tell you which one caught it, it tells you the throw happened before it.
       //
       // Against the merge, `{ ...onDisk }` swapped for `Object.assign({}, onDisk)`: only the round-trip below fires. Assign invokes the `__proto__` setter on `merged`, which retargets that object's own prototype and never touches `Object.prototype`, so neither probe can see it.
       //
@@ -334,6 +334,20 @@ describe('UserSettings', () => {
     expect(log.error).toHaveBeenCalledWith(
       expect.stringContaining('holds no JSON object')
     );
+  });
+
+  // Clearing the mark before the shape check undid the dedup for exactly this case: a file that parses and is not an object logged on every save while a parse failure logged once.
+  it('reports a rejected shape once, not on every save', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.readFileSync = vi.fn(() => Buffer.from('[1,2,3]')) as any;
+    mockFs.writeFileSync = vi.fn();
+
+    const us = new UserSettings(true);
+    us.save();
+    us.save();
+    us.save();
+
+    expect(vi.mocked(log.error).mock.calls).toHaveLength(1);
   });
 
   it('says nothing when the file is simply absent', () => {

--- a/test/unit/settings.test.ts
+++ b/test/unit/settings.test.ts
@@ -395,6 +395,9 @@ describe('UserSettings', () => {
       if (shape === 'GONE') {
         throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
       }
+      if (shape === 'EBUSY') {
+        throw Object.assign(new Error('EBUSY'), { code: 'EBUSY' });
+      }
       return Buffer.from(shape);
     }) as any;
     mockFs.writeFileSync = vi.fn();
@@ -417,6 +420,28 @@ describe('UserSettings', () => {
   // The file going away is not a repair, but whatever was reported about it no longer describes anything.
   it('reports again after the file disappeared in between', () => {
     expect(breakages(['{"a":1}', 'nope', 'GONE', 'nope'])).toBe(2);
+  });
+
+  // The case troubleshoot.md sends people into, and the one a reader can act on, so it must not be worded like a permission problem.
+  it('says the file is not valid JSON, not that it could not be read', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    let n = 0;
+    mockFs.readFileSync = vi.fn(() =>
+      Buffer.from(n++ === 0 ? '{"a":1}' : '{"theme":"dark",}')
+    ) as any;
+    mockFs.writeFileSync = vi.fn();
+
+    new UserSettings(true).save();
+
+    expect(log.error).toHaveBeenCalledWith(
+      expect.stringContaining('is not valid JSON'),
+      expect.anything()
+    );
+  });
+
+  // Its own kind, or the dedup would swallow the second break after a different first one.
+  it('reports a malformed file after an unreadable one', () => {
+    expect(breakages(['{"a":1}', 'EBUSY', '{"theme":"dark",}'])).toBe(2);
   });
 
   it('says nothing when the file is simply absent', () => {

--- a/test/unit/settings.test.ts
+++ b/test/unit/settings.test.ts
@@ -230,6 +230,29 @@ describe('UserSettings', () => {
     }
   });
 
+  // `__proto__` is the one that pollutes; `constructor` and `toString` are the two that shadow. All three have to come back out of the merge as own properties of a plain object, or a key somebody put in the file is lost the same way an unknown one used to be.
+  it('carries constructor and toString through the merge as plain keys', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.readFileSync = vi.fn(() =>
+      Buffer.from('{"constructor":"c","toString":"t","theme":"dark"}')
+    ) as any;
+    mockFs.writeFileSync = vi.fn();
+
+    const us = new UserSettings(true);
+    us.save();
+
+    const written = JSON.parse(
+      (mockFs.writeFileSync as any).mock.calls[0][1] as string
+    );
+    expect(Object.getOwnPropertyNames(written)).toEqual(
+      expect.arrayContaining(['constructor', 'toString'])
+    );
+    expect(written.constructor).toBe('c');
+    expect(written.toString).toBe('t');
+    // and nothing leaked onto the prototype on the way
+    expect(({} as any).c).toBeUndefined();
+  });
+
   it('takes nothing from a file whose top level is not an object', () => {
     mockFs.existsSync = vi.fn(() => true);
     mockFs.readFileSync = vi.fn(() => Buffer.from('[1,2,3]')) as any;

--- a/test/unit/settings.test.ts
+++ b/test/unit/settings.test.ts
@@ -282,7 +282,7 @@ describe('UserSettings', () => {
     us.save();
 
     expect(log.error).toHaveBeenCalledWith(
-      expect.stringContaining('may be dropped'),
+      expect.stringContaining('left alone until it is repaired'),
       expect.anything()
     );
   });
@@ -457,7 +457,7 @@ describe('UserSettings', () => {
   });
 
   // `[1,2,3]` is the only non-object shape that survives read(): null, a number and a string all throw out of `key in jsonData`, and that throw is #1115's to catch, not this branch's.
-  it('takes nothing from an array at the top level', () => {
+  it('leaves an array at the top level alone rather than writing over it', () => {
     mockFs.existsSync = vi.fn(() => true);
     mockFs.readFileSync = vi.fn(() => Buffer.from('[1,2,3]')) as any;
     mockFs.writeFileSync = vi.fn();
@@ -465,11 +465,8 @@ describe('UserSettings', () => {
     const us = new UserSettings(true);
     us.save();
 
-    // spreading an array would have written {"0":1,"1":2,"2":3}
-    const written = JSON.parse(
-      (mockFs.writeFileSync as any).mock.calls[0][1] as string
-    );
-    expect(written).toEqual({});
+    // the file is there and unusable, so it is left for the user to repair rather than overwritten with what this build happens to hold
+    expect(mockFs.writeFileSync).not.toHaveBeenCalled();
   });
 
   it('drops a key whose value is back to the default', () => {

--- a/test/unit/settings.test.ts
+++ b/test/unit/settings.test.ts
@@ -350,6 +350,39 @@ describe('UserSettings', () => {
     expect(vi.mocked(log.error).mock.calls).toHaveLength(1);
   });
 
+  // Two breakages of the same file are two different things to repair, and the mark used to remember only that the path had been reported, so the second stayed silent with the first one's wording standing in the log. The repaired-and-broke-again test above does not cover this: it puts a valid object between the two, which clears the mark for the wrong reason.
+  const breakages = (shapes: string[]) => {
+    mockFs.existsSync = vi.fn(() => true);
+    let n = 0;
+    mockFs.readFileSync = vi.fn(() => {
+      const shape = shapes[n++] ?? '{}';
+      if (shape === 'GONE') {
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      }
+      return Buffer.from(shape);
+    }) as any;
+    mockFs.writeFileSync = vi.fn();
+    // one shape is consumed by the constructor, the rest by a save each
+    const us = new UserSettings(true);
+    for (let i = 1; i < shapes.length; i++) {
+      us.save();
+    }
+    return vi.mocked(log.error).mock.calls.length;
+  };
+
+  it('reports a parse failure and then a rejected shape', () => {
+    expect(breakages(['{"a":1}', 'nope', '[1,2,3]'])).toBe(2);
+  });
+
+  it('reports a rejected shape and then a parse failure', () => {
+    expect(breakages(['{"a":1}', '[1,2,3]', 'nope'])).toBe(2);
+  });
+
+  // The file going away is not a repair, but whatever was reported about it no longer describes anything.
+  it('reports again after the file disappeared in between', () => {
+    expect(breakages(['{"a":1}', 'nope', 'GONE', 'nope'])).toBe(2);
+  });
+
   it('says nothing when the file is simply absent', () => {
     mockFs.existsSync = vi.fn(() => false);
     mockFs.readFileSync = vi.fn(() => {

--- a/test/unit/workspacesettings.test.ts
+++ b/test/unit/workspacesettings.test.ts
@@ -169,3 +169,65 @@ describe('WorkspaceSettings save', () => {
     expect(mockFs.writeFileSync).not.toHaveBeenCalled();
   });
 });
+
+describe('WorkspaceSettings — keys it does not claim', () => {
+  const written = () =>
+    JSON.parse(vi.mocked(fs.writeFileSync).mock.calls[0][1] as string);
+
+  beforeEach(() => {
+    mockFs.existsSync = vi.fn(() => true);
+    mockFs.writeFileSync = vi.fn();
+    mockFs.mkdirSync = vi.fn();
+    mockFs.readFileSync = vi.fn((p: fs.PathLike | fs.promises.FileHandle) => {
+      if (p.toString().includes('desktop-settings.json')) {
+        // uiMode is overridable, theme is not, futureProjectSetting is unknown
+        return Buffer.from(
+          JSON.stringify({
+            uiMode: 'zen',
+            theme: 'dark',
+            futureProjectSetting: 7
+          })
+        );
+      }
+      return Buffer.from(JSON.stringify({ futureGlobalSetting: 42 }));
+    });
+  });
+
+  it('writes back a key this build has no setting for', () => {
+    const ws = new WorkspaceSettings('/data/nb');
+
+    ws.save();
+
+    expect(written().futureProjectSetting).toBe(7);
+  });
+
+  it('writes back a key that is not overridable by a project', () => {
+    const ws = new WorkspaceSettings('/data/nb');
+
+    ws.save();
+
+    // meaningless in a project file, but deleting somebody's line is worse
+    expect(written().theme).toBe('dark');
+  });
+
+  it('keeps the global file-s leftovers out of the project file', () => {
+    const ws = new WorkspaceSettings('/data/nb');
+
+    ws.save();
+
+    // super.read() fills the base class from settings.json, and this class
+    // writes desktop-settings.json: one set each, or they cross over
+    expect('futureGlobalSetting' in written()).toBe(false);
+  });
+
+  it('drops a leftover when that key is explicitly unset', () => {
+    const ws = new WorkspaceSettings('/data/nb');
+
+    // theme, because the CLI refuses a key outside SettingType, so a name this
+    // build does not know is not a reachable input to unsetValue
+    ws.unsetValue(SettingType.theme);
+    ws.save();
+
+    expect('theme' in written()).toBe(false);
+  });
+});

--- a/test/unit/workspacesettings.test.ts
+++ b/test/unit/workspacesettings.test.ts
@@ -220,14 +220,44 @@ describe('WorkspaceSettings — keys it does not claim', () => {
     expect('futureGlobalSetting' in written()).toBe(false);
   });
 
+  it('writes a value set after that key was unset', () => {
+    const ws = new WorkspaceSettings('/data/nb');
+
+    ws.unsetValue(SettingType.uiMode);
+    ws.setValue(SettingType.uiMode, UIMode.SingleDocument);
+    ws.save();
+
+    // setting a key again has to undo the pending removal, or the write is
+    // dropped and the menu action silently does nothing
+    expect(written().uiMode).toBe(UIMode.SingleDocument);
+  });
+
+  it('drops an override that no longer differs from the global value', () => {
+    // only the project file holds it, or super.read() picks the same value up
+    // as the global one and the two no longer differ for the wrong reason
+    mockFs.readFileSync = vi.fn((p: fs.PathLike | fs.promises.FileHandle) =>
+      p.toString().includes('desktop-settings.json')
+        ? Buffer.from(JSON.stringify({ serverArgs: '--no-browser' }))
+        : Buffer.from('{}')
+    ) as any;
+    const ws = new WorkspaceSettings('/data/nb');
+    expect(ws.getValue(SettingType.serverArgs)).toBe('--no-browser');
+
+    // serverArgs is overridable and the global default is ''
+    ws.setValue(SettingType.serverArgs, '');
+    ws.save();
+
+    expect('serverArgs' in written()).toBe(false);
+  });
+
   it('drops a leftover when that key is explicitly unset', () => {
     const ws = new WorkspaceSettings('/data/nb');
 
-    // theme, because the CLI refuses a key outside SettingType, so a name this
-    // build does not know is not a reachable input to unsetValue
-    ws.unsetValue(SettingType.theme);
+    // uiMode, because the CLI refuses a key a project cannot override, so a
+    // non-overridable one is not a reachable input to unsetValue here
+    ws.unsetValue(SettingType.uiMode);
     ws.save();
 
-    expect('theme' in written()).toBe(false);
+    expect('uiMode' in written()).toBe(false);
   });
 });

--- a/test/unit/workspacesettings.test.ts
+++ b/test/unit/workspacesettings.test.ts
@@ -215,8 +215,7 @@ describe('WorkspaceSettings — keys it does not claim', () => {
 
     ws.save();
 
-    // super.read() fills the base class from settings.json, and this class
-    // writes desktop-settings.json: one set each, or they cross over
+    // super.read() fills the base class from settings.json, and this class writes desktop-settings.json: one set each, or they cross over
     expect('futureGlobalSetting' in written()).toBe(false);
   });
 
@@ -227,14 +226,12 @@ describe('WorkspaceSettings — keys it does not claim', () => {
     ws.setValue(SettingType.uiMode, UIMode.SingleDocument);
     ws.save();
 
-    // setting a key again has to undo the pending removal, or the write is
-    // dropped and the menu action silently does nothing
+    // setting a key again has to undo the pending removal, or the write is dropped and the menu action silently does nothing
     expect(written().uiMode).toBe(UIMode.SingleDocument);
   });
 
   it('drops an override that no longer differs from the global value', () => {
-    // only the project file holds it, or super.read() picks the same value up
-    // as the global one and the two no longer differ for the wrong reason
+    // only the project file holds it, or super.read() picks the same value up as the global one and the two no longer differ for the wrong reason
     mockFs.readFileSync = vi.fn((p: fs.PathLike | fs.promises.FileHandle) =>
       p.toString().includes('desktop-settings.json')
         ? Buffer.from(JSON.stringify({ serverArgs: '--no-browser' }))
@@ -253,8 +250,7 @@ describe('WorkspaceSettings — keys it does not claim', () => {
   it('drops a leftover when that key is explicitly unset', () => {
     const ws = new WorkspaceSettings('/data/nb');
 
-    // uiMode, because the CLI refuses a key a project cannot override, so a
-    // non-overridable one is not a reachable input to unsetValue here
+    // uiMode, because the CLI refuses a key a project cannot override, so a non-overridable one is not a reachable input to unsetValue here
     ws.unsetValue(SettingType.uiMode);
     ws.save();
 

--- a/test/unit/workspacesettings.test.ts
+++ b/test/unit/workspacesettings.test.ts
@@ -15,6 +15,7 @@ vi.mock('fs', async () => {
 });
 
 import {
+  resetUnreadableReports,
   SettingType,
   ThemeType,
   UIMode,
@@ -22,6 +23,11 @@ import {
 } from '../../src/main/config/settings';
 
 const mockFs = vi.mocked(fs);
+
+// The reported-unreadable set is module state and outlives a test, so without this a later one inherits a path already reported and reads as silent.
+beforeEach(() => {
+  resetUnreadableReports();
+});
 
 describe('WorkspaceSettings.getWorkspaceSettingsPath', () => {
   it('returns .jupyter/desktop-settings.json inside working dir', () => {
@@ -34,12 +40,12 @@ describe('WorkspaceSettings.getWorkspaceSettingsPath', () => {
   });
 });
 
-describe('WorkspaceSettings — no workspace file', () => {
+describe('WorkspaceSettings, no workspace file', () => {
   beforeEach(() => {
     // user settings file does not exist, workspace settings file does not exist
     mockFs.existsSync = vi.fn(() => false);
     mockFs.readFileSync = vi.fn(() => {
-      throw new Error('ENOENT');
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
     });
   });
 
@@ -60,7 +66,7 @@ describe('WorkspaceSettings — no workspace file', () => {
   });
 });
 
-describe('WorkspaceSettings — with workspace file', () => {
+describe('WorkspaceSettings, with workspace file', () => {
   beforeEach(() => {
     mockFs.existsSync = vi.fn((p: fs.PathLike) => {
       return p.toString().includes('desktop-settings.json');
@@ -72,7 +78,7 @@ describe('WorkspaceSettings — with workspace file', () => {
           JSON.stringify({ serverArgs: '--no-browser', uiMode: 'zen' })
         );
       }
-      throw new Error('ENOENT');
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
     });
   });
 
@@ -107,7 +113,7 @@ describe('WorkspaceSettings setValue / unsetValue', () => {
   beforeEach(() => {
     mockFs.existsSync = vi.fn(() => false);
     mockFs.readFileSync = vi.fn(() => {
-      throw new Error('ENOENT');
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
     });
   });
 
@@ -138,7 +144,7 @@ describe('WorkspaceSettings save', () => {
   beforeEach(() => {
     mockFs.existsSync = vi.fn(() => false);
     mockFs.readFileSync = vi.fn(() => {
-      throw new Error('ENOENT');
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
     });
     mockFs.writeFileSync = vi.fn();
     mockFs.mkdirSync = vi.fn();
@@ -170,7 +176,7 @@ describe('WorkspaceSettings save', () => {
   });
 });
 
-describe('WorkspaceSettings — keys it does not claim', () => {
+describe('WorkspaceSettings, keys it does not claim', () => {
   const written = () =>
     JSON.parse(vi.mocked(fs.writeFileSync).mock.calls[0][1] as string);
 

--- a/test/unit/workspacesettings.test.ts
+++ b/test/unit/workspacesettings.test.ts
@@ -162,6 +162,29 @@ describe('WorkspaceSettings save', () => {
     expect(parsed.uiMode).toBe(UIMode.Zen);
   });
 
+  // The twin of the UserSettings case in settings.test.ts, and it was the only one of the two guards no test could see: mutating this refusal away left the whole suite green. A project's desktop-settings.json that becomes unreadable between the read and the save would then be rebuilt from whatever survived, which is the loss the merge exists to prevent.
+  it('leaves a workspace file alone when it is there and could not be read', () => {
+    mockFs.existsSync = vi.fn(() => true);
+    let projectReads = 0;
+    mockFs.readFileSync = vi.fn((target: any) => {
+      // super.read() reads the global file first, and only the project one is the subject here
+      if (!String(target).includes('desktop-settings.json')) {
+        return Buffer.from('{}');
+      }
+      if (projectReads++ === 0) {
+        return Buffer.from('{"uiMode":"zen"}');
+      }
+      throw Object.assign(new Error('EBUSY'), { code: 'EBUSY' });
+    }) as any;
+    mockFs.writeFileSync = vi.fn();
+
+    const ws = new WorkspaceSettings('/data/nb');
+    ws.setValue(SettingType.uiMode, UIMode.MultiDocument);
+
+    expect(ws.save()).toBe(false);
+    expect(mockFs.writeFileSync).not.toHaveBeenCalled();
+  });
+
   it('creates parent directory when it does not exist', () => {
     const ws = new WorkspaceSettings('/data/nb');
     ws.setValue(SettingType.uiMode, UIMode.Zen);


### PR DESCRIPTION
## References

- Found while reviewing #1101, but older than it and independent of it: this reproduces on `master` with nothing else applied
- #1116 is the wider version of the same mechanism, for values the reader rejects rather than keys it does not know
- Worth landing before #1101, which makes rejection safe there for free

## Ordering against the other config pull requests

Measured with `git merge-tree --write-tree --name-only`, not assumed, and confirmed with a real `git merge --no-commit` that was then aborted. The three-argument `git merge-tree <base> <a> <b>` reports no conflicts for the first row, so it is the wrong form to ask:

| | |
| --- | --- |
| this x #1115 | **conflicts**, in `src/main/config/settings.ts` and `test/unit/settings.test.ts` |
| this x #1101 | same conflict, since that branch contains #1115 |
| this x #1112 | clean |
| each against `master` | clean |

`read()` and `save()` are what both this and #1115 rewrite, so whichever lands second needs a rebase. **#1115 first is the cheaper order**: the local `readJsonFileOrEmpty` here exists only because the shared reader lands there, so rebasing onto it is deleting this helper and calling `readJsonConfigFile`, plus `save` returning the writer's boolean. The reverse order works too and is no worse in substance, just more to redo.

#1112 is independent of all of these and can land whenever.

## What this does not fix

A file that is there and could not be read is now left alone rather than merged over. That started as #1115's job and turned out to be this branch's: the reason for deferring it was that an `EBUSY` or `EACCES` would fail the write too, and it does not. Measured on darwin, a `settings.json` at mode `0200` gives `EACCES` on the read and `OK` on the write, because `writeFileSync` opens `O_WRONLY` and never reads, so the file ended as `{}` with one log line. The same holds for the hand-edit with a trailing comma that `troubleshoot.md` tells people to make.

`save()` returns a boolean so a caller can tell, and `jlab config set` and `jlab config unset` both ask before printing success. Counted on the current head: four of the twenty-three call sites use the result and nineteen ignore it; #1115 changes the same signature and is where the rest get wired.

With the app open, `jlab config set logLevel debug` in a separate process is still reverted at quit: `will-quit` calls `userSettings.save()`, which writes every `SettingType` key from in-memory state that predates the other process's write. Unknown keys now survive that; known ones do not. Same as `master`, so not a regression, and not something this claims.

## Code changes

`save` rebuilds `settings.json` and `desktop-settings.json` from the values it holds, and `read` only ever looked at the keys in `SettingType`. A key the file had and this build has no setting for was not ignored. It was deleted at the next save.

Measured on `master`, nothing else applied:

```
before: {"futureSetting":42,"theme":"dark"}
after a read and a save: {"theme":"dark"}
```

So a `settings.json` written by a newer build loses whatever an older one does not recognise, and `troubleshoot.md` sends readers to edit this file by hand, so a line somebody added on purpose goes the same way.

### What the references do

| | on write | can it lose a key |
| --- | --- | --- |
| VS Code | splices edits into the original text by offset, `applyEdits` in `vs/base/common/jsonEdit.ts` | no, nothing outside the edit is touched |
| `conf`, which `electron-store` wraps | reads the whole file into an object, changes one key, writes the object back: `const {store} = this` through `this.store = store` | no, unknown keys survive by construction |
| here, before this | rebuilds from `key in SettingType` | yes, silently |

This takes conf's shape: it re-reads the file inside the write and merges there. An earlier commit on this branch cached at read time and replayed the snapshot at save, which is not the same thing and is where its defects came from; that is reworked.

VS Code's approach keeps comments and key order too, but it means a JSON-with-offsets editor, which is a larger
change than the problem needs.

### The change

`save` merges over what the file holds rather than rebuilding it, so what this build has no setting for is kept and written back. `read` is unchanged: it still walks the enum.

`read` walks `SettingType` rather than the file, which is what `master` did and is why `master` was immune to a `__proto__` key: nothing out of the file ever indexes `_settings`.

`save` decides three things per key, not two. A key of `SettingType` matching its default is deleted, because it does not belong in the file whatever the file says. A key a project cannot override is left alone. Everything else is written. Collapsing the last two into one boolean is what let a stale on-disk value outlive the change that replaced it, and the commits on this branch have that mistake in them.

A key that is not overridable by a project is kept too. It does nothing in a project file, but deleting a line somebody wrote is worse than leaving one that has no effect.

## User-facing changes

A key in `settings.json` or `.jupyter/desktop-settings.json` that this build does not recognise stays there. `jlab config list` does not show it, because it is not a setting; nothing else changes.

## Backwards-incompatible changes

None. Every key that used to round-trip still does; the ones that used to vanish do not.

## Manual testing

The before-and-after above is a run against `master` rather than a description of one, driving the real `UserSettings` against a real file.

Five new branches, mutation-checked one at a time, each turning exactly one test red: either `save` dropping the leftovers, either `read` not collecting them, and the workspace `unsetValue` not clearing them.

The three cases above were written as failing tests before the fix, and two of them turned out to be testing something else: one passed because its fixture had no `serverArgs`, so it asserted on the key's absence rather than its removal, and another drove `unsetValue` with `theme`, which no project can override and the CLI refuses. Both are fixed; that is the only reason the shape came out right this time.

Not done: none of the [Review guidance](https://github.com/jupyterlab/jupyterlab-desktop/blob/master/dev.md#review-guidance) checks were run on Windows or Linux.

## Remaining

`ApplicationData.save` rebuilds the same way. `app-data.json` is app-managed rather than documented for hand editing, and the loss reported against it is dropped array entries rather than unknown top-level keys, which needs a different fix. #1116.

## AI usage

- **YES**: Some or all of the content of this PR was generated by AI.
- **<!-- YES or NO -->**: The human author has carefully reviewed this PR and run this code (keep this PR "draft" until the answer is YES)
- AI tools and models used: Claude Code, Opus 5









